### PR TITLE
Fix small issues of ListTable

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -3,6 +3,8 @@ body {
   padding: 0;
   font-family: 'Roboto', 'sans-serif';
   background-color: #eee;
+  overflow-x: hidden;
+  max-width: 100%;
 }
 
 #main-container {

--- a/src/app/core/common/ListTable.js
+++ b/src/app/core/common/ListTable.js
@@ -8,7 +8,6 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableFooter,
   TablePagination,
   TableRow
 } from '@material-ui/core'
@@ -193,6 +192,7 @@ class ListTable extends React.Component {
     const { page, rowsPerPage } = this.state
     return (
       <TablePagination
+        component="div"
         count={count}
         rowsPerPage={rowsPerPage}
         page={page}
@@ -257,13 +257,9 @@ class ListTable extends React.Component {
                 <TableBody>
                   {paginatedData.map(this.renderRow)}
                 </TableBody>
-                <TableFooter>
-                  <TableRow>
-                    {this.renderPaginationControls(sortedData.length)}
-                  </TableRow>
-                </TableFooter>
               </Table>
             </div>
+            {this.renderPaginationControls(sortedData.length)}
           </Paper>
         </Grid>
       </Grid>


### PR DESCRIPTION
* Fix the position of TablePagination. It will stay at the right corner of table frame, even when the content is scrolled.

* Fix the `max-width` and `overflow-x` to prevent the page getting stretched horizontally when there are many columns.

![listtable_fixed](https://user-images.githubusercontent.com/3017373/41699332-49441148-74d8-11e8-997f-f9067a55d1bd.png)
