### PR TITLE
Hide OpenStack navigation for first release

### DIFF
--- a/src/app/plugins/kubernetes/index.js
+++ b/src/app/plugins/kubernetes/index.js
@@ -27,7 +27,7 @@ Kubernetes.registerPlugin = pluginManager => {
     [
       {
         name: 'Infrastructure',
-        link: { path: '/infrastructure', exact: true },
+        link: { path: '/infrastructure', exact: true, default: true },
         component: InfrastructurePage
       },
       {

--- a/src/app/plugins/openstack/index.js
+++ b/src/app/plugins/openstack/index.js
@@ -69,7 +69,7 @@ OpenStack.registerPlugin = pluginManager => {
     [
       {
         name: 'Dashboard',
-        link: { path: '/', exact: true, default: true },
+        link: { path: '/', exact: true, default: false },
         component: DashboardPage
       },
       {
@@ -253,6 +253,7 @@ OpenStack.registerPlugin = pluginManager => {
   pluginManager.registerNavItems(
     '/ui/openstack',
     [
+      /* Comment out the nav items since first UI release will be K8s only
       {
         name: 'Dashboard',
         link: { path: '/' }
@@ -309,6 +310,7 @@ OpenStack.registerPlugin = pluginManager => {
         name: 'Hosts',
         link: { path: '/hosts' }
       }
+      */
     ]
   )
 }


### PR DESCRIPTION
The first release of the new UI will be Kubernetes only.

OpenStack will take much longer and will be released later so I'm commenting out the OpenStack clutter in the side nav.