### PR TITLE
Simplify creating Add forms for trivial use case

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,12 @@
     "react/prop-types": 0,
     "no-new": 0,
     "space-infix-ops": 0,
+
+    // Allow for "table" alignment, ex:
+    // { id: 'name',       type: 'string' }
+    // { id: 'longerName', type: 'string' }
+    "no-multi-spaces": [2, { exceptions: { "ObjectExpression": true } } ],
+    "key-spacing": [2, { mode: "minimum" }]
   },
 
   "settings": {

--- a/src/app/core/createAddComponents.js
+++ b/src/app/core/createAddComponents.js
@@ -1,22 +1,29 @@
 import React from 'react'
 import FormWrapper from 'core/common/FormWrapper'
 import requiresAuthentication from 'openstack/util/requiresAuthentication'
+import createFormComponent from 'core/createFormComponent'
 import { withRouter } from 'react-router-dom'
 import { withAppContext } from 'core/AppContext'
 import { compose } from 'core/fp'
 
 const createAddComponents = options => {
   const defaults = {}
-  const {
+  let {
     FormComponent,
     createFn,
     dataKey,
+    formSpec,
     initFn,
     listUrl,
     loaderFn,
     name,
     title,
   } = { ...defaults, ...options }
+
+  if (!FormComponent && formSpec) {
+    formSpec.displayName = `${options.name}Form`
+    FormComponent = createFormComponent(formSpec)
+  }
 
   class AddPageBase extends React.Component {
     handleAdd = async data => {

--- a/src/app/core/createFormComponent.js
+++ b/src/app/core/createFormComponent.js
@@ -7,8 +7,8 @@ const createFormComponent = ({ submitLabel, initialValue, displayName, fields })
   const mapField = spec => {
     const props = {
       ...spec,
-      key:   spec.id,
-      type:  spec.type || 'string',
+      key:  spec.id,
+      type: spec.type || 'string',
     }
     if (props.type === 'string' || props.type === 'number') { return <TextField {...props} /> }
   }

--- a/src/app/core/createFormComponent.js
+++ b/src/app/core/createFormComponent.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import SubmitButton from 'core/common/SubmitButton'
+import ValidatedForm from 'core/common/ValidatedForm'
+import TextField from 'core/common/TextField'
+
+const createFormComponent = ({ submitLabel, initialValue, displayName, fields }) => {
+  const mapField = spec => {
+    const props = {
+      ...spec,
+      key:   spec.id,
+      type:  spec.type || 'string',
+    }
+    if (props.type === 'string' || props.type === 'number') { return <TextField {...props} /> }
+  }
+
+  const Form = ({ onComplete }) => (
+    <ValidatedForm onSubmit={onComplete} initialValue={initialValue}>
+      {fields.map(mapField)}
+      <SubmitButton>{submitLabel}</SubmitButton>
+    </ValidatedForm>
+  )
+  Form.displayName = displayName
+  return Form
+}
+
+export default createFormComponent

--- a/src/app/plugins/openstack/components/flavors/AddFlavorPage.js
+++ b/src/app/plugins/openstack/components/flavors/AddFlavorPage.js
@@ -1,8 +1,4 @@
-import React from 'react'
 import createAddComponents from 'core/createAddComponents'
-import SubmitButton from 'core/common/SubmitButton'
-import ValidatedForm from 'core/common/ValidatedForm'
-import TextField from 'core/common/TextField'
 import { createFlavor, loadFlavors } from './actions'
 
 const initialValue = {
@@ -13,18 +9,17 @@ const initialValue = {
   public: false,
 }
 
-export const AddFlavorForm = ({ onComplete }) => (
-  <ValidatedForm onSubmit={onComplete} initialValue={initialValue}>
-    <TextField id="name" label="Name" />
-    <TextField id="vcpus" label="VCPUs" type="number" />
-    <TextField id="ram" label="RAM" type="number" />
-    <TextField id="disk" label="Disk" type="number" />
-    <SubmitButton>Add Flavor</SubmitButton>
-  </ValidatedForm>
-)
-
 export const options = {
-  FormComponent: AddFlavorForm,
+  initialValue,
+  formSpec: {
+    fields: [
+      { id: 'name',  label: 'Name' },
+      { id: 'vcpus', label: 'VCPUs', type: 'number' },
+      { id: 'ram',   label: 'RAM',   type: 'number' },
+      { id: 'disk',  label: 'Disk',  type: 'number' },
+    ],
+    submitLabel: 'Add Flavor',
+  },
   createFn: createFlavor,
   loaderFn: loadFlavors,
   listUrl: '/ui/openstack/flavors',

--- a/src/app/plugins/openstack/components/flavors/AddFlavorPage.js
+++ b/src/app/plugins/openstack/components/flavors/AddFlavorPage.js
@@ -10,8 +10,8 @@ const initialValue = {
 }
 
 export const options = {
-  initialValue,
   formSpec: {
+    initialValue,
     fields: [
       { id: 'name',  label: 'Name' },
       { id: 'vcpus', label: 'VCPUs', type: 'number' },


### PR DESCRIPTION
This makes it simpler to create simple AddForms.  With this approach we don't need as many `import` statements.  Additionally, this allows us to generate a larger portion of the UI dynamically from a spec.

This will work for the trivial use cases, but not for something with Wizards and Picklists that require loading data from external APIs (`AddVolumeForm`).  That will still require specifying a custom `FormComponent`.  However, as we see common patterns we can incorporate that into the `formSpec`.