### PR TITLE
Refactor external links into their own component

### DIFF
--- a/src/app/core/components/ExternalLink.js
+++ b/src/app/core/components/ExternalLink.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const ExternalLink = ({ url, children, newWindow }) => {
+  const moreProps = newWindow ? { target: '_blank', rel: 'noopener' } : {}
+  return (<a href={url} {...moreProps}>{children}</a>)
+}
+
+ExternalLink.propTypes = {
+  // This should be an external link that includes the http(s) and the FQDN.
+  url: PropTypes.string.isRequired,
+
+  // Should this link open a new window (default: true)
+  newWindow: PropTypes.bool,
+
+  // The link contents.  Usually just simple text but can be any node.
+  children: PropTypes.node.isRequired,
+}
+
+ExternalLink.defaultProps = {
+  newWindow: true,
+}
+
+export default ExternalLink

--- a/src/app/plugins/kubernetes/components/infrastructure/AddClusterPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/AddClusterPage.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Checkbox from 'core/components/validatedForm/Checkbox'
+import ExternalLink from 'core/components/ExternalLink'
 import FormWrapper from 'core/components/FormWrapper'
 import KeyValuesField from 'core/components/validatedForm/KeyValuesField'
 import NodesChooser from './NodesChooser'
@@ -119,7 +120,7 @@ class AddClusterPage extends React.Component {
         info={
           <span>
             Specify the virtual IP address that will be used to provide access to the API server endpoint for this cluster. Refer to
-            <a href="https://docs.platform9.com/support/ha-for-baremetal-multimaster-kubernetes-cluster-service-type-load-balancer/" target="_blank" rel="noopener">this article</a>
+            <ExternalLink url="https://docs.platform9.com/support/ha-for-baremetal-multimaster-kubernetes-cluster-service-type-load-balancer/">this article</ExternalLink>
             for more information re how the VIP service operates, VIP configuration, etc.
           </span>
         }

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import ExternalLink from 'core/components/ExternalLink'
 import { compose } from 'ramda'
 import { withAppContext } from 'core/AppContext'
 import { withDataLoader } from 'core/DataLoader'
@@ -78,7 +79,7 @@ class ClusterAttachNodeDialog extends React.Component {
           <p>
             <b>IMPORTANT</b>:
             Before adding nodes to a cluster, please ensure that you have followed the requirements
-            in <a href="https://platform9.com/support/managed-container-cloud-requirements-checklist/" target="_blank">this article</a> for
+            in <ExternalLink url="https://docs.platform9.com/getting-started/managed-container-cloud-requirements-checklist/">this article</ExternalLink> for
             each node.
           </p>
 

--- a/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import DownloadKubeConfigLink from './DownloadKubeConfigLink'
 import KubeCLI from './KubeCLI'
+import ExternalLink from 'core/components/ExternalLink'
 import SimpleLink from 'core/components/SimpleLink'
 import clusterUsageStats from './clusterUsageStats'
 import UsageBar from 'core/components/dashboardGraphs/UsageBar'
@@ -16,7 +17,7 @@ const renderLinks = links => {
   if (!links) { return null }
   return (
     <div>
-      {links.dashboard && <SimpleLink src={links.dashboard} target="_blank">Dashboard</SimpleLink>}
+      {links.dashboard && <ExternalLink url={links.dashboard}>Dashboard</ExternalLink>}
       {links.kubeconfig && <DownloadKubeConfigLink cluster={links.kubeconfig.cluster} />}
       {links.cli && <KubeCLI {...links.cli} />}
     </div>

--- a/src/app/plugins/kubernetes/components/infrastructure/NodesListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/NodesListPage.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { localizeRoles } from 'api-client/ResMgr'
 import { maybeFnOrNull } from 'app/utils/fp'
+import ExternalLink from 'core/components/ExternalLink'
 import HostStatus from 'core/components/HostStatus'
 import ProgressBar from 'core/components/ProgressBar'
-import SimpleLink from 'core/components/SimpleLink'
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import { pathOr, pipe } from 'ramda'
 import { castBoolToStr, castFuzzyBool, columnPathLookup } from 'utils/misc'
@@ -36,7 +36,7 @@ const renderStats = field => pipe(
   maybeFnOrNull(stat => <UsageBar stat={stat} />)
 )
 
-const renderLogs = url => <SimpleLink src={url} target="_blank">logs</SimpleLink>
+const renderLogs = url => <ExternalLink url={url}>logs</ExternalLink>
 
 const getSpotInstance = pipe(
   columnPathLookup('combined.resmgr.extensions.node_metadata.data.isSpotInstance'),


### PR DESCRIPTION
This adds some consistency to our external links.  It also makes it so that `rel="noopener"` and `target="_blank"` get applied consistently.

If we use this component it will be easier to find external links and change how we link to them in the future.