### PR TITLE
Fix bug for client in simulated mode

### DIFF
--- a/src/server/middleware.js
+++ b/src/server/middleware.js
@@ -25,9 +25,9 @@ export const injectClientInfo = (req, res, next) => {
   if (context.client) {
     context.client.unscopedToken = authToken
     context.client.scopedToken = authToken
-  }
-  if (config.region) {
-    context.client.setActiveRegion(config.region)
+    if (config.region) {
+      context.client.setActiveRegion(config.region)
+    }
   }
   next()
 }


### PR DESCRIPTION
Only `setActiveRegion` when we using the REST client.  Simulated route will error otherwise.