### PR TITLE
Misc random improvements and bugfixes

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -51,7 +51,7 @@ class App extends React.Component {
     return (
       <Router>
         <MuiThemeProvider theme={theme}>
-          <AppContext initialContext={{ openstackClient }}>
+          <AppContext initialContext={{ openstackClient, initialized: false }}>
             <div id="_main-container">
               <SessionManager>
                 <Navbar links={pluginManager.getNavItems()}>

--- a/src/app/core/AppContext.js
+++ b/src/app/core/AppContext.js
@@ -17,8 +17,15 @@ class AppContext extends React.Component {
     ...this.props.initialContext,
 
     setContext: (...args) => {
-      this.setState(...args)
-      setImmediate(() => { window.context = this.state })
+      // If the `setState` async callback is not passed in default to
+      // return a Promise.
+      return new Promise((resolve, reject) => {
+        if (args.length > 1) {
+          return this.setState(...args)
+        }
+        setImmediate(() => { window.context = this.state })
+        this.setState(...args, resolve)
+      })
     },
 
     // Utility function that sets both context.session.userPreferences[key] and

--- a/src/app/core/common/CRUDListContainer.js
+++ b/src/app/core/common/CRUDListContainer.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
 import { compose, withApollo } from 'react-apollo'
 import ConfirmationDialog from './ConfirmationDialog'
+import { asyncForEach } from 'core/fp'
 
 class CRUDListContainer extends React.Component {
   componentDidMount () {
@@ -36,11 +37,11 @@ class CRUDListContainer extends React.Component {
     this.setState({ showConfirmation: false })
   }
 
-  handleDeleteConfirm = () => {
+  handleDeleteConfirm = async () => {
     const { uniqueIdentifier } = this.props
     this.setState({ showConfirmation: false })
     const items = this.state.selectedItems || []
-    items.forEach(item => this.handleRemove(item[uniqueIdentifier]))
+    await asyncForEach(items, item => this.handleRemove(item[uniqueIdentifier]))
 
     this.setState({ selectedItems: [] })
     // The user resolves the promise by clicking "confirm".
@@ -64,7 +65,7 @@ class CRUDListContainer extends React.Component {
     }
 
     if (onRemove) {
-      onRemove(id)
+      await onRemove(id)
     }
   }
 

--- a/src/app/core/fp.js
+++ b/src/app/core/fp.js
@@ -63,3 +63,10 @@ export const keyValueArrToObj = (arr = []) => arr.reduce(
   },
   {}
 )
+
+// Wait for each iteration to complete before continuing to the next (serial)
+export const asyncForEach = async (arr, callback) => {
+  for (let i=0; i<arr.length; i++) {
+    await callback(arr[i], i, arr)
+  }
+}

--- a/src/app/plugins/openstack/components/SessionManager.js
+++ b/src/app/plugins/openstack/components/SessionManager.js
@@ -34,8 +34,8 @@ class SessionManager extends React.Component {
 
   get keystone () { return this.props.context.openstackClient.keystone }
 
-  setSession (newState = {}) {
-    this.props.setContext(state => ({
+  setSession (newState = {}, cb) {
+    return this.props.setContext(state => ({
       ...state,
       session: {
         ...state.session,
@@ -61,12 +61,14 @@ class SessionManager extends React.Component {
     const { keystone } = context.openstackClient
     await keystone.changeProjectScope(activeTenant.id)
 
-    this.setSession({
+    await this.setSession({
       unscopedToken,
       username,
       loginSuccessful: true,
       userPreferences: prefs,
     })
+
+    setContext({ initialized: true })
 
     if (location.pathname === '/ui/openstack/login') {
       history.push('/ui/openstack/dashboard')
@@ -75,7 +77,11 @@ class SessionManager extends React.Component {
 
   render () {
     const { context, children } = this.props
-    const { session } = context
+    const { session, initialized } = context
+
+    if (!initialized) {
+      return <div>Loading app...</div>
+    }
 
     if (!session || !session.loginSuccessful) {
       return <LoginPage onAuthSuccess={this.initialSetup} />

--- a/src/app/plugins/openstack/components/flavors/AddFlavorPage.js
+++ b/src/app/plugins/openstack/components/flavors/AddFlavorPage.js
@@ -5,14 +5,15 @@ import { withRouter } from 'react-router-dom'
 import { compose } from 'core/fp'
 import requiresAuthentication from '../../util/requiresAuthentication'
 import { withAppContext } from 'core/AppContext'
+import { loadFlavors } from './actions'
 
 class AddFlavorPage extends React.Component {
   handleAdd = async flavor => {
     const { setContext, context, history } = this.props
     try {
-      const body = { flavor }
-      const createdFlavor = await context.openstackClient.nova.createFlavor(body)
-      setContext({ flavors: [ ...context.flavors, createdFlavor ] })
+      const existing = await loadFlavors({ setContext, context })
+      const createdFlavor = await context.openstackClient.nova.createFlavor(flavor)
+      setContext({ flavors: [ ...existing, createdFlavor ] })
       history.push('/ui/openstack/flavors')
     } catch (err) {
       console.error(err)

--- a/src/app/plugins/openstack/components/flavors/FlavorsListContainer.js
+++ b/src/app/plugins/openstack/components/flavors/FlavorsListContainer.js
@@ -11,7 +11,7 @@ class FlavorsListContainer extends React.Component {
     const { nova } = context.openstackClient
     await nova.deleteFlavor(id)
     const newFlavors = flavors.filter(x => x.id !== id)
-    setContext({ flavors: newFlavors })
+    await setContext({ flavors: newFlavors })
   }
 
   render () {

--- a/src/app/plugins/openstack/components/flavors/actions.js
+++ b/src/app/plugins/openstack/components/flavors/actions.js
@@ -1,4 +1,6 @@
-export const loadFlavors = async ({ setContext, context }) => {
+export const loadFlavors = async ({ setContext, context, reload }) => {
+  if (!reload && context.flavors) { return context.flavors }
   const flavors = await context.openstackClient.nova.getFlavors()
-  setContext({ flavors })
+  await setContext({ flavors })
+  return flavors
 }

--- a/src/app/plugins/openstack/components/sshkeys/AddSshKeyPage.js
+++ b/src/app/plugins/openstack/components/sshkeys/AddSshKeyPage.js
@@ -5,15 +5,15 @@ import { withRouter } from 'react-router-dom'
 import { compose } from 'core/fp'
 import requiresAuthentication from '../../util/requiresAuthentication'
 import { withAppContext } from 'core/AppContext'
+import { loadSshKeys } from './actions'
 
 class AddSshKeyPage extends React.Component {
   handleAdd = async sshKey => {
     const { setContext, context, history } = this.props
     try {
-      const body = { keypair: sshKey }
-      const response = await context.openstackClient.nova.createSshKey(body)
-      const createdSshKey = response.keypair
-      setContext({ sshKeys: [ ...context.sshKeys, createdSshKey ] })
+      const existing = await loadSshKeys({ context, setContext })
+      const createdSshKey = await context.openstackClient.nova.createSshKey(sshKey)
+      setContext({ sshKeys: [ ...existing, createdSshKey ] })
       history.push('/ui/openstack/sshkeys')
     } catch (err) {
       console.error(err)

--- a/src/app/plugins/openstack/components/sshkeys/actions.js
+++ b/src/app/plugins/openstack/components/sshkeys/actions.js
@@ -1,5 +1,5 @@
 export const loadSshKeys = async ({ setContext, context }) => {
-  const response = await context.openstackClient.nova.getSshKeys()
-  const sshKeys = response.map(key => key.keypair)
+  const sshKeys = await context.openstackClient.nova.getSshKeys()
   setContext({ sshKeys })
+  return sshKeys
 }

--- a/src/app/plugins/openstack/components/volumes/AddVolumePage.js
+++ b/src/app/plugins/openstack/components/volumes/AddVolumePage.js
@@ -5,13 +5,15 @@ import { withRouter } from 'react-router-dom'
 import { compose } from 'core/fp'
 import requiresAuthentication from '../../util/requiresAuthentication'
 import { withAppContext } from 'core/AppContext'
+import { loadVolumes } from './actions'
 
 class AddVolumePage extends React.Component {
   handleAdd = async volume => {
     const { setContext, context, history } = this.props
     try {
-      const createdVolume = await context.openstackClient.cinder.createVolume(volume)
-      setContext({ volumes: [ ...context.volumes, createdVolume ] })
+      const existing = await loadVolumes({ setContext, context })
+      const created = await context.openstackClient.cinder.createVolume(volume)
+      setContext({ volumes: [ ...existing, created ] })
       history.push('/ui/openstack/storage#volumes')
     } catch (err) {
       console.error(err)

--- a/src/app/plugins/openstack/components/volumes/AddVolumeTypePage.js
+++ b/src/app/plugins/openstack/components/volumes/AddVolumeTypePage.js
@@ -17,7 +17,7 @@ class AddVolumeTypePage extends React.Component {
       }
       const createdVolumeType = await context.openstackClient.cinder.createVolumeType(volumeType)
       const existingVolumeTypes = await loadVolumeTypes({ setContext, context })
-      setContext({ volumes: [ ...existingVolumeTypes, createdVolumeType ] })
+      setContext({ volumeTypes: [ ...existingVolumeTypes, createdVolumeType ] })
       history.push('/ui/openstack/storage#volumeTypes')
     } catch (err) {
       console.error(err)

--- a/src/app/plugins/openstack/components/volumes/actions.js
+++ b/src/app/plugins/openstack/components/volumes/actions.js
@@ -1,8 +1,10 @@
 import { objToKeyValueArr, keyValueArrToObj } from 'core/fp'
 
-export const loadVolumes = async ({ setContext, context }) => {
+export const loadVolumes = async ({ setContext, context, reload }) => {
+  if (!reload && context.volumes) { return context.volumes }
   const volumes = await context.openstackClient.cinder.getVolumes()
-  setContext({ volumes })
+  await setContext({ volumes })
+  return volumes
 }
 
 export const updateVolume = async ({ setContext }) => {

--- a/src/openstack-client/Nova.js
+++ b/src/openstack-client/Nova.js
@@ -24,14 +24,14 @@ class Nova {
   sshKeysUrl = async () => `${await this.endpoint()}/os-keypairs`
 
   async getFlavors () {
-    const url = `${await this.flavorsUrl()}/detail`
+    const url = `${await this.flavorsUrl()}/detail?is_public=no`
     const response = await axios.get(url, this.client.getAuthHeaders())
     return response.data.flavors
   }
 
   async createFlavor (params) {
     // The Nova API has an unfortunately horribly named key for public.
-    const converted = renameKey('public', 'os-flavor-access:is_public')(params.flavor)
+    const converted = renameKey('public', 'os-flavor-access:is_public')(params)
     const body = { flavor: converted }
     const url = await this.flavorsUrl()
     const response = await axios.post(url, body, this.client.getAuthHeaders())
@@ -60,13 +60,13 @@ class Nova {
   async getSshKeys () {
     const url = `${await this.sshKeysUrl()}`
     const response = await axios.get(url, this.client.getAuthHeaders())
-    return response.data.keypairs
+    return response.data.keypairs.map(x => x.keypair)
   }
 
   async createSshKey (params) {
     const url = await this.sshKeysUrl()
-    const response = await axios.post(url, params, this.client.getAuthHeaders())
-    return response.data
+    const response = await axios.post(url, { keypair: params }, this.client.getAuthHeaders())
+    return response.data.keypair
   }
 
   async deleteSshKey (id) {


### PR DESCRIPTION
Made some minor but significant improvements and fixes.

* `setContext` now returns a `Promise` if you do not pass in an async handler as the 2nd argument.
* Created utility `asyncForEach` that runs each callback in serial.  This is necessary to avoid race conditions when deleting multiple items and calling `setContext` after each delete.
* Fixed bug for adding a new flavor when user refreshes page on the `AddFlavorPage`.  *We will need to adopt this pattern in other places*—basically any add or update to a collection should first ensure the collection exists.
* Fixed `CRUDListContainer` to make `onRemove` "`await`".
* Added a loading notification when the app is first initializing.  This is necessary to prevent the login page from flashing temporarily.
* Refactored client to return `keypair` directly when dealing with `SshKeys`.
* Changed Flavors listing to also show private flavors.  We will need to add the `current` vs `all tenants` selector later on.