### PR TITLE
Cluster actions (attach)

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,5 @@
 {
-  "baseUrl": "http://localhost:3000"
+  "baseUrl": "http://localhost:3000",
+  "viewportWidth": 1920,
+  "viewportHeight": 1080
 }

--- a/cypress/integration/clusters.spec.js
+++ b/cypress/integration/clusters.spec.js
@@ -1,7 +1,3 @@
-// TODO: Currently these tests are not idempotent.  When running the tests in watch mode
-// within the same simulator instance, nodes will not be available because they have already
-// been attached.  We need to have the tests start the simulator and control its state in the
-// "before".
 describe('clusters', () => {
   beforeEach(() => {
     cy.setSimSession()
@@ -35,7 +31,11 @@ describe('clusters', () => {
   })
 
   context('cluster actions', () => {
-    context.only('attach node', () => {
+    before(() => {
+      cy.resetServerContext('dev')
+    })
+
+    context('attach node', () => {
       it('shows the modal for adding nodes to the cluster', () => {
         cy.visit('/ui/kubernetes/clusters')
         cy.row('fakeCluster1')

--- a/cypress/integration/clusters.spec.js
+++ b/cypress/integration/clusters.spec.js
@@ -31,7 +31,7 @@ describe('clusters', () => {
   })
 
   context('cluster actions', () => {
-    context.only('attach node', () => {
+    context('attach node', () => {
       it('shows the modal for adding nodes to the cluster', () => {
         cy.visit('/ui/kubernetes/clusters')
         cy.row('fakeCluster1')
@@ -39,17 +39,53 @@ describe('clusters', () => {
         cy.contains('Attach Node to Cluster')
       })
 
-      it.skip('closes the modal on cancel', () => {
+      it('selects "master" on the node', () => {
+        cy.get('div[role=dialog]').contains('tr', 'fakeNode2').contains('Master').click()
+      })
+
+      it('closes the modal on attach', () => {
+        cy.contains('button', 'Attach').click()
+        cy.contains('Attach Node to Cluster').should('not.exist')
+      })
+
+      it('should not allow the node to be added to another cluster', () => {
+        // We might want to add something to the UI that gets displayed when
+        // the async operation completes so we have a better UX and also so
+        // we don't need to wait.
+        cy.wait(2000)
+
+        // Reload to the page to get the latest nodes data
+        cy.visit('/ui/kubernetes/clusters')
+        // TODO: need to update the AppContext with the new cluster <-> association
+
+        cy.row('fakeCluster1')
+          .rowAction('Attach node')
+        cy.get('div[role=dialog]').contains('fakeNode2').should('not.exist')
+      })
+
+      it('should show "No nodes available to attach"', () => {
+        cy.visit('/ui/kubernetes/clusters')
+        cy.row('fakeCluster1')
+          .rowAction('Attach node')
+        cy.contains('No nodes available to attach')
+      })
+
+      it('closes the modal on cancel', () => {
+        cy.row('fakeCluster1')
+          .rowAction('Attach node')
+        cy.contains('Attach Node to Cluster')
         cy.contains('Cancel').click()
         cy.contains('Attach Node to Cluster').should('not.exist')
       })
 
-      it.skip('closes the modal on attach', () => {
-        cy.row('fakeCluster1')
-          .rowAction('Attach node')
-        cy.contains('Attach Node to Cluster')
-        cy.contains('button', 'Attach').click()
-        cy.contains('Attach Node to Cluster').should('not.exist')
+      it.only('only allows attaching for "local" cloudProviders', () => {
+        cy.visit('/ui/kubernetes/clusters')
+        cy.row('mockOpenStackCluster').rowAction().contains('Attach node').isDisabled()
+        cy.closeModal()
+        cy.row('mockAwsCluster').rowAction().contains('Attach node').isDisabled()
+        cy.closeModal()
+        cy.row('fakeCluster1').rowAction().contains('Attach node').isEnabled()
+        cy.closeModal()
       })
     })
   })

--- a/cypress/integration/clusters.spec.js
+++ b/cypress/integration/clusters.spec.js
@@ -29,4 +29,28 @@ describe('clusters', () => {
       cy.contains('Add Cluster')
     })
   })
+
+  context('cluster actions', () => {
+    context.only('attach node', () => {
+      it('shows the modal for adding nodes to the cluster', () => {
+        cy.visit('/ui/kubernetes/clusters')
+        cy.tableRowContaining('fakeCluster1')
+          .rowAction('Attach node')
+        cy.contains('Attach Node to Cluster')
+      })
+
+      it('closes the modal on cancel', () => {
+        cy.contains('Cancel').click()
+        cy.contains('Attach Node to Cluster').should('not.exist')
+      })
+
+      it('closes the modal on attach', () => {
+        cy.tableRowContaining('fakeCluster1')
+          .rowAction('Attach node')
+        cy.contains('Attach Node to Cluster')
+        cy.contains('button', 'Attach').click()
+        cy.contains('Attach Node to Cluster').should('not.exist')
+      })
+    })
+  })
 })

--- a/cypress/integration/clusters.spec.js
+++ b/cypress/integration/clusters.spec.js
@@ -1,3 +1,7 @@
+// TODO: Currently these tests are not idempotent.  When running the tests in watch mode
+// within the same simulator instance, nodes will not be available because they have already
+// been attached.  We need to have the tests start the simulator and control its state in the
+// "before".
 describe('clusters', () => {
   beforeEach(() => {
     cy.setSimSession()
@@ -22,7 +26,7 @@ describe('clusters', () => {
     })
   })
 
-  context('create cluster', () => {
+  context.skip('create cluster', () => {
     it('shows the cluster create form', () => {
       cy.visit('/ui/kubernetes/clusters')
       cy.contains('Add').click()
@@ -47,13 +51,9 @@ describe('clusters', () => {
         cy.contains('button', 'Attach').click()
         cy.contains('Attach Node to Cluster').should('not.exist')
       })
+      return
 
       it('should not allow the node to be added to another cluster', () => {
-        // We might want to add something to the UI that gets displayed when
-        // the async operation completes so we have a better UX and also so
-        // we don't need to wait.
-        cy.wait(2000)
-
         // Reload to the page to get the latest nodes data
         cy.visit('/ui/kubernetes/clusters')
         // TODO: need to update the AppContext with the new cluster <-> association
@@ -78,7 +78,7 @@ describe('clusters', () => {
         cy.contains('Attach Node to Cluster').should('not.exist')
       })
 
-      it.only('only allows attaching for "local" cloudProviders', () => {
+      it('only allows attaching for "local" cloudProviders', () => {
         cy.visit('/ui/kubernetes/clusters')
         cy.row('mockOpenStackCluster').rowAction().contains('Attach node').isDisabled()
         cy.closeModal()

--- a/cypress/integration/clusters.spec.js
+++ b/cypress/integration/clusters.spec.js
@@ -26,7 +26,7 @@ describe('clusters', () => {
     })
   })
 
-  context.skip('create cluster', () => {
+  context('create cluster', () => {
     it('shows the cluster create form', () => {
       cy.visit('/ui/kubernetes/clusters')
       cy.contains('Add').click()
@@ -35,7 +35,7 @@ describe('clusters', () => {
   })
 
   context('cluster actions', () => {
-    context('attach node', () => {
+    context.only('attach node', () => {
       it('shows the modal for adding nodes to the cluster', () => {
         cy.visit('/ui/kubernetes/clusters')
         cy.row('fakeCluster1')
@@ -51,35 +51,23 @@ describe('clusters', () => {
         cy.contains('button', 'Attach').click()
         cy.contains('Attach Node to Cluster').should('not.exist')
       })
-      return
 
       it('should not allow the node to be added to another cluster', () => {
-        // Reload to the page to get the latest nodes data
-        cy.visit('/ui/kubernetes/clusters')
-        // TODO: need to update the AppContext with the new cluster <-> association
-
         cy.row('fakeCluster1')
           .rowAction('Attach node')
         cy.get('div[role=dialog]').contains('fakeNode2').should('not.exist')
       })
 
       it('should show "No nodes available to attach"', () => {
-        cy.visit('/ui/kubernetes/clusters')
-        cy.row('fakeCluster1')
-          .rowAction('Attach node')
         cy.contains('No nodes available to attach')
       })
 
       it('closes the modal on cancel', () => {
-        cy.row('fakeCluster1')
-          .rowAction('Attach node')
-        cy.contains('Attach Node to Cluster')
         cy.contains('Cancel').click()
         cy.contains('Attach Node to Cluster').should('not.exist')
       })
 
       it('only allows attaching for "local" cloudProviders', () => {
-        cy.visit('/ui/kubernetes/clusters')
         cy.row('mockOpenStackCluster').rowAction().contains('Attach node').isDisabled()
         cy.closeModal()
         cy.row('mockAwsCluster').rowAction().contains('Attach node').isDisabled()

--- a/cypress/integration/clusters.spec.js
+++ b/cypress/integration/clusters.spec.js
@@ -34,18 +34,18 @@ describe('clusters', () => {
     context.only('attach node', () => {
       it('shows the modal for adding nodes to the cluster', () => {
         cy.visit('/ui/kubernetes/clusters')
-        cy.tableRowContaining('fakeCluster1')
+        cy.row('fakeCluster1')
           .rowAction('Attach node')
         cy.contains('Attach Node to Cluster')
       })
 
-      it('closes the modal on cancel', () => {
+      it.skip('closes the modal on cancel', () => {
         cy.contains('Cancel').click()
         cy.contains('Attach Node to Cluster').should('not.exist')
       })
 
-      it('closes the modal on attach', () => {
-        cy.tableRowContaining('fakeCluster1')
+      it.skip('closes the modal on attach', () => {
+        cy.row('fakeCluster1')
           .rowAction('Attach node')
         cy.contains('Attach Node to Cluster')
         cy.contains('button', 'Attach').click()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -87,3 +87,14 @@ Cypress.Commands.add(
     cy.get(selector).should('not.exist') // Wait for the modal to close before proceeding.
   }
 )
+
+Cypress.Commands.add(
+  'resetServerContext',
+  preset => {
+    if (preset) {
+      cy.request(`${config.apiHost}/admin/preset/${preset}`)
+    }
+    // Give time for simulator context to be initialized before using the APIs
+    cy.wait(200)
+  }
+)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,3 +36,19 @@ Cypress.Commands.add('setSimSession', () => {
   const session = { username, unscopedToken: tokenId }
   window.localStorage.setItem('pf9', JSON.stringify(session))
 })
+
+// For use with <ListTable>.  This will select the row containing the given text.
+Cypress.Commands.add('tableRowContaining', text => {
+  cy.contains(text)
+    .parentsUntil('tr').parent()
+})
+
+// Once a ListTable row is selected (prevSubject), click the specified row action.
+Cypress.Commands.add(
+  'rowAction',
+  { prevSubject: true },
+  (subject, action) => {
+    subject.find('button[aria-label="More Actions"]').click()
+    cy.get('#more-menu').contains(action).click()
+  }
+)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -38,9 +38,7 @@ Cypress.Commands.add('setSimSession', () => {
 })
 
 // For use with <ListTable>.  This will select the row containing the given text.
-Cypress.Commands.add('row', text => {
-  cy.contains('tr', text)
-})
+Cypress.Commands.add('row', text => cy.contains('tr', text))
 
 // Once a ListTable row is selected (prevSubject), click the specified row action.
 Cypress.Commands.add(
@@ -48,6 +46,43 @@ Cypress.Commands.add(
   { prevSubject: true },
   (subject, action) => {
     subject.find('button[aria-label="More Actions"]').click()
-    cy.get('#more-menu').contains(action).click()
+
+    const menu = cy.get('ul[role="menu"]')
+
+    // Allow just the menu to be opened if no action is supplied.
+    action && menu.contains(action).click()
+    return menu
+  }
+)
+
+Cypress.Commands.add(
+  'isDisabled',
+  { prevSubject: 'element' },
+  subject => {
+    cy.wrap(subject).should($subject => {
+      const classNames = $subject.attr('class')
+      console.log(classNames)
+      expect(classNames).to.contain('disabled')
+    })
+  }
+)
+
+Cypress.Commands.add(
+  'isEnabled',
+  { prevSubject: 'element' },
+  subject => {
+    cy.wrap(subject).should($subject => {
+      const classNames = $subject.attr('class')
+      expect(classNames).not.to.contain('disabled')
+    })
+  }
+)
+
+Cypress.Commands.add(
+  'closeModal',
+  () => {
+    const selector = 'div[role="presentation"] > [aria-hidden="true"]'
+    cy.get(selector).click()
+    cy.get(selector).should('not.exist') // Wait for the modal to close before proceeding.
   }
 )

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -38,9 +38,8 @@ Cypress.Commands.add('setSimSession', () => {
 })
 
 // For use with <ListTable>.  This will select the row containing the given text.
-Cypress.Commands.add('tableRowContaining', text => {
-  cy.contains(text)
-    .parentsUntil('tr').parent()
+Cypress.Commands.add('row', text => {
+  cy.contains('tr', text)
 })
 
 // Once a ListTable row is selected (prevSubject), click the specified row action.

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -83,6 +83,7 @@ Cypress.Commands.add(
   () => {
     const selector = 'div[role="presentation"] > [aria-hidden="true"]'
     cy.get(selector).click()
+    cy.wait(100) // During development the modal closes before we can see it is even open
     cy.get(selector).should('not.exist') // Wait for the modal to close before proceeding.
   }
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -8231,7 +8231,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8252,12 +8253,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8272,17 +8275,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8399,7 +8405,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8411,6 +8418,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8425,6 +8433,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8432,12 +8441,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8456,6 +8467,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8536,7 +8548,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8548,6 +8561,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8633,7 +8647,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8669,6 +8684,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8688,6 +8704,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8731,12 +8748,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2181,9 +2181,9 @@
       "dev": true
     },
     "@types/sinon-chai": {
-      "version": "2.7.29",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-2.7.29.tgz",
-      "integrity": "sha512-EkI/ZvJT4hglWo7Ipf9SX+J+R9htNOMjW8xiOhce7+0csqvgoF5IXqY5Ae1GqRgNtWCuaywR5HjVa1snkTqpOw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.2.tgz",
+      "integrity": "sha512-5zSs2AslzyPZdOsbm2NRtuSNAI2aTWzNKOHa/GRecKo7a5efYD7qGcPxMZXQDayVXT2Vnd5waXxBvV31eCZqiA==",
       "dev": true,
       "requires": {
         "@types/chai": "*",
@@ -5706,9 +5706,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.1.4.tgz",
-      "integrity": "sha512-8VJYtCAFqHXMnRDo4vdomR2CqfmhtReoplmbkXVspeKhKxU8WsZl0Nh5yeil8txxhq+YQwDrInItUqIm35Vw+g==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.1.5.tgz",
+      "integrity": "sha512-jzYGKJqU1CHoNocPndinf/vbG28SeU+hg+4qhousT/HDBMJxYgjecXOmSgBX/ga9/TakhqSrIrSP2r6gW/OLtg==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -5722,7 +5722,7 @@
         "@types/minimatch": "3.0.3",
         "@types/mocha": "2.2.44",
         "@types/sinon": "7.0.0",
-        "@types/sinon-chai": "2.7.29",
+        "@types/sinon-chai": "3.2.2",
         "bluebird": "3.5.0",
         "cachedir": "1.3.0",
         "chalk": "2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1294,6 +1294,18 @@
         "recompose": "0.28.0 - 0.30.0"
       }
     },
+    "@material-ui/lab": {
+      "version": "3.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-3.0.0-alpha.29.tgz",
+      "integrity": "sha512-rCCRgF+Dk35OyBSKAufnh0s0OvvhFN4PQyimYgk7DziIxbgOxcQI/sgpqNOB5yT+63OcTZL6OaeSytPdxlEpCQ==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "@material-ui/utils": "^3.0.0-alpha.2",
+        "classnames": "^2.2.5",
+        "keycode": "^2.1.9",
+        "prop-types": "^15.6.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "3.0.0-alpha.8",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-3.0.0-alpha.8.tgz",
@@ -8219,8 +8231,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8241,14 +8252,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8263,20 +8272,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8393,8 +8399,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8406,7 +8411,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8421,7 +8425,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8429,14 +8432,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8455,7 +8456,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8536,8 +8536,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8549,7 +8548,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8635,8 +8633,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8672,7 +8669,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8692,7 +8688,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8736,14 +8731,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "copy-webpack-plugin": "^4.6.0",
     "cross-env": "^5.2.0",
     "css-loader": "^0.28.9",
-    "cypress": "^3.1.4",
+    "cypress": "^3.1.5",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.17.0",
@@ -107,6 +107,7 @@
     "test:e2e": "cross-env NODE_ENV=test jest -i e2e-tests/",
     "test:integration": "cross-env NODE_ENV=test cypress run",
     "test:integration:watch": "cross-env NODE_ENV=test cypress open",
+    "cypress": "cross-env NODE_ENV=test cypress open",
     "test:unit": "cross-env NODE_ENV=test jest --coverage src/app src/server",
     "test:unit:watch": "cross-env NODE_ENV=test jest --watch --coverage src/app src/server"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@babel/polyfill": "^7.0.0",
     "@material-ui/core": "^3.9.0",
     "@material-ui/icons": "^3.0.2",
+    "@material-ui/lab": "^3.0.0-alpha.29",
     "@material-ui/styles": "^3.0.0-alpha.8",
     "axios": "^0.18.0",
     "classnames": "^2.2.5",

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -7,7 +7,7 @@ class Qbert {
   async endpoint () {
     const services = await this.client.keystone.getServicesForActiveRegion()
     const endpoint = services.qbert.admin.url
-    return endpoint.replace(/v(1|2|3)$/, `v2/${this.client.activeProjectId}`)
+    return endpoint.replace(/v(1|2|3)$/, `v3/${this.client.activeProjectId}`)
   }
 
   async monocularBaseUrl () {
@@ -16,6 +16,7 @@ class Qbert {
   }
 
   baseUrl = async () => `${await this.endpoint()}`
+
   clusterBaseUrl = async clusterId => `${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1`
   clusterMonocularBaseUrl = async clusterId => `${await this.clusterBaseUrl(clusterId)}/namespaces/kube-system/services/monocular-api-svc:80/proxy/v1`
 
@@ -110,7 +111,13 @@ class Qbert {
     list: this.getClusters,
   }
 
-  async attach (clusterId, nodeIds) { /* TODO */ }
+  // @param clusterId = cluster.uuid
+  // @param nodes = [{ uuid: node.uuid, isMaster: (true|false) }]
+  async attach (clusterId, nodes) {
+    console.log(clusterId, nodes)
+    return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/attach`, nodes)
+  }
+
   async _detach (clusterId, nodeIds) { /* TODO */ }
   async detach (clusterId, nodeIds) { /* TODO */ }
 

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -114,7 +114,6 @@ class Qbert {
   // @param clusterId = cluster.uuid
   // @param nodes = [{ uuid: node.uuid, isMaster: (true|false) }]
   async attach (clusterId, nodes) {
-    console.log(clusterId, nodes)
     return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/attach`, nodes)
   }
 

--- a/src/app/core/components/AnimateValues.js
+++ b/src/app/core/components/AnimateValues.js
@@ -43,13 +43,18 @@ class AnimateValues extends React.Component {
     const offsetMs = this.elapsed()
     if (offsetMs < duration) {
       this.setState({ elapsed: offsetMs })
-      return requestAnimationFrame(this.tick)
+      this.subscription = requestAnimationFrame(this.tick)
+      return this.subscription
     }
     this.setState({ elapsed: duration })
   }
 
   componentDidMount () {
-    requestAnimationFrame(this.tick)
+    this.subscription = requestAnimationFrame(this.tick)
+  }
+
+  componentWillUnmount = () => {
+    cancelAnimationFrame(this.subscription)
   }
 
   render () {

--- a/src/app/core/components/MoreMenu.js
+++ b/src/app/core/components/MoreMenu.js
@@ -7,7 +7,8 @@ import MoreVertIcon from '@material-ui/icons/MoreVert'
 
 class MoreMenu extends React.Component {
   state = {
-    anchorEl: null
+    anchorEl: null,
+    openedAction: null,
   }
 
   handleOpen = e => {
@@ -20,10 +21,15 @@ class MoreMenu extends React.Component {
     this.setState({ anchorEl: null })
   }
 
-  handleClick = action => e => {
+  handleClick = (action, label) => e => {
     e.stopPropagation()
     this.handleClose(e)
     action(this.props.data)
+    this.setState({ openedAction: label })
+  }
+
+  handleModalClose = () => {
+    this.setState({ openedAction: null })
   }
 
   render () {
@@ -31,6 +37,10 @@ class MoreMenu extends React.Component {
 
     return (
       <div>
+        {this.props.items.map(({ action, icon, dialog, label }) => {
+          const Modal = dialog
+          return this.state.openedAction === label && <Modal key={label} onClose={this.handleModalClose} />
+        })}
         <IconButton
           aria-label="More Actions"
           aria-owns={anchorEl ? 'more-menu' : null}
@@ -45,7 +55,7 @@ class MoreMenu extends React.Component {
           onClose={this.handleClose}
         >
           {this.props.items.map(({ label, action, icon }) =>
-            <MenuItem key={label} onClick={this.handleClick(action)}>
+            <MenuItem key={label} onClick={this.handleClick(action, label)}>
               {icon && icon}
               {label}
             </MenuItem>
@@ -62,8 +72,10 @@ MoreMenu.propTypes = {
    */
   items: PropTypes.arrayOf(
     PropTypes.shape({
-      label: PropTypes.string.isRequired,
       action: PropTypes.func,
+      dialog: PropTypes.func, // React class or functional component
+      icon: PropTypes.node,
+      label: PropTypes.string.isRequired,
     })
   ),
 

--- a/src/app/core/components/MoreMenu.js
+++ b/src/app/core/components/MoreMenu.js
@@ -39,7 +39,7 @@ class MoreMenu extends React.Component {
       <div>
         {this.props.items.map(({ action, icon, dialog, label }) => {
           const Modal = dialog
-          return this.state.openedAction === label && <Modal key={label} onClose={this.handleModalClose} />
+          return this.state.openedAction === label && <Modal key={label} onClose={this.handleModalClose} row={this.props.data} />
         })}
         <IconButton
           aria-label="More Actions"

--- a/src/app/core/components/MoreMenu.js
+++ b/src/app/core/components/MoreMenu.js
@@ -4,6 +4,7 @@ import Menu from '@material-ui/core/Menu'
 import MenuItem from '@material-ui/core/MenuItem'
 import IconButton from '@material-ui/core/IconButton'
 import MoreVertIcon from '@material-ui/icons/MoreVert'
+import { withAppContext } from 'core/AppContext'
 
 class MoreMenu extends React.Component {
   state = {
@@ -24,7 +25,7 @@ class MoreMenu extends React.Component {
   handleClick = (action, label) => e => {
     e.stopPropagation()
     this.handleClose(e)
-    action(this.props.data)
+    action && action(this.props.data, this.props.context)
     this.setState({ openedAction: label })
   }
 
@@ -33,13 +34,14 @@ class MoreMenu extends React.Component {
   }
 
   render () {
-    const { anchorEl } = this.state
+    const { anchorEl, openedAction } = this.state
+    const { data, context } = this.props
 
     return (
       <div>
-        {this.props.items.map(({ action, icon, dialog, label }) => {
+        {this.props.items.map(({ action, cond, dialog, icon, label }) => {
           const Modal = dialog
-          return this.state.openedAction === label && <Modal key={label} onClose={this.handleModalClose} row={this.props.data} />
+          return openedAction === label && <Modal key={label} onClose={this.handleModalClose} row={this.props.data} />
         })}
         <IconButton
           aria-label="More Actions"
@@ -53,9 +55,10 @@ class MoreMenu extends React.Component {
           anchorEl={anchorEl}
           open={!!anchorEl}
           onClose={this.handleClose}
+          onClick={e => e.stopPropagation()}
         >
-          {this.props.items.map(({ label, action, icon }) =>
-            <MenuItem key={label} onClick={this.handleClick(action, label)}>
+          {this.props.items.map(({ action, cond, icon, label }) =>
+            <MenuItem key={label} onClick={this.handleClick(action, label)} disabled={!cond(data, context)}>
               {icon && icon}
               {label}
             </MenuItem>
@@ -76,6 +79,9 @@ MoreMenu.propTypes = {
       dialog: PropTypes.func, // React class or functional component
       icon: PropTypes.node,
       label: PropTypes.string.isRequired,
+
+      // cond :: fn -> bool
+      cond: PropTypes.func,
     })
   ),
 
@@ -85,4 +91,4 @@ MoreMenu.propTypes = {
   data: PropTypes.any,
 }
 
-export default MoreMenu
+export default withAppContext(MoreMenu)

--- a/src/app/core/components/listTable/ListTable.js
+++ b/src/app/core/components/listTable/ListTable.js
@@ -427,9 +427,10 @@ class ListTable extends React.Component {
 
 const actionProps = PropTypes.shape({
   label: PropTypes.string.isRequired,
-  action: PropTypes.func.isRequired,
+  action: PropTypes.func,
   icon: PropTypes.node,
   cond: PropTypes.func,
+  dialog: PropTypes.func,  // a React class or function
 })
 
 ListTable.propTypes = {

--- a/src/app/core/helpers/createListTableComponent.js
+++ b/src/app/core/helpers/createListTableComponent.js
@@ -41,7 +41,9 @@ const createListTableComponent = ({
       columnsOrder={columnsOrder}
       rowsPerPage={rowsPerPage}
       onRowsPerPageChange={rowsPerPage => updatePreferences({ rowsPerPage })}
-      onColumnsChange={updatePreferences} />)
+      onColumnsChange={updatePreferences}
+      uniqueIdentifier={uniqueIdentifier}
+    />)
 
   CustomListTable.displayName = displayName
 

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
@@ -14,11 +14,14 @@ import {
   TableBody,
   TableRow,
   TableCell,
+  Typography,
 } from '@material-ui/core'
 
 // The modal is technically inside the row, so clicking anything inside
 // the modal window will cause the table row to be toggled.
 const stopPropagation = e => {
+  // Except for <a href=""> style links
+  if (e.target.tagName.toUpperCase() === 'A') { return }
   e.preventDefault()
   e.stopPropagation()
 }
@@ -36,6 +39,7 @@ class ClusterAttachNodeDialog extends React.Component {
       .map(uuid => ({ uuid, isMaster: this.state[uuid] === 'master' }))
     const clusterUuid = this.props.row.uuid
     if (nodes.length > 0) {
+      console.log('handleSubmit', this.state)
       this.props.context.apiClient.qbert.attach(clusterUuid, nodes)
     }
     this.handleClose()
@@ -71,6 +75,19 @@ class ClusterAttachNodeDialog extends React.Component {
       <Dialog open onClose={this.handleClose} onClick={stopPropagation}>
         <DialogTitle>Attach Node to Cluster</DialogTitle>
         <DialogContent>
+          <p>
+            <b>IMPORTANT</b>:
+            Before adding nodes to a cluster, please ensure that you have followed the requirements
+            in <a href="https://platform9.com/support/managed-container-cloud-requirements-checklist/" target="_blank">this article</a> for
+            each node.
+          </p>
+
+          <p>
+            Choose the nodes you would like to add to this cluster as well as their corresponding role.
+          </p>
+          {freeNodes.length === 0 &&
+            <Typography variant="h5">No nodes available to attach</Typography>
+          }
           <Table>
             <TableBody>
               {freeNodes.map(this.renderNodeRow)}

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { compose } from 'ramda'
 import { withAppContext } from 'core/AppContext'
 import { withDataLoader } from 'core/DataLoader'
-import { loadInfrastructure } from './actions'
+import { attachNodesToCluster, loadInfrastructure } from './actions'
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab'
 import {
   Button,
@@ -33,15 +33,15 @@ class ClusterAttachNodeDialog extends React.Component {
     this.props.onClose && this.props.onClose()
   }
 
-  handleSubmit = () => {
+  handleSubmit = async () => {
+    const { row, context, setContext } = this.props
+
     const nodes = Object.keys(this.state)
       .filter(uuid => this.state[uuid] !== 'unassigned')
       .map(uuid => ({ uuid, isMaster: this.state[uuid] === 'master' }))
-    const clusterUuid = this.props.row.uuid
-    if (nodes.length > 0) {
-      console.log('handleSubmit', this.state)
-      this.props.context.apiClient.qbert.attach(clusterUuid, nodes)
-    }
+
+    const clusterUuid = row.uuid
+    await attachNodesToCluster({ data: { clusterUuid, nodes }, context, setContext })
     this.handleClose()
   }
 

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
@@ -1,32 +1,82 @@
 import React from 'react'
+import { compose } from 'ramda'
+import { withAppContext } from 'core/AppContext'
+import { withDataLoader } from 'core/DataLoader'
+import { loadInfrastructure } from './actions'
+import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab'
 import {
   Button,
   Dialog,
   DialogActions,
   DialogContent,
-  DialogContentText,
-  DialogTitle
+  DialogTitle,
+  Table,
+  TableBody,
+  TableRow,
+  TableCell,
 } from '@material-ui/core'
 
+// The modal is technically inside the row, so clicking anything inside
+// the modal window will cause the table row to be toggled.
+const stopPropagation = e => {
+  e.preventDefault()
+  e.stopPropagation()
+}
+
 class ClusterAttachNodeDialog extends React.Component {
+  state = {}
+
   handleClose = () => {
     this.props.onClose && this.props.onClose()
   }
 
   handleSubmit = () => {
-    console.log('submitting')
+    const nodes = Object.keys(this.state)
+      .filter(uuid => this.state[uuid] !== 'unassigned')
+      .map(uuid => ({ uuid, isMaster: this.state[uuid] === 'master' }))
+    const clusterUuid = this.props.row.uuid
+    if (nodes.length > 0) {
+      this.props.context.apiClient.qbert.attach(clusterUuid, nodes)
+    }
     this.handleClose()
   }
 
-  render () {
+  setNodeRole = uuid => (e, value) => {
+    e.preventDefault()
+    e.stopPropagation()
+    this.setState({ [uuid]: value || 'unassigned' })
+  }
+
+  renderNodeRow = node => {
+    const uuid = node.uuid
+    const value = this.state[uuid] || 'unassigned'
     return (
-      <Dialog
-        open
-        onClose={this.handleClose}
-      >
+      <TableRow key={uuid}>
+        <TableCell>{node.name}</TableCell>
+        <TableCell>
+          <ToggleButtonGroup exclusive value={value} onChange={this.setNodeRole(uuid)}>
+            <ToggleButton value="unassigned">Unassigned</ToggleButton>
+            <ToggleButton value="master">Master</ToggleButton>
+            <ToggleButton value="worker">Worker</ToggleButton>
+          </ToggleButtonGroup>
+        </TableCell>
+      </TableRow>
+    )
+  }
+
+  render () {
+    const { data } = this.props
+    const freeNodes = data.filter(x => !x.clusterUuid)
+    return (
+      <Dialog open onClose={this.handleClose} onClick={stopPropagation}>
         <DialogTitle>Attach Node to Cluster</DialogTitle>
         <DialogContent>
-          <DialogContentText>testing</DialogContentText>
+          <Table>
+            <TableBody>
+              {freeNodes.map(this.renderNodeRow)}
+            </TableBody>
+          </Table>
+          <pre>{JSON.stringify(this.state, null, 4)}</pre>
         </DialogContent>
         <DialogActions>
           <Button onClick={this.handleClose} color="primary">
@@ -41,4 +91,7 @@ class ClusterAttachNodeDialog extends React.Component {
   }
 }
 
-export default ClusterAttachNodeDialog
+export default compose(
+  withDataLoader({ dataKey: 'nodes', loaderFn: loadInfrastructure }),
+  withAppContext,
+)(ClusterAttachNodeDialog)

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
@@ -93,7 +93,6 @@ class ClusterAttachNodeDialog extends React.Component {
               {freeNodes.map(this.renderNodeRow)}
             </TableBody>
           </Table>
-          <pre>{JSON.stringify(this.state, null, 4)}</pre>
         </DialogContent>
         <DialogActions>
           <Button onClick={this.handleClose} color="primary">

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle
+} from '@material-ui/core'
+
+class ClusterAttachNodeDialog extends React.Component {
+  handleClose = () => {
+    this.props.onClose && this.props.onClose()
+  }
+
+  handleSubmit = () => {
+    console.log('submitting')
+    this.handleClose()
+  }
+
+  render () {
+    return (
+      <Dialog
+        open
+        onClose={this.handleClose}
+      >
+        <DialogTitle>Attach Node to Cluster</DialogTitle>
+        <DialogContent>
+          <DialogContentText>testing</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={this.handleClose} color="primary">
+            Cancel
+          </Button>
+          <Button onClick={this.handleSubmit} color="primary" autoFocus>
+            Attach
+          </Button>
+        </DialogActions>
+      </Dialog>
+    )
+  }
+}
+
+export default ClusterAttachNodeDialog

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterNodes.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterNodes.js
@@ -13,8 +13,8 @@ const ListTable = createListTableComponent({
   title: 'Cluster Nodes',
   emptyText: 'No instances found.',
   name: 'ClusterNodes',
-  uniqueIdentifier: 'uuid',
   columns,
+  uniqueIdentifier: 'uuid',
 })
 
 const ClusterNodes = ({ context, data, match }) => {

--- a/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
@@ -38,14 +38,11 @@ const renderStats = (_, cluster, context) => {
 
 const renderClusterDetailLink = (name, cluster) => <SimpleLink src={`/ui/kubernetes/infrastructure/clusters/${cluster.uuid}`}>{name}</SimpleLink>
 
-const canAttachNode = (selected, context) => true
+const canAttachNode = row => row.cloudProviderType === 'local'
+
 const canDetachNode = (selected, context) => true
 const canScaleCluster = (selected, context) => true
 const canUpgradeCluster = (selected, context) => true
-
-const attachNode = (selected, context) => {
-  console.log('TODO: attachNode')
-}
 
 const detachNode = (selected, context) => {
   console.log('TODO: detachNode')
@@ -80,6 +77,7 @@ export const options = {
     { id: 'hasLoadBalancer', label: 'Load Balancer' },
 
     // TODO: We probably want to write a metadata renderer for this kind of format
+    //
     // since we use it in a few places for tags / metadata.
     { id: 'tags', label: 'Metadata', render: data => JSON.stringify(data) }
   ],
@@ -91,7 +89,7 @@ export const options = {
   title: 'Clusters',
   uniqueIdentifier: 'uuid',
   rowActions: [
-    { cond: canAttachNode, icon: <AttachIcon />, label: 'Attach node', dialog: ClusterAttachNodeDialog, action: attachNode },
+    { cond: canAttachNode, icon: <AttachIcon />, label: 'Attach node', dialog: ClusterAttachNodeDialog },
     { cond: canDetachNode, icon: <DetachIcon />, label: 'Detach node', action: detachNode },
     { cond: canScaleCluster, icon: <ScaleIcon />, label: 'Scale cluster', action: scaleCluster },
     { cond: canUpgradeCluster, icon: <UpgradeIcon />, label: 'Upgrade cluster', action: upgradeCluster },

--- a/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
@@ -10,6 +10,7 @@ import ScaleIcon from '@material-ui/icons/TrendingUp'
 import UpgradeIcon from '@material-ui/icons/PresentToAll'
 import { deleteCluster, loadInfrastructure } from './actions'
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
+import ClusterAttachNodeDialog from './ClusterAttachNodeDialog'
 
 const renderLinks = links => {
   if (!links) { return null }
@@ -90,7 +91,7 @@ export const options = {
   title: 'Clusters',
   uniqueIdentifier: 'uuid',
   rowActions: [
-    { cond: canAttachNode, icon: <AttachIcon />, label: 'Attach node', action: attachNode },
+    { cond: canAttachNode, icon: <AttachIcon />, label: 'Attach node', dialog: ClusterAttachNodeDialog, action: attachNode },
     { cond: canDetachNode, icon: <DetachIcon />, label: 'Detach node', action: detachNode },
     { cond: canScaleCluster, icon: <ScaleIcon />, label: 'Scale cluster', action: scaleCluster },
     { cond: canUpgradeCluster, icon: <UpgradeIcon />, label: 'Upgrade cluster', action: upgradeCluster },

--- a/src/app/plugins/kubernetes/components/infrastructure/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/actions.js
@@ -1,7 +1,5 @@
-import {
-  asyncFlatMap, asyncMap, pathOrNull, pipeWhenTruthy, tap
-} from 'app/utils/fp'
-import { find, pathOr, prop, propEq } from 'ramda'
+import { asyncFlatMap, asyncMap, pathOrNull, pipeWhenTruthy, tap } from 'app/utils/fp'
+import { find, pathOr, pluck, prop, propEq } from 'ramda'
 import { castFuzzyBool } from 'utils/misc'
 import { combineHost } from './combineHosts'
 
@@ -54,9 +52,15 @@ export const createCluster = async ({ data, context }) => {
   console.log(data)
 }
 
-export const attachNodesToCluster = ({ data, context, setContext }) => {
+export const attachNodesToCluster = async ({ data, context, setContext }) => {
   const { clusterUuid, nodes } = data
-  return context.apiClient.qbert.attach(clusterUuid, nodes)
+  const nodeUuids = pluck('uuid', nodes)
+  await context.apiClient.qbert.attach(clusterUuid, nodes)
+  // Assign nodes to their clusters in the context as well so the user
+  // can't add the same node to another cluster.
+  const newNodes = context.nodes.map(node =>
+    nodeUuids.includes(node.uuid) ? ({ ...node, clusterUuid }) : node)
+  setContext({ nodes: newNodes })
 }
 
 /*

--- a/src/app/plugins/kubernetes/components/infrastructure/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/actions.js
@@ -54,6 +54,11 @@ export const createCluster = async ({ data, context }) => {
   console.log(data)
 }
 
+export const attachNodesToCluster = ({ data, context, setContext }) => {
+  const { clusterUuid, nodes } = data
+  return context.apiClient.qbert.attach(clusterUuid, nodes)
+}
+
 /*
  * The data model needed in the UI requires interwoven dependencies between
  * nodes, clusters, and namespaces.  Ideally the API would be more aligned

--- a/src/server/api/admin/index.js
+++ b/src/server/api/admin/index.js
@@ -1,0 +1,25 @@
+import express from 'express'
+import context from '../../context'
+
+const resetContext = (req, res) => {
+  console.log('---ADMIN--- resetContext')
+  context.resetContext()
+  res.sendStatus(200)
+}
+
+const loadPreset = (req, res) => {
+  const { preset } = req.params
+  console.log(`---ADMIN--- loadPreset (${preset})`)
+  context.resetContext()
+  const loaderPreset = require(`../../presets/${preset}.js`).default
+  loaderPreset && loaderPreset()
+  context.createSimUser()
+  res.sendStatus(200)
+}
+
+const router = express.Router()
+
+router.get('/reset-context', resetContext)
+router.get('/preset/:preset', loadPreset)
+
+export default router

--- a/src/server/api/qbert/clusters/attachOperations.js
+++ b/src/server/api/qbert/clusters/attachOperations.js
@@ -1,7 +1,7 @@
 import context from '../../../context'
 import Cluster from '../../../models/qbert/Cluster'
 import Node from '../../../models/qbert/Node'
-import Operations from '../../../models/qbert/Operations'
+import { attachNodeToCluster, detachNodeFromCluster } from '../../../models/qbert/Operations'
 
 export const attachNodes = (req, res) => {
   const { clusterId } = req.params
@@ -9,7 +9,7 @@ export const attachNodes = (req, res) => {
   const nodes = req.body
   for (const node of nodes) {
     const _node = Node.findById({id: node.uuid, context, raw: true})
-    Operations.attachNodeToCluster(_node, cluster)
+    attachNodeToCluster(_node, cluster)
   }
   res.status(200).send('ok')
 }
@@ -20,7 +20,7 @@ export const detachNodes = (req, res) => {
   const nodes = req.body
   for (const node of nodes) {
     const _node = Node.findById({id: node.uuid, context, raw: true})
-    Operations.detachNodeFromCluster(_node, cluster)
+    detachNodeFromCluster(_node, cluster)
   }
   res.status(200).send('ok')
 }

--- a/src/server/api/qbert/index.js
+++ b/src/server/api/qbert/index.js
@@ -37,28 +37,29 @@ import { tokenValidator } from '../../middleware'
 
 const router = express.Router()
 
-router.get('/v2/:tenantId/cloudProviders', tokenValidator, getCloudProviders)
-router.post('/v2/:tenantId/cloudProviders', tokenValidator, postCloudProvider)
-router.put('/v2/:tenantId/cloudProviders/:cloudProviderId', tokenValidator, putCloudProvider)
-router.delete('/v2/:tenantId/cloudProviders/:cloudProviderId', tokenValidator, deleteCloudProvider)
+const version = 'v3'
+router.get(`/${version}/:tenantId/cloudProviders`, tokenValidator, getCloudProviders)
+router.post(`/${version}/:tenantId/cloudProviders`, tokenValidator, postCloudProvider)
+router.put(`/${version}/:tenantId/cloudProviders/:cloudProviderId`, tokenValidator, putCloudProvider)
+router.delete(`/${version}/:tenantId/cloudProviders/:cloudProviderId`, tokenValidator, deleteCloudProvider)
 
-router.get('/v2/:tenantId/cloudProviders/types', tokenValidator, getCpTypes)
-router.get('/v2/:tenantId/cloudProviders/:cloudProviderId', tokenValidator, getCpDetails)
-router.get('/v2/:tenantId/cloudProviders/:cloudProviderId/region/:regionId', tokenValidator, getCpRegionDetails)
+router.get(`/${version}/:tenantId/cloudProviders/types`, tokenValidator, getCpTypes)
+router.get(`/${version}/:tenantId/cloudProviders/:cloudProviderId`, tokenValidator, getCpDetails)
+router.get(`/${version}/:tenantId/cloudProviders/:cloudProviderId/region/:regionId`, tokenValidator, getCpRegionDetails)
 
-router.get('/v2/:tenantId/nodes', tokenValidator, getNodes)
+router.get(`/${version}/:tenantId/nodes`, tokenValidator, getNodes)
 
-router.get('/v2/:tenantId/clusters', tokenValidator, getClusters)
-router.post('/v2/:tenantId/clusters', tokenValidator, postCluster)
-router.put('/v2/:tenantId/clusters/:clusterId', tokenValidator, putCluster)
-router.delete('/v2/:tenantId/clusters/:clusterId', tokenValidator, deleteCluster)
-router.get('/v2/:tenantId/clusters/:clusterId/k8sapi/version', tokenValidator, getClusterVersion)
+router.get(`/${version}/:tenantId/clusters`, tokenValidator, getClusters)
+router.post(`/${version}/:tenantId/clusters`, tokenValidator, postCluster)
+router.put(`/${version}/:tenantId/clusters/:clusterId`, tokenValidator, putCluster)
+router.delete(`/${version}/:tenantId/clusters/:clusterId`, tokenValidator, deleteCluster)
+router.get(`/${version}/:tenantId/clusters/:clusterId/k8sapi/version`, tokenValidator, getClusterVersion)
 
-router.post('/v3/:tenantId/clusters/:clusterId/attach', tokenValidator, attachNodes)
-router.post('/v3/:tenantId/clusters/:clusterId/detach', tokenValidator, detachNodes)
+router.post(`/${version}/:tenantId/clusters/:clusterId/attach`, tokenValidator, attachNodes)
+router.post(`/${version}/:tenantId/clusters/:clusterId/detach`, tokenValidator, detachNodes)
 
-const k8sapi = '/v2/:tenantId/clusters/:clusterId/k8sapi/api/v1'
-const k8sBetaApi = '/v2/:tenantId/clusters/:clusterId/k8sapi/apis/extensions/v1beta1'
+const k8sapi = `/${version}/:tenantId/clusters/:clusterId/k8sapi/api/v1`
+const k8sBetaApi = `/${version}/:tenantId/clusters/:clusterId/k8sapi/apis/extensions/v1beta1`
 
 router.get(`${k8sapi}/namespaces`, tokenValidator, getNamespaces)
 
@@ -76,7 +77,7 @@ router.get(`${k8sapi}/namespaces/:namespace/services`, tokenValidator, getServic
 router.post(`${k8sapi}/namespaces/:namespace/services`, tokenValidator, postService)
 router.delete(`${k8sapi}/namespaces/:namespace/services/:serviceName`, tokenValidator, deleteService)
 
-const storageClassApi = '/v2/:tenantId/clusters/:clusterId/k8sapi/apis/storage.k8s.io/v1/storageclasses'
+const storageClassApi = `/${version}/:tenantId/clusters/:clusterId/k8sapi/apis/storage.k8s.io/v1/storageclasses`
 
 router.get(`${storageClassApi}`, tokenValidator, getStorageClasses)
 router.post(`${storageClassApi}`, tokenValidator, postStorageClass)

--- a/src/server/context/simulator.js
+++ b/src/server/context/simulator.js
@@ -15,6 +15,8 @@ import Token from '../models/openstack/Token'
 import Application from '../models/openstack/Application'
 import SshKey from '../models/openstack/SshKey'
 
+const config = require('../../../config')
+
 const defaultQuota = {
   cores: 10,
   ram: 10000,
@@ -61,6 +63,17 @@ class Context {
     this.services = []
     this.storageClasses = []
     this.charts = []
+  }
+
+  createSimUser = () => {
+    if (config.simulator) {
+      const { username, password } = config.simulator
+      if (username && password) {
+        const user = new User({ name: username, password })
+        // construct a token with a hard-coded id to make testing easier
+        new Token({ user, id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' })
+      }
+    }
   }
 
   validateToken = id => Token.validateToken(id)

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -3,8 +3,6 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 const context = require('./context').default
 const server = require('./server')
 const config = require('../../config')
-const User = require('./models/openstack/User').default
-const Token = require('./models/openstack/Token').default
 
 server.startServer()
 context.resetContext()
@@ -15,13 +13,6 @@ if (simulator) {
   if (preset) {
     const loaderPreset = require(`./presets/${preset}.js`).default
     loaderPreset()
-  }
-
-  const { username, password } = simulator
-  if (username && password) {
-    const user = new User({ name: username, password })
-
-    // construct a token with a hard-coded id to make testing easier
-    new Token({ user, id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' })
+    context.createSimUser()
   }
 }

--- a/src/server/presets/dev.js
+++ b/src/server/presets/dev.js
@@ -122,10 +122,13 @@ function loadPreset () {
   // Cloud Providers
   CloudProvider.create({ data: { name: 'mockAwsProvider', type: 'aws' }, context })
   CloudProvider.create({ data: { name: 'mockOpenstackProvider', type: 'openstack' }, context })
+  CloudProvider.create({ data: { name: 'mockLocalProvider', type: 'local' }, context })
 
   // Clusters
   const cluster = Cluster.create({ data: { name: 'fakeCluster1', sshKey: 'someKey' }, context, raw: true })
   Cluster.create({ data: { name: 'fakeCluster2' }, context })
+  Cluster.create({ data: { name: 'mockAwsCluster', cloudProviderType: 'aws' }, context })
+  Cluster.create({ data: { name: 'mockOpenStackCluster', cloudProviderType: 'openstack' }, context })
 
   // Nodes
   // Nodes must be linked to a resMgrHost id or else the UI will break

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -16,6 +16,7 @@ import cinder from './api/cinder'
 import glance from './api/glance'
 import qbert from './api/qbert'
 import resmgr from './api/resmgr'
+import admin from './api/admin'
 
 const defaultConfig = {
   port: 4444,
@@ -48,6 +49,7 @@ export function startServer (config = defaultConfig) {
   app.use('/glance', glance)
   app.use('/qbert', qbert)
   app.use('/resmgr', resmgr)
+  app.use('/admin', admin)
   app.use(cors())
 
   console.log(`Simulator server currently listening on port ${config.port}`)


### PR DESCRIPTION
This adds support for attaching nodes to a cluster.

There are also some misc bug fixes.

There is now an `/admin` API in the simulator to allow the server state to be controlled through an API.  This is used in the Cypress tests to allow state to be configured during test runs.  This is especially important in watch mode.