### PR TITLE
Remove Kubernetes clusters since it does not work

### DIFF
--- a/src/app/plugins/kubernetes/index.js
+++ b/src/app/plugins/kubernetes/index.js
@@ -25,6 +25,7 @@ Kubernetes.registerPlugin = pluginManager => {
     ]
   )
 
+  /*
   pluginManager.registerNavItems(
     '/ui/kubernetes',
     [
@@ -34,6 +35,7 @@ Kubernetes.registerPlugin = pluginManager => {
       },
     ]
   )
+  */
 
   pluginManager.registerSchema(k8Schema)
 }


### PR DESCRIPTION
Just commenting out the navigation item for K8s since we aren't using it yet and it's not implemented correctly.