### PR TITLE
Hide the developer plugin by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ Mocha and Selenium for these tests.
 A server must be provisioned before each one of these tests. These tests are
 very expensive to run (several hours) and designed to be run occasionally.
 
+## Special Flags
+
+To enable the develeper plugin use:
+
+`window.localStorage.setItem('enableDevPlugin', true)`
+
+To enable the left sidebar nav links to point to the development version use:
+
+`window.localStorage.disableClarityLinks = true`
+
 ## Docker
 
 As of right now, the Docker image is a UI development demo.  It runs with the

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -69,6 +69,7 @@ class App extends React.Component {
   render () {
     const { pluginManager } = this.props
     const plugins = toPairs(pluginManager.getPlugins())
+    const devEnabled = window.localStorage.enableDevPlugin === 'true'
     return (
       <Router>
         <MuiThemeProvider theme={theme}>
@@ -85,7 +86,7 @@ class App extends React.Component {
                           links: plugin.getNavItems()
                         }))}>
                         {plugins.map(apply(this.renderPluginRoutes))}
-                        <DeveloperToolsEmbed />
+                        {devEnabled && <DeveloperToolsEmbed />}
                       </AppContainer>
                     </SessionManager>
                   </div>

--- a/src/app/plugins/index.js
+++ b/src/app/plugins/index.js
@@ -2,10 +2,12 @@ import openstack from './openstack'
 import kubernetes from './kubernetes'
 import developer from './developer'
 
+const devEnabled = window.localStorage.enableDevPlugin === 'true'
+
 const plugins = [
   openstack,
   kubernetes,
-  developer,
+  ...(devEnabled ? [developer] : []),
 ]
 
 export default plugins


### PR DESCRIPTION
Turn it on for development using:

`window.localStorage.setItem('enableDevPlugin', true)`