### PR TITLE
Do not require setActiveRegion during initialization

### DIFF
--- a/src/api-client/Keystone.js
+++ b/src/api-client/Keystone.js
@@ -183,6 +183,10 @@ class Keystone {
       await this.getServiceCatalog()
     }
     const servicesByRegion = groupByRegion(this.client.serviceCatalog)
+    if (!this.client.activeRegion) {
+      // Just assume the first region we come across if there isn't one set.
+      this.client.activeRegion = this.client.serviceCatalog[0].endpoints[0].region
+    }
     return servicesByRegion[this.client.activeRegion]
   }
 

--- a/src/api-client/Keystone.js
+++ b/src/api-client/Keystone.js
@@ -179,9 +179,6 @@ class Keystone {
   }
 
   async getServicesForActiveRegion () {
-    if (!this.client.activeRegion) {
-      throw new Error('Must first select a region before getting services for that region')
-    }
     if (!this.client.serviceCatalog) {
       await this.getServiceCatalog()
     }


### PR DESCRIPTION
This error message was added because it can be useful during development but is preventing the app from initializing correctly in production environments where the initial region is not explicitly specified.  Looks like we can just eliminate this requirement completely and default to the keystone endpoint which has `/` instead of the FQDN by default.