### PR TITLE
Added service catalog to the simulator and UI

### DIFF
--- a/src/app/core/common/EnhancedTableHead.js
+++ b/src/app/core/common/EnhancedTableHead.js
@@ -11,18 +11,22 @@ class EnhancedTableHead extends React.Component {
   }
 
   render () {
-    const { columns, onSelectAllClick, order, orderBy, numSelected, rowCount } = this.props
+    const { columns, onSelectAllClick, order, orderBy, numSelected, rowCount, showCheckboxes } = this.props
+
+    const headerCheckbox = showCheckboxes ? (
+      <TableCell padding="checkbox">
+        <Checkbox
+          indeterminate={numSelected > 0 && numSelected < rowCount}
+          checked={numSelected === rowCount}
+          onChange={onSelectAllClick}
+        />
+      </TableCell>
+    ) : null
 
     return (
       <TableHead>
         <TableRow>
-          <TableCell padding="checkbox">
-            <Checkbox
-              indeterminate={numSelected > 0 && numSelected < rowCount}
-              checked={numSelected === rowCount}
-              onChange={onSelectAllClick}
-            />
-          </TableCell>
+          {headerCheckbox}
           {columns.map(column => {
             return (
               <TableCell
@@ -61,6 +65,7 @@ EnhancedTableHead.propTypes = {
   order: PropTypes.string.isRequired,
   orderBy: PropTypes.string.isRequired,
   rowCount: PropTypes.number.isRequired,
+  showCheckboxes: PropTypes.bool,
 }
 
 export default EnhancedTableHead

--- a/src/app/core/common/ListTable.js
+++ b/src/app/core/common/ListTable.js
@@ -127,21 +127,23 @@ class ListTable extends React.Component {
   }
 
   renderRow = row => {
-    const { columns } = this.props
-
+    const { columns, showCheckboxes } = this.props
     const isSelected = this.isSelected(row.id)
+
+    const checkboxProps = showCheckboxes ? {
+      onClick: this.handleClick(row.id),
+      role: 'checkbox',
+      tabIndex: -1,
+      selected: isSelected
+    } : {}
+
     return (
-      <TableRow
-        hover
-        onClick={this.handleClick(row.id)}
-        role="checkbox"
-        tabIndex={-1}
-        key={row.id}
-        selected={isSelected}
-      >
-        <TableCell padding="checkbox">
-          <Checkbox checked={isSelected} />
-        </TableCell>
+      <TableRow hover key={row.id} {...checkboxProps}>
+        {showCheckboxes &&
+          <TableCell padding="checkbox">
+            <Checkbox checked={isSelected} />
+          </TableCell>
+        }
         {columns.map((columnDef, colIdx) =>
           this.renderCell(columnDef, row[columnDef.id]))
         }
@@ -182,6 +184,10 @@ class ListTable extends React.Component {
       columns,
       data,
       title,
+      onAdd,
+      onDelete,
+      showCheckboxes,
+      paginate
     } = this.props
 
     const {
@@ -191,16 +197,16 @@ class ListTable extends React.Component {
     } = this.state
 
     const sortedData = this.sortData(data)
-    const paginatedData = this.paginate(sortedData)
-    const shouldShowPagination = sortedData.length > this.state.rowsPerPage
+    const paginatedData = paginate ? this.paginate(sortedData) : sortedData
+    const shouldShowPagination = paginate && sortedData.length > this.state.rowsPerPage
 
     return (
       <Paper className={classes.root}>
         <EnhancedTableToolbar
           numSelected={selected.length}
           title={title}
-          onAdd={this.handleAdd}
-          onDelete={this.handleDelete}
+          onAdd={onAdd && this.handleAdd}
+          onDelete={onDelete && this.handleDelete}
         />
         <div className={classes.tableWrapper}>
           <Table className={classes.table}>
@@ -213,6 +219,7 @@ class ListTable extends React.Component {
               onRequestSort={this.handleRequestSort}
               title={title}
               rowCount={sortedData.length}
+              showCheckboxes={showCheckboxes}
             />
             <TableBody>
               {paginatedData.map(this.renderRow)}
@@ -238,11 +245,15 @@ ListTable.propTypes = {
   title: PropTypes.string.isRequired,
   onAdd: PropTypes.func,
   onDelete: PropTypes.func,
+  paginate: PropTypes.bool,
+  showCheckboxes: PropTypes.bool
 }
 
 ListTable.defaultProps = {
   data: [],
   columns: [],
+  paginate: true,
+  showCheckboxes: true
 }
 
 export default ListTable

--- a/src/app/plugins/openstack/api/keystone.js
+++ b/src/app/plugins/openstack/api/keystone.js
@@ -68,6 +68,8 @@ export const renewUnscopedToken = async (unscopedToken) => {
 
 export const getRegions = () => authHttp.get(`${v3Base}/regions`).then(x => x.regions)
 
+export const getServiceCatalog = () => authHttp.get(`${v3Base}/auth/catalog`).then(x => x.catalog)
+
 export const createUser = user => {
   const body = {
     user: {

--- a/src/app/plugins/openstack/components/ApiAccessPage.js
+++ b/src/app/plugins/openstack/components/ApiAccessPage.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+import ApiAccessListContainer from './api-access/ApiAccessListContainer'
+
+class ApiAccessPage extends React.Component {
+  render () {
+    return (
+      <div>
+        <h1>API Access Page</h1>
+        <ApiAccessListContainer />
+      </div>
+    )
+  }
+}
+
+export default ApiAccessPage

--- a/src/app/plugins/openstack/components/api-access/ApiAccessList.js
+++ b/src/app/plugins/openstack/components/api-access/ApiAccessList.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import ListTable from 'core/common/ListTable'
+
+const columns = [
+  { id: 'name', label: 'Name' },
+  { id: 'type', label: 'Type' },
+  { id: 'url', label: 'URL' },
+]
+
+class ApiAccessList extends React.Component {
+  render () {
+    const { catalog } = this.props
+    const _catalog = catalog.map((service) => {
+      return {
+        id: service.id,
+        name: service.name,
+        type: service.type,
+        url: service.endpoints.find((endpoint) => {
+          return endpoint.interface === 'internal'
+        }).url
+      }
+    })
+
+    if (!catalog || catalog.length === 0) {
+      return (<h1>No endpoints found</h1>)
+    }
+
+    return (
+      <ListTable
+        title="API Endpoints"
+        columns={columns}
+        data={_catalog}
+        paginate={false}
+        showCheckboxes={false}
+      />
+    )
+  }
+}
+
+ApiAccessList.propTypes = {
+  /** List of services [{ name, type, endpoints, ... }] */
+  catalog: PropTypes.array.isRequired,
+}
+
+ApiAccessList.defaultProps = {
+  catalog: [],
+}
+
+export default ApiAccessList

--- a/src/app/plugins/openstack/components/api-access/ApiAccessListContainer.js
+++ b/src/app/plugins/openstack/components/api-access/ApiAccessListContainer.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import { withRouter } from 'react-router-dom'
+import { Query } from 'react-apollo'
+import requiresAuthentication from 'openstack/util/requiresAuthentication'
+import gql from 'graphql-tag'
+
+import Loader from 'core/common/Loader'
+import DisplayError from 'core/common/DisplayError'
+import ApiAccessList from './ApiAccessList'
+
+const GET_CATALOG = gql`
+  {
+    serviceCatalog {
+      id
+      type
+      name
+      endpoints {
+        id
+        interface
+        region
+        url
+      }
+    }
+  }
+`
+
+@requiresAuthentication
+@withRouter
+// @connect(mapStateToProps)
+class ApiAccessListContainer extends React.Component {
+  state = {
+    showConfirmation: false,
+  }
+
+  render () {
+    const { catalog } = this.props
+
+    return (
+      <div>
+        <ApiAccessList
+          catalog={catalog}
+        />
+      </div>
+    )
+  }
+}
+
+const GraphqlCrudContainer = ({ query, actions, children, ...props }) => {
+  return (
+    <Query query={query}>
+      {({ loading, error, data, client }) => {
+        if (loading) { return <Loader /> }
+        if (error) { return <DisplayError error={error} /> }
+        return children({ data, client, actions: {} })
+      }}
+    </Query>
+  )
+}
+
+const GraphqlApiAccessList = () => (
+  <GraphqlCrudContainer query={GET_CATALOG}>
+    {({ data, actions }) => (
+      <ApiAccessListContainer catalog={data.serviceCatalog} />
+    )}
+  </GraphqlCrudContainer>
+)
+
+export default GraphqlApiAccessList

--- a/src/app/plugins/openstack/components/flavors/FlavorsListContainer.js
+++ b/src/app/plugins/openstack/components/flavors/FlavorsListContainer.js
@@ -98,7 +98,7 @@ const GraphqlCrudContainer = ({ query, actions, children, ...props }) => {
 const GraphqlFlavorsList = () => (
   <GraphqlCrudContainer query={GET_FLAVORS}>
     {({ data, actions }) => (
-      <FlavorsListContainer flavors={data.flavors} />
+      <FlavorsListContainer flavors={data.flavors} catalog={data.serviceCatalog} />
     )}
   </GraphqlCrudContainer>
 )

--- a/src/app/plugins/openstack/index.js
+++ b/src/app/plugins/openstack/index.js
@@ -16,6 +16,8 @@ import AddFlavorPage from './components/flavors/AddFlavorPage'
 import NetworksPage from './components/NetworksPage'
 import AddNetworkPage from './components/networks/AddNetworkPage'
 
+import ApiAccessPage from './components/ApiAccessPage'
+
 import loginReducer from './reducers/login'
 import sessionReducer from './reducers/session'
 import tenantsReducer from './reducers/tenants'
@@ -89,6 +91,11 @@ OpenStack.registerPlugin = pluginManager => {
         link: { path: '/networks/add' },
         component: AddNetworkPage
       },
+      {
+        name: 'ApiAccess',
+        link: { path: '/apiaccess' },
+        component: ApiAccessPage
+      }
     ]
   )
 
@@ -115,6 +122,10 @@ OpenStack.registerPlugin = pluginManager => {
         name: 'Networks',
         link: { path: '/networks' }
       },
+      {
+        name: 'API Access',
+        link: { path: '/apiaccess' },
+      }
     ]
   )
 

--- a/src/graphql/openstack/index.js
+++ b/src/graphql/openstack/index.js
@@ -2,11 +2,13 @@ import { mergeSchemas } from 'graphql-tools'
 
 import flavors from './schemas/flavors'
 import userManagement from './schemas/userManagement'
+import serviceCatalog from './schemas/serviceCatalog'
 
 const mergedSchemas = mergeSchemas({
   schemas: [
     flavors,
     userManagement,
+    serviceCatalog
   ]
 })
 

--- a/src/graphql/openstack/schemas/serviceCatalog.graphql
+++ b/src/graphql/openstack/schemas/serviceCatalog.graphql
@@ -1,0 +1,17 @@
+type Service {
+  id: ID!
+  type: String!
+  name: String!
+  endpoints: [Endpoint]!
+}
+
+type Endpoint {
+  id: ID!
+  interface: String!
+  region: String!
+  url: String!
+}
+
+type Query {
+  serviceCatalog: [Service]!
+}

--- a/src/graphql/openstack/schemas/serviceCatalog.js
+++ b/src/graphql/openstack/schemas/serviceCatalog.js
@@ -1,0 +1,17 @@
+import typeDefs from '../schemas/serviceCatalog.graphql'
+import { makeExecutableSchema } from 'graphql-tools'
+
+const resolvers = {
+  Query: {
+    serviceCatalog (obj, args, context) {
+      return context.getServiceCatalog()
+    }
+  }
+}
+
+const schema = makeExecutableSchema({
+  typeDefs,
+  resolvers,
+})
+
+export default schema

--- a/src/server/context.js
+++ b/src/server/context.js
@@ -2,6 +2,7 @@ import { mapAsJson } from './helpers'
 import Role from './models/Role'
 import Tenant from './models/Tenant'
 import User from './models/User'
+import Catalog from './models/Catalog'
 
 const defaultQuota = {
   cores: 10,
@@ -55,6 +56,8 @@ class Context {
     tenant.destroy()
     return id
   }
+
+  getServiceCatalog = () => Catalog.getCatalog()
 }
 
 const context = new Context()

--- a/src/server/models/Catalog.js
+++ b/src/server/models/Catalog.js
@@ -1,0 +1,68 @@
+import uuid from 'uuid'
+
+const fakeTenantId = uuid.v4()
+
+const Catalog = {
+  getCatalog: () => {
+    return [
+      {
+        endpoints: [
+          {
+            id: uuid.v4(),
+            interface: 'admin',
+            region: 'master',
+            region_id: 'master',
+            url: '/neutron'
+          },
+          {
+            id: uuid.v4(),
+            interface: 'internal',
+            region: 'master',
+            region_id: 'master',
+            url: '/neutron'
+          },
+          {
+            id: uuid.v4(),
+            interface: 'public',
+            region: 'master',
+            region_id: 'master',
+            url: '/neutron'
+          }
+        ],
+        id: uuid.v4(),
+        name: 'neutron',
+        type: 'network'
+      },
+      {
+        endpoints: [
+          {
+            id: uuid.v4(),
+            interface: 'admin',
+            region: 'master',
+            region_id: 'master',
+            url: `/nova/v2.1/${fakeTenantId}`
+          },
+          {
+            id: uuid.v4(),
+            interface: 'internal',
+            region: 'master',
+            region_id: 'master',
+            url: `/nova/v2.1/${fakeTenantId}`
+          },
+          {
+            id: uuid.v4(),
+            interface: 'public',
+            region: 'master',
+            region_id: 'master',
+            url: `/nova/v2.1/${fakeTenantId}`
+          }
+        ],
+        id: uuid.v4(),
+        name: 'nova',
+        type: 'compute'
+      }
+    ]
+  }
+}
+
+export default Catalog

--- a/src/stories/api-access/fakeService.js
+++ b/src/stories/api-access/fakeService.js
@@ -1,0 +1,24 @@
+import faker from 'faker'
+
+const fakeService = () => {
+  const interfaces = ['admin', 'internal', 'public']
+
+  const endpoints = interfaces.map((iface) => {
+    return {
+      id: faker.random.uuid(),
+      interface: iface,
+      region: faker.random.word(),
+      region_id: faker.random.word(),
+      url: faker.internet.url()
+    }
+  })
+
+  return {
+    id: faker.random.uuid(),
+    name: faker.random.word(),
+    type: faker.random.number(),
+    endpoints
+  }
+}
+
+export default fakeService

--- a/src/stories/api-access/listApis.stories.js
+++ b/src/stories/api-access/listApis.stories.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { addStories, range } from '../helpers'
+import fakeService from './fakeService'
+import ApiAccessList from 'openstack/components/api-access/ApiAccessList'
+
+const someServices = range(15).map(fakeService)
+
+addStories('Service Catalog/Listing services', {
+  'With some services': () => (
+    <ApiAccessList catalog={someServices} />
+  ),
+})


### PR DESCRIPTION
One thing that may need to change:

Currently the service catalog is stored in state in the 'openstack' property. However, the service catalog stores services outside of openstack too, like qbert, so it should probably be moved up to root level. I need to work on something for the old codebase now but I wanted to send a review first. I haven't been able to completely work out all the details about the way state is stored just yet.