### PR TITLE
CRUD volumes refactoring

### DIFF
--- a/src/app/core/DataUpdater.js
+++ b/src/app/core/DataUpdater.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import DataLoader from 'core/DataLoader'
+import { compose } from 'core/fp'
+import { withAppContext } from 'core/AppContext'
+
+/* This is a convenience HOC to make updating the in-memory cache easier.
+ * After updating we need to replace the in-memory cache that is normally an
+ * array of items.  We do this by looping through the array and finding the
+ * entity with `objId` and replacing it with the result of `updateFn`
+ *
+ * Additionally, it handles loading as well through `DataLoader`.
+ */
+class DataUpdater extends React.Component {
+  findById = (arr, id) => arr.find(x => x.id === id)
+
+  handleSubmit = async data => {
+    const { dataKey, updateFn, objId, context, setContext } = this.props
+    const updatedEntity = await updateFn(data)
+    setContext({
+      [dataKey]: context[dataKey].map(x => x.id === objId ? updatedEntity : x)
+    })
+  }
+
+  render () {
+    const { dataKey, loaderFn, objId, children } = this.props
+    return (
+      <DataLoader dataKey={dataKey} loaderFn={loaderFn}>
+        {({ data }) =>
+          children({
+            data: this.findById(data, objId),
+            onSubmit: this.handleSubmit
+          })
+        }
+      </DataLoader>
+    )
+  }
+}
+
+DataUpdater.propTypes = {
+  /**
+   * Used to determine if data already exists in context.
+   * If `context[dataKey]` exists it does not run the `loaderFn`.
+   * Once the data has been loaded `context[dataKey]` is passed
+   * to the child component in the `data` prop.
+   */
+  dataKey: PropTypes.string.isRequired,
+
+  /**
+   * This function is invoked when the data does not yet exist.
+   * It is passed `setContext` to use for updating.
+  */
+  loaderFn: PropTypes.func.isRequired,
+
+  updateFn: PropTypes.func.isRequired,
+
+  objId: PropTypes.string.isRequired,
+}
+
+export default compose(
+  withAppContext,
+)(DataUpdater)

--- a/src/app/core/common/CRUDListContainer.js
+++ b/src/app/core/common/CRUDListContainer.js
@@ -103,6 +103,12 @@ class CRUDListContainer extends React.Component {
 CRUDListContainer.propTypes = {
   addUrl: PropTypes.string,
   editUrl: PropTypes.string,
+
+  /**
+   * Handler that is responsible for deleting the entity.
+   * It is passed the id of the entity.
+   */
+  onRemove: PropTypes.func,
   /*
     Some objects have a unique identifier other than 'id'
     For example sshKeys have unique identifier of 'name' and the APIs

--- a/src/app/core/common/Checkbox.js
+++ b/src/app/core/common/Checkbox.js
@@ -13,8 +13,16 @@ class Checkbox extends React.Component {
 
   get restFields () { return filterFields(...withFormContext.propsToExclude, 'value')(this.props) }
 
+  handleChange = e => {
+    const { id, onChange, setField } = this.props
+    setField(id, e.target.checked)
+    if (onChange) {
+      onChange(e.target.checked)
+    }
+  }
+
   render () {
-    const { id, value, label, setField } = this.props
+    const { id, value, label } = this.props
     return (
       <div id={id}>
         <FormControlLabel
@@ -23,7 +31,7 @@ class Checkbox extends React.Component {
             <BaseCheckbox
               {...this.restFields}
               checked={value[id]}
-              onChange={e => setField(this.props.id, e.target.checked)}
+              onChange={this.handleChange}
             />
           }
         />
@@ -41,5 +49,6 @@ Checkbox.propTypes = {
   label: PropTypes.string,
   validations: PropTypes.arrayOf(PropTypes.object),
   initialValue: PropTypes.bool,
+  onChange: PropTypes.func,
 }
 export default withFormContext(Checkbox)

--- a/src/app/core/common/ListTable.js
+++ b/src/app/core/common/ListTable.js
@@ -33,7 +33,6 @@ const styles = theme => ({
 
 // TODO: this component should take an optional sort function in the columns prop (eg. for IP addresses)
 
-@withStyles(styles)
 class ListTable extends React.Component {
   constructor (props) {
     super(props)
@@ -103,12 +102,16 @@ class ListTable extends React.Component {
     let newSelected = []
 
     if (selectedIndex === -1) {
+      // not found
       newSelected = newSelected.concat(selected, row)
     } else if (selectedIndex === 0) {
+      // first
       newSelected = newSelected.concat(selected.slice(1))
     } else if (selectedIndex === selected.length - 1) {
+      // last
       newSelected = newSelected.concat(selected.slice(0, -1))
     } else if (selectedIndex > 0) {
+      // somewhere inbetween
       newSelected = newSelected.concat(
         selected.slice(0, selectedIndex),
         selected.slice(selectedIndex + 1),
@@ -178,10 +181,15 @@ class ListTable extends React.Component {
 
   renderCell = (columnDef, contents) => {
     const { cellProps = {} } = columnDef
+    let _contents = contents
+
+    if (typeof contents === 'boolean') { _contents = String(_contents) }
+
+    // Allow for customized rendering in the columnDef
+    if (columnDef.render) { _contents = columnDef.render(contents) }
+
     return (
-      <TableCell key={columnDef.id} {...cellProps} >
-        {(typeof contents === 'boolean') ? String(contents) : contents}
-      </TableCell>
+      <TableCell key={columnDef.id} {...cellProps}>{_contents}</TableCell>
     )
   }
 

--- a/src/app/core/common/Picklist.js
+++ b/src/app/core/common/Picklist.js
@@ -7,6 +7,10 @@ import Select from '@material-ui/core/Select'
 import { withStyles } from '@material-ui/core/styles'
 import { compose } from 'core/fp'
 
+/**
+ * Picklist is a bare-bones widget-only implmentation.
+ * See PicklistField if you need ValidatedForm integration.
+ */
 const styles = theme => ({
   root: {
     display: 'flex',
@@ -23,20 +27,16 @@ const styles = theme => ({
 
 class Picklist extends React.Component {
   get options () {
-    const opts = this.props.options
-    if (opts.length === 0) { return [] }
-    if (typeof opts[0] === 'string') {
-      return opts.map(x => ({ value: x, label: x }))
-    }
-    return opts
+    return this.props.options.map(x =>
+      typeof x === 'string' ? ({ value: x, label: x }) : x
+    )
   }
 
-  handleChange = () => {
-    console.log('handleChange')
-  }
+  handleChange = value => this.props.onChange && this.props.onChange(value)
 
   render () {
     const { classes, label, name, value } = this.props
+
     return (
       <FormControl className={classes.formControl}>
         <InputLabel htmlFor={name}>{label}</InputLabel>
@@ -60,6 +60,7 @@ Picklist.propTypes = {
     PropTypes.object,
   ])).isRequired,
   value: PropTypes.string,
+  onChange: PropTypes.func,
 }
 
 export default compose(

--- a/src/app/core/common/Picklist.js
+++ b/src/app/core/common/Picklist.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import FormControl from '@material-ui/core/FormControl'
+import InputLabel from '@material-ui/core/InputLabel'
+import MenuItem from '@material-ui/core/MenuItem'
+import Select from '@material-ui/core/Select'
+import { withStyles } from '@material-ui/core/styles'
+import { compose } from 'core/fp'
+
+const styles = theme => ({
+  root: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  formControl: {
+    marginTop: theme.spacing.unit,
+    minWidth: 120,
+  },
+  selectEmpty: {
+    marginTop: theme.spacing.unit * 2,
+  },
+})
+
+class Picklist extends React.Component {
+  get options () {
+    const opts = this.props.options
+    if (opts.length === 0) { return [] }
+    if (typeof opts[0] === 'string') {
+      return opts.map(x => ({ value: x, label: x }))
+    }
+    return opts
+  }
+
+  handleChange = () => {
+    console.log('handleChange')
+  }
+
+  render () {
+    const { classes, label, name, value } = this.props
+    return (
+      <FormControl className={classes.formControl}>
+        <InputLabel htmlFor={name}>{label}</InputLabel>
+        <Select
+          value={value || ''}
+          onChange={this.handleChange}
+          inputProps={{ name: label, id: name }}
+        >
+          {this.options.map(x => <MenuItem value={x.value} key={x.value}>{x.label}</MenuItem>)}
+        </Select>
+      </FormControl>
+    )
+  }
+}
+
+Picklist.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ])).isRequired,
+  value: PropTypes.string,
+}
+
+export default compose(
+  withStyles(styles),
+)(Picklist)

--- a/src/app/core/common/Picklist.js
+++ b/src/app/core/common/Picklist.js
@@ -26,14 +26,27 @@ const styles = theme => ({
 })
 
 class Picklist extends React.Component {
-  handleChange = e => this.props.onChange && this.props.onChange(e.target.value)
+  handleChange = e => {
+    const { onChange } = this.props
+    // Hack to work around the fact that Material UI's "Select" will ignore
+    // an options with value of '' (empty string).
+    const value = e.target.value === '__none__' ? '' : e.target.value
+    onChange && onChange(value)
+  }
 
   render () {
-    const { classes, label, name, value } = this.props
+    const { classes, label, name } = this.props
 
     const options = this.props.options.map(x =>
       typeof x === 'string' ? ({ value: x, label: x }) : x
-    )
+    ).map(x => ({
+      label: x.label,
+      // Hack to work around Material UI's Select ignoring empty string as a value
+      value: x.value === '' ? '__none__' : x.value
+    }))
+
+    // Hack to work around Material UI's Select ignoring empty string as a value
+    const value = this.props.value === '' ? '__none__' : this.props.value
 
     return (
       <FormControl className={classes.formControl}>
@@ -42,6 +55,7 @@ class Picklist extends React.Component {
           value={value}
           onChange={this.handleChange}
           inputProps={{ name: label, id: name }}
+          displayEmpty
         >
           {options.map(x => <MenuItem value={x.value} key={x.value}>{x.label}</MenuItem>)}
         </Select>

--- a/src/app/core/common/Picklist.js
+++ b/src/app/core/common/Picklist.js
@@ -18,7 +18,7 @@ const styles = theme => ({
   },
   formControl: {
     marginTop: theme.spacing.unit,
-    minWidth: 120,
+    minWidth: 200,
   },
   selectEmpty: {
     marginTop: theme.spacing.unit * 2,
@@ -26,26 +26,24 @@ const styles = theme => ({
 })
 
 class Picklist extends React.Component {
-  get options () {
-    return this.props.options.map(x =>
-      typeof x === 'string' ? ({ value: x, label: x }) : x
-    )
-  }
-
-  handleChange = value => this.props.onChange && this.props.onChange(value)
+  handleChange = e => this.props.onChange && this.props.onChange(e.target.value)
 
   render () {
     const { classes, label, name, value } = this.props
+
+    const options = this.props.options.map(x =>
+      typeof x === 'string' ? ({ value: x, label: x }) : x
+    )
 
     return (
       <FormControl className={classes.formControl}>
         <InputLabel htmlFor={name}>{label}</InputLabel>
         <Select
-          value={value || ''}
+          value={value}
           onChange={this.handleChange}
           inputProps={{ name: label, id: name }}
         >
-          {this.options.map(x => <MenuItem value={x.value} key={x.value}>{x.label}</MenuItem>)}
+          {options.map(x => <MenuItem value={x.value} key={x.value}>{x.label}</MenuItem>)}
         </Select>
       </FormControl>
     )

--- a/src/app/core/common/PicklistField.js
+++ b/src/app/core/common/PicklistField.js
@@ -1,14 +1,21 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Selector from 'core/common/Selector'
+import Picklist from 'core/common/Picklist'
 import { withFormContext } from 'core/common/ValidatedForm'
 import { pickMultiple, filterFields } from 'core/fp'
 
+/**
+ * PicklistField builds upon Picklist and adds integration with ValidatedForm
+ */
 class PicklistField extends React.Component {
   constructor (props) {
     super(props)
     const spec = pickMultiple('validations')(props)
-    props.defineField(props.id, spec)
+    const { id, initialValue, setField } = this.props
+    props.defineField(id, spec)
+    if (initialValue !== undefined) {
+      setField(id, initialValue)
+    }
   }
 
   get restFields () { return filterFields(...withFormContext.propsToExclude)(this.props) }
@@ -17,12 +24,13 @@ class PicklistField extends React.Component {
     const { id, label, options, value, setField } = this.props
     return (
       <div id={id}>
-        <Selector
-          name={label}
+        <Picklist
+          name={id}
+          label={label}
           {...this.restFields}
-          list={options}
+          options={options}
           value={value[id] !== undefined ? value[id] : ''}
-          onChoose={e => setField(this.props.id, e.target.value)}
+          onChange={e => setField(id, e.target.value)}
         />
       </div>
     )
@@ -36,7 +44,10 @@ PicklistField.defaultProps = {
 PicklistField.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string,
-  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  options: PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ])).isRequired,
   validations: PropTypes.arrayOf(PropTypes.object),
   initialValue: PropTypes.string,
 }

--- a/src/app/core/common/PicklistField.js
+++ b/src/app/core/common/PicklistField.js
@@ -30,7 +30,7 @@ class PicklistField extends React.Component {
           {...this.restFields}
           options={options}
           value={value[id] !== undefined ? value[id] : ''}
-          onChange={e => setField(id, e.target.value)}
+          onChange={value => setField(id, value)}
         />
       </div>
     )

--- a/src/app/core/common/PicklistField.js
+++ b/src/app/core/common/PicklistField.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Selector from 'core/common/Selector'
+import { withFormContext } from 'core/common/ValidatedForm'
+import { pickMultiple, filterFields } from 'core/fp'
+
+class PicklistField extends React.Component {
+  constructor (props) {
+    super(props)
+    const spec = pickMultiple('validations')(props)
+    props.defineField(props.id, spec)
+  }
+
+  get restFields () { return filterFields(...withFormContext.propsToExclude)(this.props) }
+
+  render () {
+    const { id, label, options, value, setField } = this.props
+    return (
+      <div id={id}>
+        <Selector
+          name={label}
+          {...this.restFields}
+          list={options}
+          value={value[id] !== undefined ? value[id] : ''}
+          onChoose={e => setField(this.props.id, e.target.value)}
+        />
+      </div>
+    )
+  }
+}
+
+PicklistField.defaultProps = {
+  validations: [],
+}
+
+PicklistField.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  validations: PropTypes.arrayOf(PropTypes.object),
+  initialValue: PropTypes.string,
+}
+export default withFormContext(PicklistField)

--- a/src/app/core/common/PicklistField.js
+++ b/src/app/core/common/PicklistField.js
@@ -21,7 +21,8 @@ class PicklistField extends React.Component {
   get restFields () { return filterFields(...withFormContext.propsToExclude)(this.props) }
 
   render () {
-    const { id, label, options, value, setField } = this.props
+    const { id, label, value, setField, showNone } = this.props
+    const options = showNone ? [{ value: '', label: 'None' }, ...this.props.options] : this.props.options
     return (
       <div id={id}>
         <Picklist
@@ -50,5 +51,8 @@ PicklistField.propTypes = {
   ])).isRequired,
   validations: PropTypes.arrayOf(PropTypes.object),
   initialValue: PropTypes.string,
+
+  /** Create an option of 'None' as the first default choice */
+  showNone: PropTypes.bool,
 }
 export default withFormContext(PicklistField)

--- a/src/app/core/common/TextField.js
+++ b/src/app/core/common/TextField.js
@@ -17,14 +17,20 @@ class TextField extends React.Component {
 
   get restFields () { return filterFields(...withFormContext.propsToExclude)(this.props) }
 
+  handleChange = e => {
+    const { id, onChange, setField } = this.props
+    setField(id, e.target.value)
+    if (onChange) { onChange(e.target.value) }
+  }
+
   render () {
-    const { id, value, setField } = this.props
+    const { id, value } = this.props
     return (
       <div id={id}>
         <BaseTextField
           {...this.restFields}
           value={value[id] !== undefined ? value[id] : ''}
-          onChange={e => setField(this.props.id, e.target.value)}
+          onChange={this.handleChange}
         />
       </div>
     )
@@ -40,5 +46,6 @@ TextField.propTypes = {
   label: PropTypes.string,
   validations: PropTypes.arrayOf(PropTypes.object),
   initialValue: PropTypes.string,
+  onChange: PropTypes.func,
 }
 export default withFormContext(TextField)

--- a/src/app/core/common/TextField.js
+++ b/src/app/core/common/TextField.js
@@ -8,7 +8,11 @@ class TextField extends React.Component {
   constructor (props) {
     super(props)
     const spec = pickMultiple('validations')(props)
-    props.defineField(props.id, spec)
+    const { id, initialValue, setField } = this.props
+    props.defineField(id, spec)
+    if (initialValue !== undefined) {
+      setField(id, initialValue)
+    }
   }
 
   get restFields () { return filterFields(...withFormContext.propsToExclude)(this.props) }

--- a/src/app/core/common/ValidatedForm.js
+++ b/src/app/core/common/ValidatedForm.js
@@ -130,27 +130,44 @@ class ValidatedForm extends React.Component {
 }
 
 ValidatedForm.propTypes = {
-  // GraphQl query to add an object
-  addQuery: PropTypes.object,
-  // GraphQl query to get an object
-  getQuery: PropTypes.object,
-  // GraphQl query to update an object
-  updateQuery: PropTypes.object,
-  // Action to take(add/delete/update)
-  action: PropTypes.string,
   // Url to go back when the operation ends
   backUrl: PropTypes.string,
-  // Type of objects to operate
-  objType: PropTypes.string,
-  // String of query to cache
-  cacheQuery: PropTypes.string,
-  // Id of object to update
-  objId: PropTypes.string,
+
   // Initial values
   initialValue: PropTypes.object,
+
   // Set parent context
   onSubmit: PropTypes.func,
+
   triggerSubmit: PropTypes.func,
+
+  /**
+   * TODO: The props below are coupled to GraphQL
+   * specific logic.  The recommended way to use this
+   * component is to instrument what is needed somewhere
+   * else in the `onSubmit` handler.
+   */
+
+  /** @deprecated GraphQl query to add an object */
+  addQuery: PropTypes.object,
+
+  /** @deprecated GraphQl query to get an object */
+  getQuery: PropTypes.object,
+
+  /** @deprecated GraphQl query to update an object */
+  updateQuery: PropTypes.object,
+
+  /** @deprecated Action to take(add/delete/update) */
+  action: PropTypes.string,
+
+  /** @deprecated Type of objects to operate */
+  objType: PropTypes.string,
+
+  /** @deprecated String of query to cache */
+  cacheQuery: PropTypes.string,
+
+  /** @deprecated Id of object to update */
+  objId: PropTypes.string,
 }
 
 export const PropKeys = Object.keys(ValidatedForm.propTypes)

--- a/src/app/core/common/ValidatedForm.js
+++ b/src/app/core/common/ValidatedForm.js
@@ -200,4 +200,4 @@ export const withFormContext = Component => props =>
     }
   </Consumer>
 
-withFormContext.propsToExclude = ['defineField', 'setField']
+withFormContext.propsToExclude = ['defineField', 'setField', 'initialValue']

--- a/src/app/core/common/Wizard.js
+++ b/src/app/core/common/Wizard.js
@@ -66,13 +66,13 @@ class Wizard extends React.Component {
   render () {
     const { context, setContext, steps, step } = this.state
     const lastStep = this.state.steps.length - 1
+    const activeStepId = steps[step] && steps[step].stepId
 
     return (
       <div>
         <Provider value={this.state}>
           <ProgressTracker steps={steps} activeStep={step} />
-          {this.props.children({ context, setContext, onNext: this.onNext })}
-          {steps[step] ? steps[step].contents : null}
+          {this.props.children({ context, setContext, onNext: this.onNext, activeStepId })}
           <FormButtons>
             { step > 0 && <BackButton handleBack={this.handleBack} /> }
             { step < lastStep && <NextButton handleNext={this.handleNext}>Next</NextButton> }

--- a/src/app/core/common/WizardStep.js
+++ b/src/app/core/common/WizardStep.js
@@ -3,12 +3,15 @@ import PropTypes from 'prop-types'
 import { withWizardContext } from 'core/common/Wizard'
 
 class WizardStep extends React.Component {
-  constructor (props) {
-    super(props)
-    props.addStep({stepId: props.stepId, label: props.label, contents: props.children})
+  componentDidMount () {
+    const { addStep, stepId, label } = this.props
+    addStep({ stepId, label })
   }
 
-  render = () => null
+  render () {
+    const { stepId, activeStepId, children } = this.props
+    return stepId === activeStepId ? children : null
+  }
 }
 
 // Validations should be an object with a rule definition

--- a/src/app/core/fp.js
+++ b/src/app/core/fp.js
@@ -45,3 +45,9 @@ export function setObjLens (obj, value, paths) {
 export const setStateLens = (value, paths) => state => {
   return setObjLens(state, value, paths)
 }
+
+export const range = (start, end) => {
+  let arr = []
+  for (let i=start; i<=end; i++) { arr.push(i) }
+  return arr
+}

--- a/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
+++ b/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
@@ -3,7 +3,7 @@ import Wizard from 'core/common/Wizard'
 import WizardStep from 'core/common/WizardStep'
 import ValidatedForm from 'core/common/ValidatedForm'
 import TextField from 'core/common/TextField'
-import Picklist from 'core/common/Picklist'
+import PicklistField from 'core/common/PicklistField'
 import Checkbox from 'core/common/Checkbox'
 
 const initialValue = {
@@ -11,7 +11,12 @@ const initialValue = {
   bootable: false,
   readonly: false,
 }
-const volumeSourceTypes = ['None (empty volume)', 'Snapshot', 'Another Volume', 'Image']
+const volumeSourceTypes = [
+  {value: 'None', label: 'None (empty volume)'},
+  'Snapshot',
+  'Another Volume',
+  'Image'
+]
 
 // See if the data supplied to WizardStep can be raised up to AddVolumeForm state
 const AddVolumeForm = ({ onComplete }) =>
@@ -22,11 +27,10 @@ const AddVolumeForm = ({ onComplete }) =>
           <WizardStep stepId="basic" label="Basic">
             <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
               <TextField id="name" label="Volume Name" />
-              <Picklist name="volume_type" label="Volume Type" options={volumeSourceTypes} />
+              <PicklistField id="volume_type" label="Volume Type" options={volumeSourceTypes} initialValue="None" />
               <TextField id="description" label="Description" />
               <TextField id="status" label="Status" />
             </ValidatedForm>
-            <pre>{JSON.stringify(context, null, 4)}</pre>
           </WizardStep>
           <WizardStep stepId="advanced" label="Advanced">
             <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
@@ -46,6 +50,7 @@ const AddVolumeForm = ({ onComplete }) =>
               <TextField id="metadata" label="Metadata" />
             </ValidatedForm>
           </WizardStep>
+          <pre>{JSON.stringify(context, null, 4)}</pre>
         </div>
       )
     }}

--- a/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
+++ b/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
@@ -4,7 +4,11 @@ import WizardStep from 'core/common/WizardStep'
 import ValidatedForm from 'core/common/ValidatedForm'
 import TextField from 'core/common/TextField'
 import Picklist from 'core/common/Picklist'
+import PicklistField from 'core/common/PicklistField'
 import Checkbox from 'core/common/Checkbox'
+import DataLoader from 'core/DataLoader'
+import { range } from 'core/fp'
+import { loadVolumeTypes } from './actions'
 
 const initialValue = {
   size: 0,
@@ -18,31 +22,74 @@ const sourceTypes = [
   'Image'
 ]
 
+const schemaSamples = (prefix, num) => range(1, num).map(i => `${prefix}${i}`)
+
 // See if the data supplied to WizardStep can be raised up to AddVolumeForm state
 class AddVolumeForm extends React.Component {
-  state = { sourceType: '' }
+  state = {
+    createMultiple: false,
+    name: '',
+    numVolumes: 1,
+    sourceType: 'None',
+  }
 
-  setSourceType = value => {
-    this.setState({ sourceType: value })
+  setField = key => value => {
+    this.setState({ [key]: value })
+    if (key === 'createMultiple') {
+      this.setState({ prefix: this.state.name })
+    }
   }
 
   render () {
     const { onComplete } = this.props
-    const { sourceType } = this.state
+    const { createMultiple, prefix, numVolumes, sourceType } = this.state
     return (
       <Wizard onComplete={onComplete} context={initialValue}>
         {({ context, setContext, onNext, activeStepId }) => {
           return (
             <div>
               <WizardStep stepId="source" label="Source" activeStepId={activeStepId}>
-                <Picklist name="sourceType" label="Volume Source" value={sourceType} onChange={this.setSourceType} options={sourceTypes} />
+                <Picklist name="sourceType" label="Volume Source" value={sourceType} onChange={this.setField('sourceType')} options={sourceTypes} />
+                {sourceType === 'Snapshot' &&
+                  <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
+                    <h1>Snapshot</h1>
+                  </ValidatedForm>
+                }
+                {sourceType === 'Another Volume' &&
+                  <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
+                    <h1>Another Volume</h1>
+                  </ValidatedForm>
+                }
+                {sourceType === 'Image' &&
+                  <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
+                    <h1>Image</h1>
+                  </ValidatedForm>
+                }
               </WizardStep>
+
               <WizardStep stepId="basic" label="Basic" activeStepId={activeStepId}>
-                <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
-                  <TextField id="name" label="Volume Name" />
-                  <TextField id="description" label="Description" />
-                </ValidatedForm>
+                <DataLoader dataKey="volumeTypes" loaderFn={loadVolumeTypes}>
+                  {({ data }) =>
+                    <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
+                      <TextField id="name" label="Volume Name" onChange={this.setField('name')} />
+                      <TextField id="description" label="Description" />
+                      <PicklistField id="volumeType" label="Volume Type" options={(data || []).map(x => x.name)} />
+                      <TextField id="size" label="Capacity (GB)" type="number" />
+                      <Checkbox id="bootable" label="Bootable" />
+                      <Checkbox id="createMultiple" label="Create multiple?" onChange={this.setField('createMultiple')} />
+                      {createMultiple &&
+                        <React.Fragment>
+                          <TextField id="numVolumes" label="Number of volumes" type="number" initialValue="1" onChange={this.setField('numVolumes')} />
+                          <TextField id="volumeNamePrefix" label="Volume name prefix" initialValue={this.state.name} />
+                          <br />
+                          {schemaSamples(prefix, Math.min(numVolumes, 3)).map(str => <div key={str}>{str}</div>)}
+                        </React.Fragment>
+                      }
+                    </ValidatedForm>
+                  }
+                </DataLoader>
               </WizardStep>
+
               <WizardStep stepId="advanced" label="Advanced" activeStepId={activeStepId}>
                 <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
                   <TextField id="tenant" label="Tenant" />
@@ -52,17 +99,15 @@ class AddVolumeForm extends React.Component {
                   <TextField id="device" label="Device" />
                 </ValidatedForm>
               </WizardStep>
+
               <WizardStep stepId="config" label="Config" activeStepId={activeStepId}>
                 <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
-                  <TextField id="size" label="Capacity (GB)" type="number" />
-                  <Checkbox id="bootable" label="Bootable" />
                   <Checkbox id="attachedMode" label="Attached Mode" />
                   <Checkbox id="readonly" label="Read only?" />
                   <TextField id="metadata" label="Metadata" />
                 </ValidatedForm>
               </WizardStep>
               <pre>{JSON.stringify(context, null, 4)}</pre>
-              <pre>{JSON.stringify(this.state, null, 4)}</pre>
             </div>
           )
         }}

--- a/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
+++ b/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
@@ -3,6 +3,7 @@ import Wizard from 'core/common/Wizard'
 import WizardStep from 'core/common/WizardStep'
 import ValidatedForm from 'core/common/ValidatedForm'
 import TextField from 'core/common/TextField'
+import Picklist from 'core/common/Picklist'
 import Checkbox from 'core/common/Checkbox'
 
 const initialValue = {
@@ -10,6 +11,7 @@ const initialValue = {
   bootable: false,
   readonly: false,
 }
+const volumeSourceTypes = ['None (empty volume)', 'Snapshot', 'Another Volume', 'Image']
 
 // See if the data supplied to WizardStep can be raised up to AddVolumeForm state
 const AddVolumeForm = ({ onComplete }) =>
@@ -20,10 +22,11 @@ const AddVolumeForm = ({ onComplete }) =>
           <WizardStep stepId="basic" label="Basic">
             <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
               <TextField id="name" label="Volume Name" />
-              <TextField id="volume_type" label="Volume Type" />
+              <Picklist name="volume_type" label="Volume Type" options={volumeSourceTypes} />
               <TextField id="description" label="Description" />
               <TextField id="status" label="Status" />
             </ValidatedForm>
+            <pre>{JSON.stringify(context, null, 4)}</pre>
           </WizardStep>
           <WizardStep stepId="advanced" label="Advanced">
             <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>

--- a/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
+++ b/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
@@ -24,6 +24,11 @@ const sourceTypes = [
 
 const schemaSamples = (prefix, num) => range(1, num).map(i => `${prefix}${i}`)
 
+/* placeholders */
+const nop = () => ({})
+const VolumeSnapshotChooser = () => <h2>Volume Snapshot Chooser</h2>
+/* end placeholders */
+
 // See if the data supplied to WizardStep can be raised up to AddVolumeForm state
 class AddVolumeForm extends React.Component {
   state = {
@@ -52,7 +57,12 @@ class AddVolumeForm extends React.Component {
                 <Picklist name="sourceType" label="Volume Source" value={sourceType} onChange={this.setField('sourceType')} options={sourceTypes} />
                 {sourceType === 'Snapshot' &&
                   <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
-                    <h1>Snapshot</h1>
+                    <DataLoader dataKey="volumeSnapshots" loaderFn={nop}>
+                      {({ data }) =>
+                        <VolumeSnapshotChooser snapshots={data} onChange={value => setContext({ volumeSnapshot: value })} />
+                      }
+                    </DataLoader>
+                    <h1>Volume Snapshots</h1>
                   </ValidatedForm>
                 }
                 {sourceType === 'Another Volume' &&

--- a/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
+++ b/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
@@ -83,7 +83,7 @@ class AddVolumeForm extends React.Component {
                     <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
                       <TextField id="name" label="Volume Name" onChange={this.setField('name')} />
                       <TextField id="description" label="Description" />
-                      <PicklistField id="volumeType" label="Volume Type" options={(data || []).map(x => x.name)} />
+                      <PicklistField id="volumeType" label="Volume Type" options={(data || []).map(x => x.name)} showNone />
                       <TextField id="size" label="Capacity (GB)" type="number" />
                       <Checkbox id="bootable" label="Bootable" />
                       <Checkbox id="createMultiple" label="Create multiple?" onChange={this.setField('createMultiple')} />
@@ -100,24 +100,11 @@ class AddVolumeForm extends React.Component {
                 </DataLoader>
               </WizardStep>
 
-              <WizardStep stepId="advanced" label="Advanced" activeStepId={activeStepId}>
+              <WizardStep stepId="metadata" label="Metadata" activeStepId={activeStepId}>
                 <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
-                  <TextField id="tenant" label="Tenant" />
-                  <TextField id="source" label="Source" />
-                  <TextField id="host" label="Host" />
-                  <TextField id="instance" label="Instance" />
-                  <TextField id="device" label="Device" />
-                </ValidatedForm>
-              </WizardStep>
-
-              <WizardStep stepId="config" label="Config" activeStepId={activeStepId}>
-                <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
-                  <Checkbox id="attachedMode" label="Attached Mode" />
-                  <Checkbox id="readonly" label="Read only?" />
                   <TextField id="metadata" label="Metadata" />
                 </ValidatedForm>
               </WizardStep>
-              <pre>{JSON.stringify(context, null, 4)}</pre>
             </div>
           )
         }}

--- a/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
+++ b/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
@@ -3,7 +3,7 @@ import Wizard from 'core/common/Wizard'
 import WizardStep from 'core/common/WizardStep'
 import ValidatedForm from 'core/common/ValidatedForm'
 import TextField from 'core/common/TextField'
-import PicklistField from 'core/common/PicklistField'
+import Picklist from 'core/common/Picklist'
 import Checkbox from 'core/common/Checkbox'
 
 const initialValue = {
@@ -11,7 +11,7 @@ const initialValue = {
   bootable: false,
   readonly: false,
 }
-const volumeSourceTypes = [
+const sourceTypes = [
   {value: 'None', label: 'None (empty volume)'},
   'Snapshot',
   'Another Volume',
@@ -19,41 +19,56 @@ const volumeSourceTypes = [
 ]
 
 // See if the data supplied to WizardStep can be raised up to AddVolumeForm state
-const AddVolumeForm = ({ onComplete }) =>
-  <Wizard onComplete={onComplete} context={initialValue}>
-    {({ context, setContext, onNext }) => {
-      return (
-        <div>
-          <WizardStep stepId="basic" label="Basic">
-            <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
-              <TextField id="name" label="Volume Name" />
-              <PicklistField id="volume_type" label="Volume Type" options={volumeSourceTypes} initialValue="None" />
-              <TextField id="description" label="Description" />
-              <TextField id="status" label="Status" />
-            </ValidatedForm>
-          </WizardStep>
-          <WizardStep stepId="advanced" label="Advanced">
-            <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
-              <TextField id="tenant" label="Tenant" />
-              <TextField id="source" label="Source" />
-              <TextField id="host" label="Host" />
-              <TextField id="instance" label="Instance" />
-              <TextField id="device" label="Device" />
-            </ValidatedForm>
-          </WizardStep>
-          <WizardStep stepId="config" label="Config">
-            <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
-              <TextField id="size" label="Capacity" type="number" />
-              <Checkbox id="bootable" label="Bootable" />
-              <Checkbox id="attachedMode" label="Attached Mode" />
-              <Checkbox id="readonly" label="Read only?" />
-              <TextField id="metadata" label="Metadata" />
-            </ValidatedForm>
-          </WizardStep>
-          <pre>{JSON.stringify(context, null, 4)}</pre>
-        </div>
-      )
-    }}
-  </Wizard>
+class AddVolumeForm extends React.Component {
+  state = { sourceType: '' }
+
+  setSourceType = value => {
+    this.setState({ sourceType: value })
+  }
+
+  render () {
+    const { onComplete } = this.props
+    const { sourceType } = this.state
+    return (
+      <Wizard onComplete={onComplete} context={initialValue}>
+        {({ context, setContext, onNext, activeStepId }) => {
+          return (
+            <div>
+              <WizardStep stepId="source" label="Source" activeStepId={activeStepId}>
+                <Picklist name="sourceType" label="Volume Source" value={sourceType} onChange={this.setSourceType} options={sourceTypes} />
+              </WizardStep>
+              <WizardStep stepId="basic" label="Basic" activeStepId={activeStepId}>
+                <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
+                  <TextField id="name" label="Volume Name" />
+                  <TextField id="description" label="Description" />
+                </ValidatedForm>
+              </WizardStep>
+              <WizardStep stepId="advanced" label="Advanced" activeStepId={activeStepId}>
+                <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
+                  <TextField id="tenant" label="Tenant" />
+                  <TextField id="source" label="Source" />
+                  <TextField id="host" label="Host" />
+                  <TextField id="instance" label="Instance" />
+                  <TextField id="device" label="Device" />
+                </ValidatedForm>
+              </WizardStep>
+              <WizardStep stepId="config" label="Config" activeStepId={activeStepId}>
+                <ValidatedForm initialValue={context} onSubmit={setContext} triggerSubmit={onNext}>
+                  <TextField id="size" label="Capacity (GB)" type="number" />
+                  <Checkbox id="bootable" label="Bootable" />
+                  <Checkbox id="attachedMode" label="Attached Mode" />
+                  <Checkbox id="readonly" label="Read only?" />
+                  <TextField id="metadata" label="Metadata" />
+                </ValidatedForm>
+              </WizardStep>
+              <pre>{JSON.stringify(context, null, 4)}</pre>
+              <pre>{JSON.stringify(this.state, null, 4)}</pre>
+            </div>
+          )
+        }}
+      </Wizard>
+    )
+  }
+}
 
 export default AddVolumeForm

--- a/src/app/plugins/openstack/components/volumes/UpdateVolumeForm.js
+++ b/src/app/plugins/openstack/components/volumes/UpdateVolumeForm.js
@@ -1,16 +1,12 @@
 import React from 'react'
-import { UPDATE_VOLUME } from './actions'
 import { Button } from '@material-ui/core'
 import ValidatedForm from 'core/common/ValidatedForm'
 import TextField from 'core/common/TextField'
 import Checkbox from 'core/common/Checkbox'
 
-const UpdateVolumeForm = ({ volume, objId }) =>
+const UpdateVolumeForm = ({ volume, onSubmit }) =>
   <ValidatedForm
     initialValue={volume}
-    objId={objId}
-    updateQuery={UPDATE_VOLUME}
-    action="update"
     backUrl="/ui/openstack/storage#volumes"
   >
     <TextField id="name" label="Volume Name" />

--- a/src/app/plugins/openstack/components/volumes/UpdateVolumePage.js
+++ b/src/app/plugins/openstack/components/volumes/UpdateVolumePage.js
@@ -1,29 +1,26 @@
 import React from 'react'
-import { Query } from 'react-apollo'
 import FormWrapper from 'core/common/FormWrapper'
-import UpdateVolumeForm from './UpdateVolumeForm'
-import { GET_VOLUME } from './actions'
 import requiresAuthentication from '../../util/requiresAuthentication'
+import DataUpdater from 'core/DataUpdater'
+import UpdateVolumeForm from './UpdateVolumeForm'
+import { compose } from 'core/fp'
+import { loadVolumes, updateVolume } from './actions'
 
-class UpdateVolumePage extends React.Component {
-  render () {
-    const id = this.props.match.params.volumeId
+const UpdateVolumePage = props => (
+  <DataUpdater
+    dataKey="volumes"
+    loaderFn={loadVolumes}
+    updateFn={updateVolume}
+    objId={props.match.params.volumeId}
+  >
+    {({ data, onSubmit }) =>
+      <FormWrapper title="Update Volume" backUrl="/ui/openstack/storage#volumes">
+        <UpdateVolumeForm volume={data} onSubmit={onSubmit} />
+      </FormWrapper>
+    }
+  </DataUpdater>
+)
 
-    return (
-      <Query query={GET_VOLUME} variables={{ id }}>
-        {({ data }) =>
-          <FormWrapper title="Update Volume" backUrl="/ui/openstack/storage#volumes">
-            { data && data.volume &&
-              <UpdateVolumeForm
-                volume={data.volume}
-                objId={id}
-              />
-            }
-          </FormWrapper>
-        }
-      </Query>
-    )
-  }
-}
-
-export default requiresAuthentication(UpdateVolumePage)
+export default compose(
+  requiresAuthentication,
+)(UpdateVolumePage)

--- a/src/app/plugins/openstack/components/volumes/VolumeTypesListPage.js
+++ b/src/app/plugins/openstack/components/volumes/VolumeTypesListPage.js
@@ -1,14 +1,9 @@
 import React from 'react'
-
-import { compose } from 'core/fp'
 import VolumeTypesListContainer from './VolumeTypesListContainer'
 import requiresAuthentication from '../../util/requiresAuthentication'
 import DataLoader from 'core/DataLoader'
-
-const loadVolumeTypes = async ({ setContext, context }) => {
-  const volumeTypes = await context.openstackClient.cinder.getVolumeTypes()
-  setContext({ volumeTypes })
-}
+import { compose } from 'core/fp'
+import { loadVolumeTypes } from './actions'
 
 const VolumesListPage = () =>
   <DataLoader dataKey="volumeTypes" loaderFn={loadVolumeTypes}>

--- a/src/app/plugins/openstack/components/volumes/VolumesList.js
+++ b/src/app/plugins/openstack/components/volumes/VolumesList.js
@@ -19,8 +19,12 @@ const columns = [
   { id: 'id', label: 'OpenStack ID' },
   { id: 'attachedMode', label: 'attached_mode' },
   { id: 'readonly', label: 'readonly' },
-  { id: 'metadata', label: 'Metadata' }
+
+  // TODO: We probably want to write a metadata renderer for this kind of format
+  // since we use it in a few places for tags / metadata.
+  { id: 'metadata', label: 'Metadata', render: data => JSON.stringify(data) }
 ]
+
 class VolumesList extends React.Component {
   render () {
     const { onAdd, onDelete, onEdit, volumes } = this.props

--- a/src/app/plugins/openstack/components/volumes/VolumesListContainer.js
+++ b/src/app/plugins/openstack/components/volumes/VolumesListContainer.js
@@ -2,27 +2,16 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import CRUDListContainer from 'core/common/CRUDListContainer'
 import VolumesList from './VolumesList'
-import { GET_VOLUMES, REMOVE_VOLUME } from './actions'
 
 class VolumesListContainer extends React.Component {
   render () {
     return (
       <CRUDListContainer
         items={this.props.volumes}
-        objType="volumes"
-        getQuery={GET_VOLUMES}
-        removeQuery={REMOVE_VOLUME}
         addUrl="/ui/openstack/storage/volumes/add"
         editUrl="/ui/openstack/storage/volumes/edit"
       >
-        {({ onDelete, onAdd, onEdit }) => (
-          <VolumesList
-            volumes={this.props.volumes}
-            onAdd={onAdd}
-            onDelete={onDelete}
-            onEdit={onEdit}
-          />
-        )}
+        {handlers => <VolumesList volumes={this.props.volumes} {...handlers} />}
       </CRUDListContainer>
     )
   }

--- a/src/app/plugins/openstack/components/volumes/VolumesListContainer.js
+++ b/src/app/plugins/openstack/components/volumes/VolumesListContainer.js
@@ -2,14 +2,24 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import CRUDListContainer from 'core/common/CRUDListContainer'
 import VolumesList from './VolumesList'
+import { compose } from 'core/fp'
+import { withAppContext } from 'core/AppContext'
 
 class VolumesListContainer extends React.Component {
+  handleRemove = async id => {
+    const { context, setContext } = this.props
+    await context.openstack.cinder.deleteVolume(id)
+    const newVolumes = context.volumes.filter(x => x.id !== id)
+    setContext({ volumes: newVolumes })
+  }
+
   render () {
     return (
       <CRUDListContainer
         items={this.props.volumes}
         addUrl="/ui/openstack/storage/volumes/add"
         editUrl="/ui/openstack/storage/volumes/edit"
+        onRemove={this.handleRemove}
       >
         {handlers => <VolumesList volumes={this.props.volumes} {...handlers} />}
       </CRUDListContainer>
@@ -21,4 +31,6 @@ VolumesListContainer.propTypes = {
   volumes: PropTypes.arrayOf(PropTypes.object)
 }
 
-export default VolumesListContainer
+export default compose(
+  withAppContext,
+)(VolumesListContainer)

--- a/src/app/plugins/openstack/components/volumes/VolumesListContainer.js
+++ b/src/app/plugins/openstack/components/volumes/VolumesListContainer.js
@@ -8,7 +8,7 @@ import { withAppContext } from 'core/AppContext'
 class VolumesListContainer extends React.Component {
   handleRemove = async id => {
     const { context, setContext } = this.props
-    await context.openstack.cinder.deleteVolume(id)
+    await context.openstackClient.cinder.deleteVolume(id)
     const newVolumes = context.volumes.filter(x => x.id !== id)
     setContext({ volumes: newVolumes })
   }

--- a/src/app/plugins/openstack/components/volumes/VolumesListPage.js
+++ b/src/app/plugins/openstack/components/volumes/VolumesListPage.js
@@ -1,24 +1,15 @@
 import React from 'react'
-import { compose, graphql } from 'react-apollo'
-
-import DisplayError from 'core/common/DisplayError'
-import Loader from 'core/common/Loader'
 import VolumesListContainer from './VolumesListContainer'
 import requiresAuthentication from '../../util/requiresAuthentication'
-import { GET_VOLUMES } from './actions'
+import DataLoader from 'core/DataLoader'
+import { compose } from 'core/fp'
+import { loadVolumes } from './actions'
 
-const VolumesListPage =
-  ({ data, loading, error, context }) => {
-    return (
-      <div>
-        {loading && <Loader />}
-        {error && <DisplayError error={error} />}
-        {data && <VolumesListContainer volumes={data.volumes} />}
-      </div>
-    )
-  }
+const VolumesListPage = () =>
+  <DataLoader dataKey="volumes" loaderFn={loadVolumes}>
+    {({ data }) => <VolumesListContainer volumes={data} />}
+  </DataLoader>
 
 export default compose(
   requiresAuthentication,
-  graphql(GET_VOLUMES),
 )(VolumesListPage)

--- a/src/app/plugins/openstack/components/volumes/actions.js
+++ b/src/app/plugins/openstack/components/volumes/actions.js
@@ -5,3 +5,8 @@ export const loadVolumes = async ({ setContext, context }) => {
 
 export const updateVolume = async ({ setContext }) => {
 }
+
+export const loadVolumeTypes = async ({ setContext, context }) => {
+  const volumeTypes = await context.openstackClient.cinder.getVolumeTypes()
+  setContext({ volumeTypes })
+}

--- a/src/app/plugins/openstack/components/volumes/actions.js
+++ b/src/app/plugins/openstack/components/volumes/actions.js
@@ -1,65 +1,7 @@
-import { gql } from 'apollo-boost'
+export const loadVolumes = async ({ setContext, context }) => {
+  const volumes = await context.openstackClient.cinder.getVolumes()
+  setContext({ volumes })
+}
 
-export const GET_VOLUME = gql`
-  query GetVolumeById($id: ID!) {
-    volume(id: $id) {
-      id
-      name
-      description
-      bootable
-    }
-  }
-`
-
-export const GET_VOLUMES = gql`
-  {
-    volumes {
-      id
-      name
-      description
-      volume_type
-      status
-      metadata
-      size
-      bootable
-      tenant
-      source
-      host
-      instance
-      device
-      created_at
-      attachedMode
-      readonly
-    }
-  }
-`
-
-export const REMOVE_VOLUME = gql`
-  mutation RemoveVolume($id: ID!) {
-    removeVolume(id: $id)
-  }
-`
-
-export const ADD_VOLUME = gql`
-  mutation CreateVolume($input: VolumeInput!) {
-    createVolume(input: $input) { id name description volume_type status metadata size bootable tenant source host instance device created_at attachedMode readonly }
-  }
-`
-
-export const UPDATE_VOLUME= gql`
-  mutation UpdateVolume($id: ID!, $input: UpdateInput!) {
-    updateVolume(id: $id, input: $input) { id name description bootable }
-  }
-`
-
-export const GET_VOLUME_TYPES = gql`
-  {
-    volumeTypes {
-      id
-      name
-      description
-      is_public
-      extra_specs
-    }
-  }
-`
+export const updateVolume = async ({ setContext }) => {
+}


### PR DESCRIPTION
* Making some Higher Order Components (HOCs) to make CRUD based operations easier outside of GraphQL.
* Creating `<Picklist>` functionality since we don't have anything that works well in forms.
* Added custom `render` method support for Table `columnDef`s.

Currently this PR still needs some work on the Picklist and Volumes CRUD functionality.