### PR TITLE
Set scoped token on login

### DIFF
--- a/src/app/plugins/openstack/components/SessionManager.js
+++ b/src/app/plugins/openstack/components/SessionManager.js
@@ -44,8 +44,11 @@ class SessionManager extends React.Component {
   }
 
   // Handler that gets invoked on successful authentication
-  initialSetup = ({ username, unscopedToken }) => {
+  initialSetup = async ({ username, unscopedToken }) => {
     const { getUserPreferences, history, location } = this.props
+
+    // Set scoped token
+    await this.keystone.renewToken(unscopedToken)
 
     setStorage('username', username)
     setStorage('unscopedToken', unscopedToken)

--- a/src/openstack-client/Keystone.js
+++ b/src/openstack-client/Keystone.js
@@ -124,7 +124,7 @@ class Keystone {
       const newToken = response.headers['x-subject-token']
       this.client.unscopedToken = token
       this.client.scopedToken = newToken
-      return newToken
+      return token
     } catch (err) {
       // authentication failed
       return null


### PR DESCRIPTION
Scoped token doesn't seem to be set upon logging in -- this change works but not sure if it's ideal.

To reproduce:

Start with fresh ui server and login -- go directly to SSH keys or Hosts page (these go through OpenStack client, which is where the issue exists). Should show unauthorized.