### PR TITLE
Added kubeconfig download link to clusters list

### DIFF
--- a/src/api-client/Keystone.js
+++ b/src/api-client/Keystone.js
@@ -140,6 +140,21 @@ class Keystone {
     }
   }
 
+  async renewScopedToken () {
+    const body = constructAuthBody('token', this.client.unscopedToken)
+    const projectId = this.client.activeProjectId
+    body.auth.scope = { project: { id: projectId } }
+    try {
+      const response = await axios.post(this.tokensUrl, body)
+      const scopedToken = response.headers['x-subject-token']
+      this.client.scopedToken = scopedToken
+      return scopedToken
+    } catch (err) {
+      // authentication failed
+      return null
+    }
+  }
+
   async getRegions () {
     const response = await axios.get(this.regionsUrl, this.client.getAuthHeaders())
     return response.data.regions

--- a/src/api-client/Keystone.js
+++ b/src/api-client/Keystone.js
@@ -151,6 +151,7 @@ class Keystone {
       return scopedToken
     } catch (err) {
       // authentication failed
+      console.error(err)
       return null
     }
   }

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -129,6 +129,10 @@ class Qbert {
     return response.token
   }
 
+  async getKubeConfig (clusterId) {
+    return this.client.basicGet(`${await this.baseUrl()}/kubeconfig/${clusterId}`)
+  }
+
   /* k8s API */
   async getKubernetesVersion (clusterId) {
     return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/version`)

--- a/src/app/core/components/SimpleLink.js
+++ b/src/app/core/components/SimpleLink.js
@@ -23,7 +23,7 @@ const SimpleLink = ({
       onClick(e)
     }
     // If there is no provided onClick, just use the `src` as a normal link.
-    if (!src.startsWith('http')) {
+    if (src && !src.startsWith('http')) {
       // local paths should use the History's push state
       e.preventDefault()
       return history.push(src)

--- a/src/server/api/qbert/index.js
+++ b/src/server/api/qbert/index.js
@@ -12,6 +12,8 @@ import getNodes from './nodes/getNodes'
 import { getClusters, postCluster, putCluster, deleteCluster } from './clusters/clusterActions'
 import getClusterVersion from './clusters/getClusterVersion'
 import { attachNodes, detachNodes } from './clusters/attachOperations'
+import getKubeConfig from './kubeConfig/getKubeConfig'
+
 // Namespaces
 import getNamespaces from './namespaces/getNamespaces'
 
@@ -56,6 +58,8 @@ router.get(`/${version}/:tenantId/clusters/:clusterId/k8sapi/version`, tokenVali
 
 router.post(`/${version}/:tenantId/clusters/:clusterId/attach`, tokenValidator, attachNodes)
 router.post(`/${version}/:tenantId/clusters/:clusterId/detach`, tokenValidator, detachNodes)
+
+router.get(`/${version}/:tenantId/kubeconfig/:clusterId`, tokenValidator, getKubeConfig)
 
 const k8sapi = `/${version}/:tenantId/clusters/:clusterId/k8sapi/api/v1`
 const k8sBetaApi = `/${version}/:tenantId/clusters/:clusterId/k8sapi/apis/extensions/v1beta1`

--- a/src/server/api/qbert/kubeConfig/getKubeConfig.js
+++ b/src/server/api/qbert/kubeConfig/getKubeConfig.js
@@ -1,0 +1,35 @@
+import context from '../../../context'
+import Cluster from '../../../models/qbert/Cluster'
+
+const getKubeConfig = (req, res) => {
+  const { clusterId } = req.params
+  const cluster = Cluster.findById({ id: clusterId, context })
+
+  if (!cluster) {
+    return res.status(404).send({code: 404, message: 'cluster not found'})
+  }
+
+  const yamlString = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURYRENDQWtTZ0F3SUJBZ0lKQUkwb1BLcmwwRUZZTUEwR0NTcUdTSWIzRFFFQkN3VUFNQ014SVRBZkJnTlYKQkFNTUdHdDFZbVZ5Ym1WMFpYTXRZMkZBTVRVek5EZzNOekV4TmpBZUZ3MHhPREE0TWpFeE9EUTFNVGRhRncweQpPREE0TVRneE9EUTFNVGRhTUNNeElUQWZCZ05WQkFNTUdHdDFZbVZ5Ym1WMFpYTXRZMkZBTVRVek5EZzNOekV4Ck5qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU1FaU8wU1Z1cHY4OE5maGlOQ3QKY2lNdFR6empiWWlLYUppYUNUbE9Gb3d2ODdnQUJ3ekRaOTNRYUlsNzFacHpoOWk5TkxPaDdjbmNBK3Z6VHlPawpVanlOZDJYMWNWNGFuRFo1WkU1bGZGYU9ZRUxXeVovVSsrbk00N3Zicjk3MmdIMVI2TENRVmQyTC9kTkdxeU9wCk1pNWt4TkxKWTlRa3EzUlVVdy9objVlRW1RQTZPQ2J3ZVVEVFBzMks5TnU3dTM0YTJaMWc2WkFrQWNra1NKd2EKUjZOWVdMZzRHSUxnRVhGekNxYzFNRDloSGxTaDg1TDRlUlhZeGZUZ3czdXdpa0lVdFVycmNHVEpGWHEvdlpGVgpBVzFneUFQN01vYm1tOFZpY2gwb2NHa2MxYjA0WllRMnhyb1JOZ3NINnViSno2SUxNOHhOYzNKcitGVGx6K2ZICm84VUNBd0VBQWFPQmtqQ0JqekFkQmdOVkhRNEVGZ1FVM2RFU25NcUo2QXdTZTIvdWpVK2d2SXlRNzZZd1V3WUQKVlIwakJFd3dTb0FVM2RFU25NcUo2QXdTZTIvdWpVK2d2SXlRNzZhaEo2UWxNQ014SVRBZkJnTlZCQU1NR0d0MQpZbVZ5Ym1WMFpYTXRZMkZBTVRVek5EZzNOekV4Tm9JSkFJMG9QS3JsMEVGWU1Bd0dBMVVkRXdRRk1BTUJBZjh3CkN3WURWUjBQQkFRREFnRUdNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUNERVpBcEZISjNkYmQvZ0w2VXlFUVAKclZPelBpT0xBbG9vTVE1YXFCYW1NcjBwYU9zQmdNSnBIcjNzT0xrRXJLckZEVUVjK2JISXErR2tHMkYxQlNwTAozanJ6VC9EVUhSTGZMNnJwK3hQbnZ6dTI3QVRIN3pkZ1dsZFVDem9ZdDNHUzhVSFRNUTUvQXZHUXZZOUswTEIzCmFiWE16SHpDZE5lVkVGTXZtUUdGaHFuK0xyYmxWM0FhY0VrSUtEa3pEeGcyczZieW5KYTFFWVh0b1lBZDFwRncKYVl3NnRtQ2pWanMwZVM0ODAyaUpQMk9FRXd1cnZ0ZkRxS21QR3J4cmtUb0s2STVyWkJtQzRpcGtncUVDU2FCbQpURDJDM29hZjB1KzFwRmoyZDk1UVFvZmdkYlVDNWR3d2RZZUtBU1BISFF6Wlp5SDNYaEVxTGp1MkR1MXVLM2tsCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    server: https://10.105.16.26
+  name: ${cluster.name}
+contexts:
+- context:
+    cluster: ${cluster.name}
+    namespace: default
+    user: user@platform9.net
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: user@platform9.net
+  user:
+    token: __INSERT_BEARER_TOKEN_HERE__`
+
+  return res.status(200).send(yamlString)
+}
+
+export default getKubeConfig

--- a/src/server/api/qbert/kubeConfig/getKubeConfig.js
+++ b/src/server/api/qbert/kubeConfig/getKubeConfig.js
@@ -1,5 +1,46 @@
 import context from '../../../context'
 import Cluster from '../../../models/qbert/Cluster'
+import faker from 'faker'
+import yaml from 'js-yaml'
+
+const randomKubeConfig = (cluster) => {
+  const configObject = {
+    apiVersion: 'v1',
+    clusters: [
+      {
+        cluster: {
+          'certificate-authority-data': faker.random.uuid(),
+          server: `https://${faker.internet.ip()}`
+        },
+        name: cluster.name
+      }
+    ],
+    contexts: [
+      {
+        context: {
+          cluster: cluster.name,
+          namespace: 'default',
+          user: 'user@platform9.net'
+        },
+        name: 'default'
+      }
+    ],
+    'current-context': 'default',
+    kind: 'Config',
+    preferences: {},
+    users: [
+      {
+        name: 'user@platform9.net',
+        user: {
+          token: '__INSERT_BEARER_TOKEN_HERE__'
+        }
+      }
+    ]
+  }
+
+  const configYaml = yaml.safeDump(configObject)
+  return configYaml
+}
 
 const getKubeConfig = (req, res) => {
   const { clusterId } = req.params
@@ -9,26 +50,7 @@ const getKubeConfig = (req, res) => {
     return res.status(404).send({code: 404, message: 'cluster not found'})
   }
 
-  const yamlString = `apiVersion: v1
-clusters:
-- cluster:
-    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURYRENDQWtTZ0F3SUJBZ0lKQUkwb1BLcmwwRUZZTUEwR0NTcUdTSWIzRFFFQkN3VUFNQ014SVRBZkJnTlYKQkFNTUdHdDFZbVZ5Ym1WMFpYTXRZMkZBTVRVek5EZzNOekV4TmpBZUZ3MHhPREE0TWpFeE9EUTFNVGRhRncweQpPREE0TVRneE9EUTFNVGRhTUNNeElUQWZCZ05WQkFNTUdHdDFZbVZ5Ym1WMFpYTXRZMkZBTVRVek5EZzNOekV4Ck5qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQU1FaU8wU1Z1cHY4OE5maGlOQ3QKY2lNdFR6empiWWlLYUppYUNUbE9Gb3d2ODdnQUJ3ekRaOTNRYUlsNzFacHpoOWk5TkxPaDdjbmNBK3Z6VHlPawpVanlOZDJYMWNWNGFuRFo1WkU1bGZGYU9ZRUxXeVovVSsrbk00N3Zicjk3MmdIMVI2TENRVmQyTC9kTkdxeU9wCk1pNWt4TkxKWTlRa3EzUlVVdy9objVlRW1RQTZPQ2J3ZVVEVFBzMks5TnU3dTM0YTJaMWc2WkFrQWNra1NKd2EKUjZOWVdMZzRHSUxnRVhGekNxYzFNRDloSGxTaDg1TDRlUlhZeGZUZ3czdXdpa0lVdFVycmNHVEpGWHEvdlpGVgpBVzFneUFQN01vYm1tOFZpY2gwb2NHa2MxYjA0WllRMnhyb1JOZ3NINnViSno2SUxNOHhOYzNKcitGVGx6K2ZICm84VUNBd0VBQWFPQmtqQ0JqekFkQmdOVkhRNEVGZ1FVM2RFU25NcUo2QXdTZTIvdWpVK2d2SXlRNzZZd1V3WUQKVlIwakJFd3dTb0FVM2RFU25NcUo2QXdTZTIvdWpVK2d2SXlRNzZhaEo2UWxNQ014SVRBZkJnTlZCQU1NR0d0MQpZbVZ5Ym1WMFpYTXRZMkZBTVRVek5EZzNOekV4Tm9JSkFJMG9QS3JsMEVGWU1Bd0dBMVVkRXdRRk1BTUJBZjh3CkN3WURWUjBQQkFRREFnRUdNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUNERVpBcEZISjNkYmQvZ0w2VXlFUVAKclZPelBpT0xBbG9vTVE1YXFCYW1NcjBwYU9zQmdNSnBIcjNzT0xrRXJLckZEVUVjK2JISXErR2tHMkYxQlNwTAozanJ6VC9EVUhSTGZMNnJwK3hQbnZ6dTI3QVRIN3pkZ1dsZFVDem9ZdDNHUzhVSFRNUTUvQXZHUXZZOUswTEIzCmFiWE16SHpDZE5lVkVGTXZtUUdGaHFuK0xyYmxWM0FhY0VrSUtEa3pEeGcyczZieW5KYTFFWVh0b1lBZDFwRncKYVl3NnRtQ2pWanMwZVM0ODAyaUpQMk9FRXd1cnZ0ZkRxS21QR3J4cmtUb0s2STVyWkJtQzRpcGtncUVDU2FCbQpURDJDM29hZjB1KzFwRmoyZDk1UVFvZmdkYlVDNWR3d2RZZUtBU1BISFF6Wlp5SDNYaEVxTGp1MkR1MXVLM2tsCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
-    server: https://10.105.16.26
-  name: ${cluster.name}
-contexts:
-- context:
-    cluster: ${cluster.name}
-    namespace: default
-    user: user@platform9.net
-  name: default
-current-context: default
-kind: Config
-preferences: {}
-users:
-- name: user@platform9.net
-  user:
-    token: __INSERT_BEARER_TOKEN_HERE__`
-
+  const yamlString = randomKubeConfig(cluster)
   return res.status(200).send(yamlString)
 }
 


### PR DESCRIPTION
Had a few points I wanted to run by you guys:

1. We need some way to tell users that the kubeconfig will only work for 24 hours. Ideally this should go through a designer.
2. Wasn't sure if it'd be worth it to create a util function for creating a download. Currently this is our only use for this kind of functionality, although I could certainly see nice-to-have features that could use it (like a csv download of a list table for example)