### PR TITLE
Redirect navItems to the old UI

### DIFF
--- a/src/app/core/utils/pluginManager.js
+++ b/src/app/core/utils/pluginManager.js
@@ -20,7 +20,7 @@ const parseNavItem = basePath => navItem => ({
   ...navItem,
   link: {
     ...navItem.link,
-    path: pathJoin(basePath, navItem.link.path)
+    path: navItem.link.external ? navItem.link.path : pathJoin(basePath, navItem.link.path)
   },
   nestedLinks: navItem.nestedLinks
     ? navItem.nestedLinks.map(parseNavItem(basePath))

--- a/src/app/plugins/kubernetes/index.js
+++ b/src/app/plugins/kubernetes/index.js
@@ -117,50 +117,103 @@ Kubernetes.registerPlugin = pluginManager => {
     ]
   )
 
-  plugin.registerNavItems(
-    [
-      {
-        name: 'Infrastructure',
-        link: { path: '/infrastructure' },
-        nestedLinks: [
-          { name: 'Clusters', link: { path: '/infrastructure#clusters' } },
-          { name: 'Nodes', link: { path: '/infrastructure#nodes' } },
-          { name: 'Cloud Providers', link: { path: '/infrastructure#cloudProviders' } },
-        ]
-      },
-      {
-        name: 'App Catalog',
-        link: { path: '/apps' },
-        nestedLinks: [
-          { name: 'App Catalog', link: { path: '/apps#appCatalog' } },
-          { name: 'Deployed Apps', link: { path: '/apps#deployedApps' } },
-          { name: 'Repositories', link: { path: '/apps#repositories' } },
-        ]
-      },
-      {
-        name: 'Pods, Deployments, Services',
-        link: { path: '/pods' },
-        nestedLinks: [
-          { name: 'Pods', link: { path: '/pods#pods' } },
-          { name: 'Deployments', link: { path: '/pods#deployments' } },
-          { name: 'Services', link: { path: '/pods#services' } },
-        ]
-      },
-      { name: 'Storage Classes', link: { path: '/storage_classes' } },
-      { name: 'Namespaces', link: { path: '/namespaces' } },
-      { name: 'API Access', link: { path: '/api_access' } },
-      {
-        name: 'Tenants & Users',
-        link: { path: '/user_management' },
-        nestedLinks: [
-          { name: 'Tenants', link: { path: '/user_management#tenants' } },
-          { name: 'Users', link: { path: '/user_management#users' } },
-          { name: 'Groups', link: { path: '/user_management#userGroups' } },
-          { name: 'Roles', link: { path: '/user_management#roles' } },
-        ]
-      },
-    ]
-  )
+  const hostPrefix = '' // set to another host during development
+  const clarityBase = path => `${hostPrefix}/clarity/index.html#${path}`
+  const clarityLink = path => ({ link: { path: clarityBase(path), external: true } })
+
+  // For development we can set this manually
+  const useClarityLinks = Boolean(!window.localStorage.disableClarityLinks)
+
+  // These nav items will redirect to the old "clarity" UI while the new UI is under development.
+  const clarityNavItems = [
+    {
+      name: 'Infrastructure',
+      ...clarityLink('/infrastructureK8s'),
+      nestedLinks: [
+        { name: 'Clusters', ...clarityLink('/infrastructureK8s#clusters') },
+        { name: 'Nodes', ...clarityLink('/infrastructureK8s#nodes') },
+        { name: 'Cloud Providers', ...clarityLink('/infrastructureK8s#cps') },
+      ]
+    },
+    {
+      name: 'App Catalog',
+      ...clarityLink('/kubernetes/apps'),
+      nestedLinks: [
+        { name: 'App Catalog', ...clarityLink('/kubernetes/apps#catalog') },
+        { name: 'Deployed Apps', ...clarityLink('/kubernetes/apps#deployed_apps') },
+        { name: 'Repositories', ...clarityLink('/kubernetes/apps#repositories') },
+      ]
+    },
+    {
+      name: 'Pods, Deployments, Services',
+      ...clarityLink('/podsK8s'),
+      nestedLinks: [
+        { name: 'Pods', ...clarityLink('/podsK8s#pods') },
+        { name: 'Deployments', ...clarityLink('/podsK8s#deployments') },
+        { name: 'Services', ...clarityLink('/podsK8s#services') },
+      ]
+    },
+    { name: 'Storage Classes', ...clarityLink('/kubernetes/storage_classes') },
+    { name: 'Namespaces', ...clarityLink('/kubernetes/namespaces') },
+    { name: 'API Access', ...clarityLink('/kubernetes/api_access') },
+    {
+      name: 'Tenants & Users',
+      ...clarityLink('/kubernetes/users'),
+      nestedLinks: [
+        { name: 'Tenants', ...clarityLink('/kubernetes/users#tenants') },
+        { name: 'Users', ...clarityLink('/kubernetes/users#users') },
+        { name: 'Groups', ...clarityLink('/kubernetes/users#groups') },
+        { name: 'Roles', ...clarityLink('/kubernetes/users#roles') },
+      ]
+    },
+  ]
+
+  // These nav items are in active development but not shown in production.
+  const devNavItems = [
+    {
+      name: 'Infrastructure',
+      link: { path: '/infrastructure' },
+      nestedLinks: [
+        { name: 'Clusters', link: { path: '/infrastructure#clusters' } },
+        { name: 'Nodes', link: { path: '/infrastructure#nodes' } },
+        { name: 'Cloud Providers', link: { path: '/infrastructure#cloudProviders' } },
+      ]
+    },
+    {
+      name: 'App Catalog',
+      link: { path: '/apps' },
+      nestedLinks: [
+        { name: 'App Catalog', link: { path: '/apps#appCatalog' } },
+        { name: 'Deployed Apps', link: { path: '/apps#deployedApps' } },
+        { name: 'Repositories', link: { path: '/apps#repositories' } },
+      ]
+    },
+    {
+      name: 'Pods, Deployments, Services',
+      link: { path: '/pods' },
+      nestedLinks: [
+        { name: 'Pods', link: { path: '/pods#pods' } },
+        { name: 'Deployments', link: { path: '/pods#deployments' } },
+        { name: 'Services', link: { path: '/pods#services' } },
+      ]
+    },
+    { name: 'Storage Classes', link: { path: '/storage_classes' } },
+    { name: 'Namespaces', link: { path: '/namespaces' } },
+    { name: 'API Access', link: { path: '/api_access' } },
+    {
+      name: 'Tenants & Users',
+      link: { path: '/user_management' },
+      nestedLinks: [
+        { name: 'Tenants', link: { path: '/user_management#tenants' } },
+        { name: 'Users', link: { path: '/user_management#users' } },
+        { name: 'Groups', link: { path: '/user_management#userGroups' } },
+        { name: 'Roles', link: { path: '/user_management#roles' } },
+      ]
+    },
+  ]
+
+  const links = useClarityLinks ? clarityNavItems : devNavItems
+  plugin.registerNavItems(links)
 }
 
 export default Kubernetes

--- a/src/app/utils/__tests__/fp.test.js
+++ b/src/app/utils/__tests__/fp.test.js
@@ -5,6 +5,7 @@ import {
   filterFields,
   identity,
   mergeKey,
+  notEmpty,
   pick,
   pickMultiple,
   pipe,
@@ -107,5 +108,22 @@ describe('functional programming utils', () => {
     )
     const result2 = arr.map(fn2)
     expect(result2).toEqual(['unknown', 'three', 'five', 'seven', 'seven', 'three'])
+  })
+
+  it('notEmpty', () => {
+    expect(notEmpty(null)).toEqual(false)
+    expect(notEmpty(undefined)).toEqual(false)
+    expect(notEmpty(0)).toEqual(false)
+    expect(notEmpty(false)).toEqual(false)
+    expect(notEmpty(123)).toEqual(false)
+    expect(notEmpty(true)).toEqual(false)
+    expect(notEmpty(() => {})).toEqual(false)
+    expect(notEmpty([])).toEqual(false)
+    expect(notEmpty('')).toEqual(false)
+
+    expect(notEmpty('blah')).toEqual(true)
+    expect(notEmpty([123])).toEqual(true)
+    expect(notEmpty([null])).toEqual(true)
+    expect(notEmpty([undefined])).toEqual(true)
   })
 })

--- a/src/app/utils/fp.js
+++ b/src/app/utils/fp.js
@@ -9,6 +9,9 @@ export const isTruthy = x => !!x
 export const exists = x => x !== undefined
 export const propExists = curry((key, obj) => obj[key] !== undefined)
 
+// Works for arrays and strings.  All other types return false.
+export const notEmpty = arr => !!(arr && arr.length)
+
 export const pluckAsync = key => promise => promise.then(obj => obj[key])
 
 export const compose = (...fns) =>


### PR DESCRIPTION
This redirects the current nav item links to the old clarity UI.

During development we can `window.localStorage.disableClarityLinks = true`.

This only works when clicking on nav links.  It does not redirect to Clarity on initial page loads.  We probably don't need to worry about this since it is going to be rare for people to bookmark pages on the new UI before it is fully ported.