### PR TITLE
Update React-Dom and Add material-ui/icons.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,22 @@
         }
       }
     },
+    "@babel/runtime": {
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.49.tgz",
+      "integrity": "sha1-A7O/B+uYIHLI6FHdLd1RECguYb8=",
+      "requires": {
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.0.0-beta.36",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
@@ -190,6 +206,118 @@
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
         }
+      }
+    },
+    "@material-ui/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-7rh/FAmdmWsjRYJlOEUT2NajlpvC+I28cbGUq0dNFdOHTcxRL/xsUraFvAEFBXvsLrzLkzNPl3mA2Svn80aLVw==",
+      "requires": {
+        "@babel/runtime": "7.0.0-beta.49",
+        "@types/jss": "9.5.3",
+        "@types/react-transition-group": "2.0.8",
+        "brcast": "3.0.1",
+        "classnames": "2.2.5",
+        "csstype": "2.5.3",
+        "debounce": "1.1.0",
+        "deepmerge": "2.1.0",
+        "dom-helpers": "3.3.1",
+        "hoist-non-react-statics": "2.5.0",
+        "jss": "9.8.1",
+        "jss-camel-case": "6.1.0",
+        "jss-default-unit": "8.0.2",
+        "jss-global": "3.0.0",
+        "jss-nested": "6.0.1",
+        "jss-props-sort": "6.0.0",
+        "jss-vendor-prefixer": "7.0.0",
+        "keycode": "2.2.0",
+        "normalize-scroll-left": "0.1.2",
+        "prop-types": "15.6.0",
+        "react-event-listener": "0.6.0",
+        "react-jss": "8.4.0",
+        "react-popper": "0.10.4",
+        "react-transition-group": "2.3.0",
+        "recompose": "0.26.0",
+        "scroll": "2.0.3",
+        "warning": "4.0.1"
+      },
+      "dependencies": {
+        "@types/jss": {
+          "version": "9.5.3",
+          "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.3.tgz",
+          "integrity": "sha512-RQWhcpOVyIhGryKpnUyZARwsgmp+tB82O7c75lC4Tjbmr3hPiCnM1wc+pJipVEOsikYXW0IHgeiQzmxQXbnAIA==",
+          "requires": {
+            "csstype": "2.5.3",
+            "indefinite-observable": "1.0.1"
+          }
+        },
+        "csstype": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.3.tgz",
+          "integrity": "sha512-G5HnoK8nOiAq3DXIEoY2n/8Vb7Lgrms+jGJl8E4EJpQEeVONEnPFJSl8IK505wPBoxxtrtHhrRm4WX2GgdqarA=="
+        },
+        "hoist-non-react-statics": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+          "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
+        },
+        "react-event-listener": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.0.tgz",
+          "integrity": "sha512-CqewJSQ/0p09oPZ9BABNvoFhGMhUAuLQ4B4skPsZXxxgOBx+2SP3AgM9lP7zc68pRmJXlCQBDjgOAQsp1jnhAQ==",
+          "requires": {
+            "@babel/runtime": "7.0.0-beta.49",
+            "prop-types": "15.6.0",
+            "warning": "3.0.0"
+          },
+          "dependencies": {
+            "warning": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+              "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+              "requires": {
+                "loose-envify": "1.3.1"
+              }
+            }
+          }
+        },
+        "react-popper": {
+          "version": "0.10.4",
+          "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.10.4.tgz",
+          "integrity": "sha1-rypBXqIike3VBGeNev2opu4ylao=",
+          "requires": {
+            "popper.js": "1.14.3",
+            "prop-types": "15.6.1"
+          },
+          "dependencies": {
+            "prop-types": {
+              "version": "15.6.1",
+              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+              "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1"
+              }
+            }
+          }
+        },
+        "warning": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.1.tgz",
+          "integrity": "sha512-rAVtTNZw+cQPjvGp1ox0XC5Q2IBFyqoqh+QII4J/oguyu83Bax1apbo2eqB8bHRS+fqYUBagys6lqUoVwKSmXQ==",
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        }
+      }
+    },
+    "@material-ui/icons": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-1.1.0.tgz",
+      "integrity": "sha512-Z4Xo/EYXuVqCIOjLw7AeBJPtJZsgy9dMAdqu6uYr7gxAefFA8L/QukLv/XE5ByxKYvRhzFG/AjA2OKXwKqfXBQ==",
+      "requires": {
+        "recompose": "0.26.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -6551,6 +6679,11 @@
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
+    },
+    "debounce": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.1.0.tgz",
+      "integrity": "sha512-ZQVKfRVlwRfD150ndzEK8M90ABT+Y/JQKs4Y7U4MXdpuoUkkrr4DwKbVux3YjylA5bUMUj0Nc3pMxPJX6N2QQQ=="
     },
     "debug": {
       "version": "2.6.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -528,7 +528,7 @@
         "prop-types": "15.6.1",
         "qs": "6.5.1",
         "react": "16.2.0",
-        "react-dom": "16.2.0",
+        "react-dom": "16.4.0",
         "redux": "3.7.2",
         "serve-favicon": "2.5.0",
         "shelljs": "0.8.1",
@@ -15085,9 +15085,9 @@
       }
     },
     "react-dom": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.0.tgz",
+      "integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Platform9 UI",
   "main": "src/app/index.js",
   "dependencies": {
+    "@material-ui/core": "^1.2.0",
+    "@material-ui/icons": "^1.1.0",
     "apollo-boost": "^0.1.6",
     "apollo-server-express": "^1.3.6",
     "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-apollo": "^2.1.4",
-    "react-dom": "^16.2.0",
+    "react-dom": "^16.4.0",
     "react-redux": "^5.0.6",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",


### PR DESCRIPTION
Update `react-dom` from 16.2.0 to 16.4.0 to ensure material_ui will work right.

With version 16.2.0, modals of material_ui will be assigned a property of `visibility: hidden`, which will make popup, select and menu not work.

After switching to version 16.4.0, the following part are tested:
- `npm run test` all passed
- All existing pages work right as before.
  - login page
  - user/flavor page (including adding new elements)
  - API page
  - Other pages with no data

Add `@material-ui/core` and `@material-ui/icons`, while keeping the old version of the old versions.