### PR TITLE
Added padding to main content div to account for navbar

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -23,6 +23,10 @@ body {
   grid-area: main;
 }
 
+#_main-content {
+  padding-top: 64px;
+}
+
 #main-footer {
   grid-area: ft;
 }


### PR DESCRIPTION
Added it to the css file instead of js because I assume that MuiThemeProvider theme needs to be defined outside of the component we try to use withStyles on.

Other way could be extracting _main-content div as its own react component. Which would be the better implementation?