### PR TITLE
Scaffold out how we can do integration tests

### DIFF
--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/integration/clusters.spec.js
+++ b/cypress/integration/clusters.spec.js
@@ -1,0 +1,32 @@
+describe('clusters', () => {
+  beforeEach(() => {
+    cy.setSimSession()
+  })
+
+  context('list clusters', () => {
+    it('lists clusters', () => {
+      cy.visit('/ui/kubernetes/clusters')
+      cy.contains('fakeCluster1')
+    })
+  })
+
+  context('cluster details', () => {
+    it('allows navigation to the cluster details', () => {
+      cy.contains('fakeCluster1').click()
+      cy.contains('someCloudProvider')
+    })
+
+    it('shows nodes on cluster details', () => {
+      cy.contains('Nodes').click()
+      cy.contains('Cluster Nodes')
+    })
+  })
+
+  context('create cluster', () => {
+    it('shows the cluster create form', () => {
+      cy.visit('/ui/kubernetes/clusters')
+      cy.contains('Add').click()
+      cy.contains('Add Cluster')
+    })
+  })
+})

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -34,10 +34,8 @@ describe('login', () => {
   })
 
   it('remembers the login state on refresh', () => {
-    // TODO: Need to find a way to mock a login.
-    // It seems like calls to visit discard all browser state.
-    // cy.visit('/')
-    // cy.contains('SIGN IN')
-    // .should('not.exist')
+    cy.setSimSession()
+    cy.visit('/')
+    cy.contains('Current Region')
   })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,5 @@
+const config = require('../../config')
+
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite
@@ -23,3 +25,14 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+// Allow the session to be stubbed out.
+// The hard-coded token id is explicitly whitelisted in the simulator.
+// TODO: For true e2e tests we can have this command make actual API calls to login,
+// then memoize the result, and set them here.
+Cypress.Commands.add('setSimSession', () => {
+  const tokenId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+  const username = config.simulator.username
+  const session = { username, unscopedToken: tokenId }
+  window.localStorage.setItem('pf9', JSON.stringify(session))
+})

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
     "test:client": "cross-env NODE_ENV=test jest src/api-client",
     "test:client:watch": "cross-env NODE_ENV=test jest --watch src/api-client",
     "test:e2e": "cross-env NODE_ENV=test jest -i e2e-tests/",
-    "test:integration": "cross-env NODE_ENV=test cypress open",
+    "test:integration": "cross-env NODE_ENV=test cypress run",
+    "test:integration:watch": "cross-env NODE_ENV=test cypress open",
     "test:unit": "cross-env NODE_ENV=test jest --coverage src/app src/server",
     "test:unit:watch": "cross-env NODE_ENV=test jest --watch --coverage src/app src/server"
   },

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -4,6 +4,7 @@ const context = require('./context').default
 const server = require('./server')
 const config = require('../../config')
 const User = require('./models/openstack/User').default
+const Token = require('./models/openstack/Token').default
 
 server.startServer()
 context.resetContext()
@@ -18,6 +19,9 @@ if (simulator) {
 
   const { username, password } = simulator
   if (username && password) {
-    new User({ name: username, password })
+    const user = new User({ name: username, password })
+
+    // construct a token with a hard-coded id to make testing easier
+    new Token({ user, id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' })
   }
 }


### PR DESCRIPTION
* Created a mechanism to stub out the session so we don't have to log in on every single test.
* Created a hard-coded token that only works in the simulator that tests can use to bypass login.

There's some debate in my mind between making each test run independently and having previous tests be a prerequisite.  Using `cy.visit` on every test means we have to wait for the full page loads on every test.  I decided to make assumptions that the previous test ran in most of the tests to make tests run faster.

![login spec](https://user-images.githubusercontent.com/289156/51941650-fa861280-23c9-11e9-8868-523c903a8c43.gif)


![clusters spec](https://user-images.githubusercontent.com/289156/51941567-ce6a9180-23c9-11e9-8052-b5e9dab629d2.gif)
