### PR TITLE
Cluster links

### DIFF
--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -99,7 +99,8 @@ class Qbert {
   async detach (clusterId, nodeIds) { /* TODO */ }
 
   async getCliToken (clusterId, namespace) {
-    return this.client.basicPost(`${await this.baseUrl()}/webcli/${clusterId}`, { namespace })
+    const response = await this.client.basicPost(`${await this.baseUrl()}/webcli/${clusterId}`, { namespace })
+    return response.token
   }
 
   /* k8s API */

--- a/src/app/core/common/ListTable.js
+++ b/src/app/core/common/ListTable.js
@@ -186,8 +186,10 @@ class ListTable extends React.Component {
 
     if (typeof contents === 'boolean') { _contents = String(_contents) }
 
-    // Allow for customized rendering in the columnDef
-    if (columnDef.render) { _contents = columnDef.render(contents, row) }
+    // Allow for customized rendering in the columnDef.  The render function might need
+    // to know more about the entire object (row) being rendered and in some cases the
+    // entire context.
+    if (columnDef.render) { _contents = columnDef.render(contents, row, this.props.context) }
 
     return (
       <TableCell key={columnDef.id} {...cellProps}>{_contents}</TableCell>

--- a/src/app/core/common/SimpleLink.js
+++ b/src/app/core/common/SimpleLink.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+const SimpleLink = ({ onClick, src, children, ...rest }) => {
+  const handleClick = e => {
+    // Prevent links inside of a table row from triggering row selection.
+    e.stopPropagation()
+    if (onClick) {
+      e.preventDefault()
+      onClick(e)
+    }
+    // If there is no provided onClick, just use the `src` as a normal link.
+  }
+
+  return (
+    <a href={src || '#'} onClick={handleClick} {...rest}>{children}</a>
+  )
+}
+
+export default SimpleLink

--- a/src/app/plugins/developer/components/ApiHelper.js
+++ b/src/app/plugins/developer/components/ApiHelper.js
@@ -57,8 +57,8 @@ class ApiHelper extends React.Component {
 
     const response = await {
       GET:    () => apiClient.basicGet(finalUrl),
-      POST:   () => apiClient.basicPost(finalUrl, body),
-      PUT:    () => apiClient.basicPut(finalUrl, body),
+      POST:   () => apiClient.basicPost(finalUrl, JSON.parse(body)),
+      PUT:    () => apiClient.basicPut(finalUrl, JSON.parse(body)),
       DELETE: () => apiClient.basicGet(finalUrl),
     }[method]()
 
@@ -67,8 +67,14 @@ class ApiHelper extends React.Component {
 
   setField = key => value => this.setState({ [key]: value })
 
-  handleServiceChange = ({ service, baseUrl }) => {
-    this.setState({ service, baseUrl })
+  handleServiceChange = async ({ service, baseUrl }) => {
+    const { apiClient } = this.props.context
+    this.setState({ service })
+
+    if (service === 'qbert') {
+      return this.setState({ baseUrl: await apiClient.qbert.baseUrl() })
+    }
+    this.setState({ baseUrl })
   }
 
   toggleFieldSelection = field => e => {

--- a/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
@@ -2,22 +2,14 @@ import React from 'react'
 import createCRUDComponents from 'core/createCRUDComponents'
 import DownloadKubeConfigLink from './DownloadKubeConfigLink'
 import KubeCLI from './KubeCLI'
+import SimpleLink from 'core/common/SimpleLink'
 import { loadInfrastructure } from './actions'
-
-// Prevent the cluster row from being selected
-const stopPropagation = e => e.stopPropagation()
-
-const Link = ({ src, Icon, label }) => (
-  <div>
-    <a href={src} target="_blank" onClick={stopPropagation}>{label}</a>
-  </div>
-)
 
 const renderLinks = links => {
   if (!links) { return null }
   return (
     <div>
-      {links.dashboard && <Link src={links.dashboard} label="Dashboard" />}
+      {links.dashboard && <SimpleLink src={links.dashboard} target="_blank">Dashboard</SimpleLink>}
       {links.kubeconfig && <DownloadKubeConfigLink cluster={links.kubeconfig.cluster} />}
       {links.cli && <KubeCLI {...links.cli} />}
     </div>

--- a/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
@@ -1,11 +1,27 @@
 import React from 'react'
 import createCRUDComponents from 'core/createCRUDComponents'
+import DownloadKubeConfigLink from './DownloadKubeConfigLink'
+import KubeCLI from './KubeCLI'
 import { loadInfrastructure } from './actions'
 
-// TOOD: I can't do anything async in the render function.
-// I'll need to do this inside of `loadInfrastructure` unfortunately.
-const renderLinks = async (_, cluster, context) => {
-  return Promise.resolve(<div>test</div>)
+// Prevent the cluster row from being selected
+const stopPropagation = e => e.stopPropagation()
+
+const Link = ({ src, Icon, label }) => (
+  <div>
+    <a href={src} target="_blank" onClick={stopPropagation}>{label}</a>
+  </div>
+)
+
+const renderLinks = links => {
+  if (!links) { return null }
+  return (
+    <div>
+      {links.dashboard && <Link src={links.dashboard} label="Dashboard" />}
+      {links.kubeconfig && <DownloadKubeConfigLink cluster={links.kubeconfig.cluster} />}
+      {links.cli && <KubeCLI {...links.cli} />}
+    </div>
+  )
 }
 
 export const options = {

--- a/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
@@ -1,11 +1,19 @@
+import React from 'react'
 import createCRUDComponents from 'core/createCRUDComponents'
+import { loadInfrastructure } from './actions'
+
+// TOOD: I can't do anything async in the render function.
+// I'll need to do this inside of `loadInfrastructure` unfortunately.
+const renderLinks = async (_, cluster, context) => {
+  return Promise.resolve(<div>test</div>)
+}
 
 export const options = {
   baseUrl: '/ui/kubernetes/infrastructure/clusters',
   columns: [
     { id: 'name', label: 'Cluster name' },
     { id: 'status', label: 'Status' },
-    { id: 'links', label: 'Links' },
+    { id: 'links', label: 'Links', render: renderLinks },
     { id: 'deployment_type', label: 'Deployment Type' },
     { id: 'resource_utilization', label: 'Resource Utilization' },
     { id: 'version', label: 'Kubernetes version' },
@@ -28,7 +36,7 @@ export const options = {
     { id: 'metadata', label: 'Metadata', render: data => JSON.stringify(data) }
   ],
   dataKey: 'clusters',
-  actions: { service: 'qbert', entity: 'clusters' },
+  loaderFn: loadInfrastructure,
   name: 'Clusters',
   title: 'Clusters',
   uniqueIdentifier: 'uuid',

--- a/src/app/plugins/kubernetes/components/infrastructure/DownloadKubeConfigLink.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/DownloadKubeConfigLink.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { compose } from 'ramda'
+import { withAppContext } from 'core/AppContext'
+
+class DownloadKubeConfigLink extends React.Component {
+  handleClick = e => {
+    // Prevent the table row from being selected
+    e.preventDefault()
+    e.stopPropagation()
+
+    console.log('DownloadKubeConfigLink#handleClick')
+    // TODO: The original solution involves requesting the user
+    // for their username and password and then saving them
+    // in the "context" for future use.  I'm not crazy about the
+    // security implications.  I'd like to punt on this for now
+    // and see if we can get a dedicated endpoint that uses the
+    // existing auth headers to authenticate.
+  }
+
+  render () {
+    return (
+      <a href="#" onClick={this.handleClick}>kubeconfig</a>
+    )
+  }
+}
+
+export default compose(
+  withAppContext,
+)(DownloadKubeConfigLink)

--- a/src/app/plugins/kubernetes/components/infrastructure/DownloadKubeConfigLink.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/DownloadKubeConfigLink.js
@@ -1,13 +1,10 @@
 import React from 'react'
 import { compose } from 'ramda'
 import { withAppContext } from 'core/AppContext'
+import SimpleLink from 'core/common/SimpleLink'
 
 class DownloadKubeConfigLink extends React.Component {
   handleClick = e => {
-    // Prevent the table row from being selected
-    e.preventDefault()
-    e.stopPropagation()
-
     console.log('DownloadKubeConfigLink#handleClick')
     // TODO: The original solution involves requesting the user
     // for their username and password and then saving them
@@ -15,11 +12,18 @@ class DownloadKubeConfigLink extends React.Component {
     // security implications.  I'd like to punt on this for now
     // and see if we can get a dedicated endpoint that uses the
     // existing auth headers to authenticate.
+    //
+    // After further discussions with the Qbert team there will
+    // be some refactoring done to support self-service users.
+    // It is likely we can re-use that logic instead when it
+    // becomes available.
   }
 
   render () {
     return (
-      <a href="#" onClick={this.handleClick}>kubeconfig</a>
+      <div>
+        <SimpleLink onClick={this.handleClick}>kubeconfig</SimpleLink>
+      </div>
     )
   }
 }

--- a/src/app/plugins/kubernetes/components/infrastructure/KubeCLI.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/KubeCLI.js
@@ -5,6 +5,7 @@ import { withAppContext } from 'core/AppContext'
 import { AppBar, Dialog, IconButton, Slide, Toolbar, Typography } from '@material-ui/core'
 import { withStyles } from '@material-ui/core/styles'
 import CloseIcon from '@material-ui/icons/Close'
+import SimpleLink from 'core/common/SimpleLink'
 
 const styles = {
   appBar: {
@@ -24,9 +25,7 @@ const Transition = props => <Slide direction="up" {...props} />
 class KubeCLI extends React.Component {
   state = { url: null, open: false }
 
-  handleClick = async e => {
-    e.preventDefault()
-    e.stopPropagation()
+  handleClick = async () => {
     const { host, cluster, context } = this.props
     const token = await context.apiClient.qbert.getCliToken(cluster.uuid)
     const url = `${host}/container/index.html?token=${token}`
@@ -44,7 +43,7 @@ class KubeCLI extends React.Component {
     const { classes } = this.props
     return (
       <div>
-        <a href="#" onClick={this.handleClick}>CLI</a>
+        <SimpleLink onClick={this.handleClick}>CLI</SimpleLink>
         <Dialog
           fullScreen
           open={this.state.open}

--- a/src/app/plugins/kubernetes/components/infrastructure/KubeCLI.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/KubeCLI.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { compose } from 'ramda'
+import { withAppContext } from 'core/AppContext'
+import { AppBar, Dialog, IconButton, Slide, Toolbar, Typography } from '@material-ui/core'
+import { withStyles } from '@material-ui/core/styles'
+import CloseIcon from '@material-ui/icons/Close'
+
+const styles = {
+  appBar: {
+    position: 'relative'
+  },
+  flex: {
+    flex: 1,
+  },
+  iframe: {
+    width: '95%',
+    height: '95%',
+  }
+}
+
+const Transition = props => <Slide direction="up" {...props} />
+
+class KubeCLI extends React.Component {
+  state = { url: null, open: false }
+
+  handleClick = async e => {
+    e.preventDefault()
+    e.stopPropagation()
+    const { host, cluster, context } = this.props
+    const token = await context.apiClient.qbert.getCliToken(cluster.uuid)
+    const url = `${host}/container/index.html?token=${token}`
+    this.setState({ url, open: true })
+  }
+
+  handleClose = e => {
+    // Need to stop the bubbling so the row does not get selected in the table
+    e.preventDefault()
+    e.stopPropagation()
+    this.setState({ open: false })
+  }
+
+  render () {
+    const { classes } = this.props
+    return (
+      <div>
+        <a href="#" onClick={this.handleClick}>CLI</a>
+        <Dialog
+          fullScreen
+          open={this.state.open}
+          onClose={this.handleClose}
+          TransitionComponent={Transition}
+        >
+          <AppBar className={classes.appBar}>
+            <Toolbar>
+              <IconButton color="inherit" onClick={this.handleClose}>
+                <CloseIcon />
+              </IconButton>
+              <Typography variant="h6" color="inherit" className={classes.flex}>KubeCLI</Typography>
+            </Toolbar>
+          </AppBar>
+          <iframe className={classes.iframe} src={this.state.url} />
+        </Dialog>
+      </div>
+    )
+  }
+}
+
+KubeCLI.propTypes = {
+  host: PropTypes.string.isRequired,
+  cluster: PropTypes.object.isRequired,
+}
+
+export default compose(
+  withAppContext,
+  withStyles(styles),
+)(KubeCLI)


### PR DESCRIPTION
This PR adds the Kubernetes Dashboard link as well as the CLI.

For the CLI I just used a `<Dialog fullScreen>` instead of the complex tab solution we have now.  The iTerm like tab solution might not be necessary and is a lot of custom code so I opted for the simpler solution for now.

I'm punting on the kubeconfig since I don't like saving the username / password in the client and re-using it.  We already have an auth mechanism so the backend should really provide a proper endpoint for this functionality.