### PR TITLE
Monitoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4534,7 +4534,7 @@
         "anymatch": "2.0.0",
         "async-each": "1.0.1",
         "braces": "2.3.2",
-        "fsevents": "1.2.4",
+        "fsevents": "1.2.7",
         "glob-parent": "3.1.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -8212,550 +8212,416 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "dev": true,
-      "optional": true,
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
       "requires": {
-        "nan": "2.12.1",
-        "node-pre-gyp": "0.10.0"
+        "nan": "2.13.2",
+        "node-pre-gyp": "0.10.3"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "version": "1.1.1",
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "version": "0.6.0",
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.5"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.5"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.2.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.24",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.10.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.4",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.2.0",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.6.3",
+            "semver": "5.6.0",
+            "tar": "4.4.8"
           }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "version": "1.0.5",
+          "bundled": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.2.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.5"
           }
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "version": "5.1.2",
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "version": "5.6.0",
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.1.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.5",
+            "minizlib": "1.2.1",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "version": "3.0.3",
+          "bundled": true
         }
       }
     },
@@ -12502,11 +12368,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
-      "dev": true,
-      "optional": true
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -16692,7 +16556,7 @@
         "capture-exit": "1.2.0",
         "exec-sh": "0.2.2",
         "fb-watchman": "2.0.0",
-        "fsevents": "1.2.4",
+        "fsevents": "1.2.7",
         "micromatch": "3.1.10",
         "minimist": "1.2.0",
         "walker": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "codemirror": "^5.42.2",
     "concurrently": "^3.6.0",
     "cors": "^2.8.4",
+    "fsevents": "^1.2.7",
     "history": "^4.7.2",
     "isomorphic-fetch": "^2.2.1",
     "js-yaml": "^3.12.1",

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -316,6 +316,19 @@ class Qbert {
   async deleteRepositoriesForCluster (clusterId, repoId) {
     return this.client.basicDelete(`${await this.clusterMonocularBaseUrl(clusterId)}/repos/${repoId}`)
   }
+
+  /* Managed Apps */
+  async getPrometheusInstances (clusterId) {
+    return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/prometheuses`)
+  }
+
+  async getPrometheusServiceMonitors (clusterId) {
+    return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/servicemonitors`)
+  }
+
+  async getPrometheusRules (clusterId) {
+    return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/prometheusrules`)
+  }
 }
 
 export default Qbert

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -324,7 +324,7 @@ class Qbert {
   }
 
   /* Managed Apps */
-  async getPrometheusInstances (clusterId, namespace) {
+  async getPrometheusInstances (clusterId) {
     return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/prometheuses`)
   }
 
@@ -376,7 +376,7 @@ class Qbert {
       },
       spec: {
         endpoints: [
-          { port: data.port }, // TODO: we don't have this data from the UI yet
+          { port: data.port },
         ],
         selector: { matchLabels: appLabels },
       },

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -377,13 +377,32 @@ class Qbert {
     }
 
     let alertManagerBody = {
+      // TODO: what goes in here
+    }
+
+    let prometheusRulesBody = {
+      metadata: {
+        labels: { /* what goes here */ },
+        name: `${data.name}-prometheus-rules`,
+        namespace: data.namespace,
+      },
+      spec: {
+        groups: [
+          {
+            name: '', // TODO: name of group?
+            rules: data.rules,
+          }
+        ]
+      }
     }
 
     console.log('prometheusInstanceBody', body)
     console.log('serviceMonitorBody', serviceMonitorBody)
     console.log('alertMonitorBody', alertManagerBody)
+    console.log('prometheusRulesBody', prometheusRulesBody)
     // return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/prometheuses`, body)
     // return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/servicemonitors`, serviceMonitorBody)
+    // return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/prometheusrules`, prometheusRulesBody)
   }
 
   async getPrometheusServiceMonitors (clusterId) {

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -327,11 +327,12 @@ class Qbert {
   async createPrometheusInstance (clusterId, data) {
     const requests = {}
     if (data.cpu) { requests.cpu = `${data.cpu}m` }
-    if (data.memory) { requests.cpu = `${data.memory}Gi` }
-    if (data.storage) { requests.cpu = `${data.storage}Gi` }
+    if (data.memory) { requests.memory = `${data.memory}Mi` }
+    if (data.storage) { requests.storage = `${data.storage}Gi` }
 
     let metadata = {
       name: data.name,
+      namespace: data.namespace,
 
       // TODO: Do we want to scope this to a namespace?  We don't have a field for that in the mockup.
       // Another alternative is that we use the value from a namespace chooser.  But that probably means making
@@ -340,7 +341,7 @@ class Qbert {
 
     let spec = {
       replicas: data.numInstances,
-      retention: data.retention,
+      retention: `${data.retention}d`,
       resources: { requests },
     }
 
@@ -358,7 +359,31 @@ class Qbert {
 
     console.log('apiClient.qbert#createPrometheusInstance')
     console.log('body', body)
+
+    // TODO: We need to get the prometheus port name/number in the UI
+
+    let serviceMonitorBody = {
+      metadata: {
+        name: `${data.name}-service-monitor`,
+        namespace: data.namespace,
+        labels: serviceMonitor,
+      },
+      spec: {
+        endpoints: [
+          { port: data.port }, // TODO: we don't have this data from the UI yet
+        ],
+        selector: { matchLabels: serviceMonitor },
+      },
+    }
+
+    let alertManagerBody = {
+    }
+
+    console.log('prometheusInstanceBody', body)
+    console.log('serviceMonitorBody', serviceMonitorBody)
+    console.log('alertMonitorBody', alertManagerBody)
     // return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/prometheuses`, body)
+    // return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/servicemonitors`, serviceMonitorBody)
   }
 
   async getPrometheusServiceMonitors (clusterId) {

--- a/src/app/core/components/Picklist.js
+++ b/src/app/core/components/Picklist.js
@@ -54,7 +54,6 @@ class Picklist extends React.Component {
           variant={filled ? 'filled' : 'standard'}
           label={label}
           value={nonEmptyValue}
-          displayEmpty
           onChange={this.handleChange}
           inputProps={{ name: label, id: name }}
         >

--- a/src/app/core/components/validatedForm/KeyValuesField.js
+++ b/src/app/core/components/validatedForm/KeyValuesField.js
@@ -1,15 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { withInfoTooltip } from 'app/core/components/InfoTooltip'
+import { Typography } from '@material-ui/core'
 import { compose } from 'app/utils/fp'
 import KeyValues from 'core/components/KeyValues'
 import withFormContext, { ValidatedFormInputPropTypes } from 'core/components/validatedForm/withFormContext'
 
 class KeyValuesField extends React.Component {
   render () {
-    const { id, value, ...restProps } = this.props
+    const { id, value, label, ...restProps } = this.props
     return (
       <div id={id}>
+        <Typography variant="subtitle1">{label}</Typography>
         <KeyValues
           {...restProps}
           entries={value !== undefined ? value : []}

--- a/src/app/core/components/validatedForm/PicklistField.js
+++ b/src/app/core/components/validatedForm/PicklistField.js
@@ -60,6 +60,7 @@ PicklistField.propTypes = {
   label: PropTypes.string,
   options: PropTypes.arrayOf(optionPropType).isRequired,
   initialValue: PropTypes.string,
+  onChange: PropTypes.func,
 
   /** Create an option of 'None' as the first default choice */
   showNone: PropTypes.bool,

--- a/src/app/core/components/validatedForm/ValidatedForm.js
+++ b/src/app/core/components/validatedForm/ValidatedForm.js
@@ -136,7 +136,7 @@ class ValidatedForm extends React.Component {
   }
 
   handleSubmit = event => {
-    const { onSubmit } = this.props
+    const { clearOnSubmit, onSubmit } = this.props
     const { values, showingErrors } = this.state
     if (event) {
       event.preventDefault()
@@ -151,6 +151,10 @@ class ValidatedForm extends React.Component {
 
     if (onSubmit) {
       onSubmit(values)
+    }
+
+    if (clearOnSubmit) {
+      this.setState({ values: {} })
     }
   }
 
@@ -167,6 +171,12 @@ class ValidatedForm extends React.Component {
 }
 
 ValidatedForm.propTypes = {
+  // When the form is successfully submitted, clear the form.
+  // A common use case for this will be when we want to have the form stay on
+  // the screen but each time the user makes a submit we add an item to an array
+  // and allow them to add another.
+  clearOnSubmit: PropTypes.bool,
+
   // Initial values
   initialValues: PropTypes.object,
 
@@ -176,6 +186,10 @@ ValidatedForm.propTypes = {
   triggerSubmit: PropTypes.func,
 
   showErrorsOnBlur: PropTypes.bool,
+}
+
+ValidatedForm.defaultProps = {
+  clearOnSubmit: false,
 }
 
 export default ValidatedForm

--- a/src/app/core/components/validatedForm/ValidatedForm.js
+++ b/src/app/core/components/validatedForm/ValidatedForm.js
@@ -137,7 +137,7 @@ class ValidatedForm extends React.Component {
 
   handleSubmit = event => {
     const { clearOnSubmit, onSubmit } = this.props
-    const { values, showingErrors } = this.state
+    const { initialValues, values, showingErrors } = this.state
     if (event) {
       event.preventDefault()
     }
@@ -154,7 +154,7 @@ class ValidatedForm extends React.Component {
     }
 
     if (clearOnSubmit) {
-      this.setState({ values: {} })
+      this.setState({ values: initialValues })
     }
   }
 

--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -84,7 +84,7 @@ class AddPrometheusInstancePage extends React.Component {
                       options={clusterOptions}
                       onChange={this.handleClusterChange}
                       label="Cluster"
-                      info="Clusters available with RoleBing from admin delegation"
+                      info="Clusters available with RoleBinding from admin delegation"
                     />
 
                     {namespaceOptions.length > 0 &&

--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -8,6 +8,7 @@ import ValidatedForm from 'core/components/validatedForm/ValidatedForm'
 import Wizard from 'core/components/Wizard'
 import WizardStep from 'core/components/WizardStep'
 import { compose } from 'ramda'
+import { createPrometheusInstance } from './actions'
 import { loadInfrastructure } from '../infrastructure/actions'
 import { projectAs } from 'utils/fp'
 import { withAppContext } from 'core/AppContext'
@@ -22,7 +23,10 @@ const initialContext = {
 }
 
 class AddPrometheusInstancePage extends React.Component {
-  handleSubmit = () => console.log('TODO: AddPrometheusInstancePage#handleSubmit')
+  handleSubmit = data => {
+    const { context, setContext } = this.props
+    createPrometheusInstance({ data, context, setContext })
+  }
 
   render () {
     const clusters = this.props.data
@@ -37,10 +41,10 @@ class AddPrometheusInstancePage extends React.Component {
                   <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
                     <TextField id="name" label="Name" info="Name of the Prometheus instance" />
                     <TextField id="numInstances" label="# of instances" info="Number of Prometheus instances" type="number" />
+                    <TextField id="cpu" label="CPU" info="Expressed in 'm' (1m = 1/1000th of a core)" type="number" />
                     <TextField id="memory" label="Memory" info="GiB of memory to allocate" type="number" />
-                    <TextField id="cpu" label="CPU" info="# of CPUs to allocate" type="number" />
-                    <PicklistField id="cluster" options={clusterOptions} label="Cluster" info="Clusters available with RoleBing from admin delegation" />
                     <TextField id="storage" label="Storage" info="The storage allocation.  Default is 8 GiB" type="number" />
+                    <PicklistField id="cluster" options={clusterOptions} label="Cluster" info="Clusters available with RoleBing from admin delegation" />
                     <Checkbox id="enablePersistentStorage" label="Enable persistent storage" />
                     <TextField id="retention" label="Storage Retention (days)" info="Defaults to 15 days if nothing is set" type="number" />
                     <KeyValuesField id="serviceMonitor" label="Service Monitor" info="Key/value pairs for service monitor that Prometheus will use" />

--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -23,6 +23,7 @@ const initialContext = {
   cpu: 500,
   storage: 8,
   retention: 15,
+  port: 'prometheus',
 }
 
 class AddPrometheusInstancePage extends React.Component {
@@ -33,11 +34,11 @@ class AddPrometheusInstancePage extends React.Component {
 
   handleSubmit = data => {
     const { context, setContext } = this.props
+    data.rules = this.state.rules
     createPrometheusInstance({ data, context, setContext })
   }
 
   handleAddRule = rule => {
-    console.log('handleAddRule', rule)
     const withId = { id: uuid.v4(), ...rule }
     this.setState({ rules: [...this.state.rules, withId] })
   }
@@ -73,6 +74,7 @@ class AddPrometheusInstancePage extends React.Component {
                     {namespaceOptions.length > 0 && <PicklistField id="namespace" options={namespaceOptions} label="Namespace" info="Which namespace to use" />}
                     {enableStorage && <CheckboxField id="enablePersistentStorage" label="Enable persistent storage" />}
                     <TextField id="retention" label="Storage Retention (days)" info="Defaults to 15 days if nothing is set" type="number" />
+                    <TextField id="port" label="Service Monitor Port" info="Port for the service monitor" />
                     <KeyValuesField id="serviceMonitor" label="Service Monitor" info="Key/value pairs for service monitor that Prometheus will use" />
                   </ValidatedForm>
                 </WizardStep>

--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Checkbox from 'core/components/validatedForm/Checkbox'
+import CheckboxField from 'core/components/validatedForm/CheckboxField'
 import FormWrapper from 'core/components/FormWrapper'
 import KeyValuesField from 'core/components/validatedForm/KeyValuesField'
 import PicklistField from 'core/components/validatedForm/PicklistField'
@@ -71,7 +71,7 @@ class AddPrometheusInstancePage extends React.Component {
                     <TextField id="storage" label="Storage" info="The storage allocation.  Default is 8 GiB" type="number" />
                     <PicklistField id="cluster" options={clusterOptions} onChange={this.handleClusterChange} label="Cluster" info="Clusters available with RoleBing from admin delegation" />
                     {namespaceOptions.length > 0 && <PicklistField id="namespace" options={namespaceOptions} label="Namespace" info="Which namespace to use" />}
-                    {enableStorage && <Checkbox id="enablePersistentStorage" label="Enable persistent storage" />}
+                    {enableStorage && <CheckboxField id="enablePersistentStorage" label="Enable persistent storage" />}
                     <TextField id="retention" label="Storage Retention (days)" info="Defaults to 15 days if nothing is set" type="number" />
                     <KeyValuesField id="serviceMonitor" label="Service Monitor" info="Key/value pairs for service monitor that Prometheus will use" />
                   </ValidatedForm>

--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -3,10 +3,13 @@ import Checkbox from 'core/components/validatedForm/Checkbox'
 import FormWrapper from 'core/components/FormWrapper'
 import KeyValuesField from 'core/components/validatedForm/KeyValuesField'
 import PicklistField from 'core/components/validatedForm/PicklistField'
+import PrometheusRuleForm from './PrometheusRuleForm'
+import PrometheusRulesTable from './PrometheusRulesTable'
 import TextField from 'core/components/validatedForm/TextField'
 import ValidatedForm from 'core/components/validatedForm/ValidatedForm'
 import Wizard from 'core/components/Wizard'
 import WizardStep from 'core/components/WizardStep'
+import uuid from 'uuid'
 import { compose } from 'ramda'
 import { createPrometheusInstance } from './actions'
 import { loadInfrastructure } from '../infrastructure/actions'
@@ -16,21 +19,37 @@ import { withDataLoader } from 'core/DataLoader'
 
 const initialContext = {
   numInstances: 1,
-  memory: 8,
-  cpu: 1,
+  memory: 512,
+  cpu: 500,
   storage: 8,
   retention: 15,
 }
 
 class AddPrometheusInstancePage extends React.Component {
+  state = {
+    rules: [],
+  }
+
   handleSubmit = data => {
     const { context, setContext } = this.props
     createPrometheusInstance({ data, context, setContext })
   }
 
+  handleAddRule = rule => {
+    console.log('handleAddRule', rule)
+    const withId = { id: uuid.v4(), ...rule }
+    this.setState({ rules: [...this.state.rules, withId] })
+  }
+
+  handleDeleteRule = id => () => {
+    this.setState(state => ({ rules: state.rules.filter(rule => rule.id !== id) }))
+  }
+
   render () {
+    const { rules } = this.state
     const clusters = this.props.data
     const clusterOptions = projectAs({ value: 'uuid', label: 'name' }, clusters)
+    const enableStorage = false // We are just using ephemeral storage for the first version
     return (
       <FormWrapper title="Add Prometheus Instance">
         <Wizard onComplete={this.handleSubmit} context={initialContext}>
@@ -38,22 +57,22 @@ class AddPrometheusInstancePage extends React.Component {
             return (
               <React.Fragment>
                 <WizardStep stepId="instance" label="Prometheus Instsance">
+                  {rules.length > 0 && <PrometheusRulesTable rules={this.state.rules} onDelete={this.handleDeleteRule} />}
+                  <PrometheusRuleForm onSubmit={this.handleAddRule} onDelete={this.handleDeleteRule} />
                   <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
                     <TextField id="name" label="Name" info="Name of the Prometheus instance" />
                     <TextField id="numInstances" label="# of instances" info="Number of Prometheus instances" type="number" />
-                    <TextField id="cpu" label="CPU" info="Expressed in 'm' (1m = 1/1000th of a core)" type="number" />
-                    <TextField id="memory" label="Memory" info="GiB of memory to allocate" type="number" />
+                    <TextField id="cpu" label="CPU" info="Expressed in millicores (1m = 1/1000th of a core)" type="number" />
+                    <TextField id="memory" label="Memory" info="MiB of memory to allocate" type="number" />
                     <TextField id="storage" label="Storage" info="The storage allocation.  Default is 8 GiB" type="number" />
                     <PicklistField id="cluster" options={clusterOptions} label="Cluster" info="Clusters available with RoleBing from admin delegation" />
-                    <Checkbox id="enablePersistentStorage" label="Enable persistent storage" />
+                    {enableStorage && <Checkbox id="enablePersistentStorage" label="Enable persistent storage" />}
                     <TextField id="retention" label="Storage Retention (days)" info="Defaults to 15 days if nothing is set" type="number" />
                     <KeyValuesField id="serviceMonitor" label="Service Monitor" info="Key/value pairs for service monitor that Prometheus will use" />
                   </ValidatedForm>
                 </WizardStep>
                 <WizardStep stepId="config" label="Configure Alerting">
-                  <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
-                    <h1>TODO: alerting</h1>
-                  </ValidatedForm>
+                  <PrometheusRuleForm onSubmit={this.handleAddRule} onDelete={this.handleDeleteRule} />
                 </WizardStep>
               </React.Fragment>
             )

--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -37,10 +37,10 @@ class AddPrometheusInstancePage extends React.Component {
                   <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
                     <TextField id="name" label="Name" info="Name of the Prometheus instance" />
                     <TextField id="numInstances" label="# of instances" info="Number of Prometheus instances" type="number" />
-                    <TextField id="memory" label="Memory" info="GB of memory to allocate" type="number" />
+                    <TextField id="memory" label="Memory" info="GiB of memory to allocate" type="number" />
                     <TextField id="cpu" label="CPU" info="# of CPUs to allocate" type="number" />
                     <PicklistField id="cluster" options={clusterOptions} label="Cluster" info="Clusters available with RoleBing from admin delegation" />
-                    <TextField id="storage" label="Storage" info="The storage allocation.  Default is 8GB" type="number" />
+                    <TextField id="storage" label="Storage" info="The storage allocation.  Default is 8 GiB" type="number" />
                     <Checkbox id="enablePersistentStorage" label="Enable persistent storage" />
                     <TextField id="retention" label="Storage Retention (days)" info="Defaults to 15 days if nothing is set" type="number" />
                     <KeyValuesField id="serviceMonitor" label="Service Monitor" info="Key/value pairs for service monitor that Prometheus will use" />

--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import Checkbox from 'core/components/validatedForm/Checkbox'
+import FormWrapper from 'core/components/FormWrapper'
+import KeyValuesField from 'core/components/validatedForm/KeyValuesField'
+import PicklistField from 'core/components/validatedForm/PicklistField'
+import TextField from 'core/components/validatedForm/TextField'
+import ValidatedForm from 'core/components/validatedForm/ValidatedForm'
+import Wizard from 'core/components/Wizard'
+import WizardStep from 'core/components/WizardStep'
+import { compose } from 'ramda'
+import { loadInfrastructure } from '../infrastructure/actions'
+import { projectAs } from 'utils/fp'
+import { withAppContext } from 'core/AppContext'
+import { withDataLoader } from 'core/DataLoader'
+
+const initialContext = {
+  numInstances: 1,
+  memory: 8,
+  cpu: 1,
+  storage: 8,
+  retention: 15,
+}
+
+class AddPrometheusInstancePage extends React.Component {
+  handleSubmit = () => console.log('TODO: AddPrometheusInstancePage#handleSubmit')
+
+  render () {
+    const clusters = this.props.data
+    const clusterOptions = projectAs({ value: 'uuid', label: 'name' }, clusters)
+    return (
+      <FormWrapper title="Add Prometheus Instance">
+        <Wizard onComplete={this.handleSubmit} context={initialContext}>
+          {({ wizardContext, setWizardContext, onNext }) => {
+            return (
+              <React.Fragment>
+                <WizardStep stepId="instance" label="Prometheus Instsance">
+                  <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
+                    <TextField id="name" label="Name" info="Name of the Prometheus instance" />
+                    <TextField id="numInstances" label="# of instances" info="Number of Prometheus instances" type="number" />
+                    <TextField id="memory" label="Memory" info="GB of memory to allocate" type="number" />
+                    <TextField id="cpu" label="CPU" info="# of CPUs to allocate" type="number" />
+                    <PicklistField id="cluster" options={clusterOptions} label="Cluster" info="Clusters available with RoleBing from admin delegation" />
+                    <TextField id="storage" label="Storage" info="The storage allocation.  Default is 8GB" type="number" />
+                    <Checkbox id="enablePersistentStorage" label="Enable persistent storage" />
+                    <TextField id="retention" label="Storage Retention (days)" info="Defaults to 15 days if nothing is set" type="number" />
+                    <KeyValuesField id="serviceMonitor" label="Service Monitor" info="Key/value pairs for service monitor that Prometheus will use" />
+                  </ValidatedForm>
+                </WizardStep>
+                <WizardStep stepId="config" label="Configure Alerting">
+                  <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
+                    <h1>TODO: alerting</h1>
+                  </ValidatedForm>
+                </WizardStep>
+              </React.Fragment>
+            )
+          }}
+        </Wizard>
+      </FormWrapper>
+    )
+  }
+}
+
+export default compose(
+  withDataLoader({ dataKey: 'clusters', loaderFn: loadInfrastructure }),
+  withAppContext,
+)(AddPrometheusInstancePage)

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusAlerts.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusAlerts.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const PrometheusAlerts = () => <h1>Prometheus Alerts</h1>
+
+export default PrometheusAlerts

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
@@ -1,0 +1,33 @@
+// import React from 'react'
+import createCRUDComponents from 'core/helpers/createCRUDComponents'
+import { loadPrometheusInstances } from './actions'
+
+const renderAsJson = data => JSON.stringify(data)
+
+export const columns = [
+  { id: 'name', label: 'Name' },
+  { id: 'namespace', label: 'Namespace' },
+  { id: 'serviceMonitor', label: 'Service Monitor', render: renderAsJson },
+  { id: 'alertManager', label: 'Alert Manager' },
+  { id: 'disk', label: 'Disk' },
+  { id: 'retention', label: 'Retention' },
+  { id: 'version', label: 'version' },
+  { id: 'status', label: 'Status' },
+  { id: 'age', label: 'Age' },
+  { id: 'numInstances', label: '# Instances' },
+]
+
+export const options = {
+  addUrl: '/ui/kubernetes/prometheus/instances/add',
+  columns,
+  dataKey: 'prometheusInstances',
+  editUrl: '/ui/kubernetes/prometheus/instances/edit',
+  loaderFn: loadPrometheusInstances,
+  name: 'PrometheusInstances',
+  title: 'Prometheus Instances',
+}
+
+const { ListPage, List } = createCRUDComponents(options)
+export const PrometheusInstancesList = List
+
+export default ListPage

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
@@ -27,7 +27,6 @@ export const options = {
   loaderFn: loadPrometheusResources,
   name: 'PrometheusInstances',
   title: 'Prometheus Instances',
-  debug: true,
 }
 
 const { ListPage, List } = createCRUDComponents(options)

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
@@ -1,20 +1,22 @@
-// import React from 'react'
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
-import { loadPrometheusInstances } from './actions'
+import { loadPrometheusResources } from './actions'
 
-const renderAsJson = data => JSON.stringify(data)
+// const renderAsJson = data => JSON.stringify(data)
+const renderKeyValues = obj => Object.entries(obj)
+  .map(([key, value]) => `${key}: ${value}`)
+  .join(', <br/>')
 
 export const columns = [
   { id: 'name', label: 'Name' },
   { id: 'namespace', label: 'Namespace' },
-  { id: 'serviceMonitor', label: 'Service Monitor', render: renderAsJson },
-  { id: 'alertManager', label: 'Alert Manager' },
-  { id: 'disk', label: 'Disk' },
+  { id: 'serviceMonitorSelector', label: 'Service Monitor', render: renderKeyValues },
+  { id: 'alertManagersSelector', label: 'Alert Managers' },
+  { id: 'cpu', label: 'CPU' },
+  { id: 'storage', label: 'Storage' },
+  { id: 'memory', label: 'Memory' },
   { id: 'retention', label: 'Retention' },
   { id: 'version', label: 'version' },
-  { id: 'status', label: 'Status' },
-  { id: 'age', label: 'Age' },
-  { id: 'numInstances', label: '# Instances' },
+  { id: 'replicas', label: '# of instances' },
 ]
 
 export const options = {
@@ -22,9 +24,10 @@ export const options = {
   columns,
   dataKey: 'prometheusInstances',
   editUrl: '/ui/kubernetes/prometheus/instances/edit',
-  loaderFn: loadPrometheusInstances,
+  loaderFn: loadPrometheusResources,
   name: 'PrometheusInstances',
   title: 'Prometheus Instances',
+  debug: true,
 }
 
 const { ListPage, List } = createCRUDComponents(options)

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusMonitoringPage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusMonitoringPage.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import Tabs from 'core/components/Tabs'
+import Tab from 'core/components/Tab'
+
+const PrometheusMonitoringPage = () => (
+  <Tabs>
+    <Tab value="instances" label="Instances">Instances</Tab>
+    <Tab value="alerts" label="Alerts">Alerts</Tab>
+  </Tabs>
+)
+
+export default PrometheusMonitoringPage

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusMonitoringPage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusMonitoringPage.js
@@ -2,10 +2,13 @@ import React from 'react'
 import Tabs from 'core/components/Tabs'
 import Tab from 'core/components/Tab'
 
+import PrometheusInstances from './PrometheusInstances'
+import PrometheusAlerts from './PrometheusAlerts'
+
 const PrometheusMonitoringPage = () => (
   <Tabs>
-    <Tab value="instances" label="Instances">Instances</Tab>
-    <Tab value="alerts" label="Alerts">Alerts</Tab>
+    <Tab value="instances" label="Prometheus Instances"><PrometheusInstances /></Tab>
+    <Tab value="alerts" label="Alerts"><PrometheusAlerts /></Tab>
   </Tabs>
 )
 

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusRuleForm.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusRuleForm.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import PicklistField from 'core/components/ValidatedForm/PicklistField'
+import SubmitButton from 'core/components/SubmitButton'
+import TextField from 'core/components/validatedForm/TextField'
+import ValidatedForm from 'core/components/validatedForm/ValidatedForm'
+import { Card, CardContent, Typography } from '@material-ui/core'
+import { withStyles } from '@material-ui/styles'
+
+const styles = theme => ({
+  root: {
+  }
+})
+
+// TODO: Need some UI mechanism to delete a rule.
+const PrometheusRuleForm = ({ onDelete, onSubmit, classes }) => {
+  const severityOptions = 'critical warning info'.split(' ').map(x => ({ value: x, label: x }))
+
+  const initialValues = {
+    severity: 'warning',
+  }
+
+  return (
+    <Card className={classes.root}>
+      <CardContent>
+        <Typography variant="h6">Prometheus Rule</Typography>
+        <ValidatedForm initialValues={initialValues} onSubmit={onSubmit}>
+          <TextField id="name" label="Name" info="Name of the rule " />
+          <TextField id="rule" label="Rule" info="Prometheus Rule Expression" />
+          <PicklistField id="severity" options={severityOptions} label="Severity" info="Severity of the alert" />
+          <TextField id="period" label="Period" info="How long rule needs to be true before triggering an alert" />
+          <TextField id="description" label="Description" info="Optional description for this rule" />
+          <SubmitButton>Create</SubmitButton>
+        </ValidatedForm>
+      </CardContent>
+    </Card>
+  )
+}
+
+PrometheusRuleForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+}
+
+export default withStyles(styles)(PrometheusRuleForm)

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusRuleForm.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusRuleForm.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import PicklistField from 'core/components/ValidatedForm/PicklistField'
+import PicklistField from 'core/components/validatedForm/PicklistField'
 import SubmitButton from 'core/components/SubmitButton'
 import TextField from 'core/components/validatedForm/TextField'
 import ValidatedForm from 'core/components/validatedForm/ValidatedForm'
@@ -24,11 +24,11 @@ const PrometheusRuleForm = ({ onDelete, onSubmit, classes }) => {
     <Card className={classes.root}>
       <CardContent>
         <Typography variant="h6">Prometheus Rule</Typography>
-        <ValidatedForm initialValues={initialValues} onSubmit={onSubmit}>
-          <TextField id="name" label="Name" info="Name of the rule " />
-          <TextField id="rule" label="Rule" info="Prometheus Rule Expression" />
+        <ValidatedForm initialValues={initialValues} onSubmit={onSubmit} clearOnSubmit>
+          <TextField id="alert" label="Alert Name" info="Name of the alert " />
+          <TextField id="expr" label="Rule" info="Prometheus Rule Expression" />
           <PicklistField id="severity" options={severityOptions} label="Severity" info="Severity of the alert" />
-          <TextField id="period" label="Period" info="How long rule needs to be true before triggering an alert" />
+          <TextField id="period" label="Period" info="How long rule needs to be true before triggering an alert (Ex: 5m)" />
           <TextField id="description" label="Description" info="Optional description for this rule" />
           <SubmitButton>Create</SubmitButton>
         </ValidatedForm>

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusRulesTable.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusRulesTable.js
@@ -9,7 +9,7 @@ const PrometheusRulesTable = ({ rules, onDelete }) => {
       <Table>
         <TableHead>
           <TableRow>
-            <TableCell>Name</TableCell>
+            <TableCell>Alert Name</TableCell>
             <TableCell>Rule</TableCell>
             <TableCell>Severity</TableCell>
             <TableCell>Period</TableCell>
@@ -20,8 +20,8 @@ const PrometheusRulesTable = ({ rules, onDelete }) => {
         <TableBody>
           {rules.map(rule => (
             <TableRow key={rule.id}>
-              <TableCell>{rule.name}</TableCell>
-              <TableCell>{rule.rule}</TableCell>
+              <TableCell>{rule.alert}</TableCell>
+              <TableCell>{rule.expr}</TableCell>
               <TableCell>{rule.severity}</TableCell>
               <TableCell>{rule.period}</TableCell>
               <TableCell>{rule.description}</TableCell>

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusRulesTable.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusRulesTable.js
@@ -1,33 +1,36 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core'
+import { Button, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@material-ui/core'
 
 const PrometheusRulesTable = ({ rules, onDelete }) => {
   return (
-    <Table>
-      <TableHead>
-        <TableRow>
-          <TableCell>Name</TableCell>
-          <TableCell>Rule</TableCell>
-          <TableCell>Severity</TableCell>
-          <TableCell>Period</TableCell>
-          <TableCell>Description</TableCell>
-          <TableCell>&nbsp;</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {rules.map(rule => (
+    <div>
+      <Typography variant="h6">Prometheus Rules</Typography>
+      <Table>
+        <TableHead>
           <TableRow>
-            <TableCell>{rule.name}</TableCell>
-            <TableCell>{rule.rule}</TableCell>
-            <TableCell>{rule.severity}</TableCell>
-            <TableCell>{rule.period}</TableCell>
-            <TableCell>{rule.description}</TableCell>
-            <TableCell><Button size="small" color="primary" onClick={onDelete(rule.id)}>Delete</Button></TableCell>
+            <TableCell>Name</TableCell>
+            <TableCell>Rule</TableCell>
+            <TableCell>Severity</TableCell>
+            <TableCell>Period</TableCell>
+            <TableCell>Description</TableCell>
+            <TableCell>&nbsp;</TableCell>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHead>
+        <TableBody>
+          {rules.map(rule => (
+            <TableRow key={rule.id}>
+              <TableCell>{rule.name}</TableCell>
+              <TableCell>{rule.rule}</TableCell>
+              <TableCell>{rule.severity}</TableCell>
+              <TableCell>{rule.period}</TableCell>
+              <TableCell>{rule.description}</TableCell>
+              <TableCell><Button size="small" color="primary" onClick={onDelete(rule.id)}>Delete</Button></TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
   )
 }
 

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusRulesTable.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusRulesTable.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core'
+
+const PrometheusRulesTable = ({ rules, onDelete }) => {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>Name</TableCell>
+          <TableCell>Rule</TableCell>
+          <TableCell>Severity</TableCell>
+          <TableCell>Period</TableCell>
+          <TableCell>Description</TableCell>
+          <TableCell>&nbsp;</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rules.map(rule => (
+          <TableRow>
+            <TableCell>{rule.name}</TableCell>
+            <TableCell>{rule.rule}</TableCell>
+            <TableCell>{rule.severity}</TableCell>
+            <TableCell>{rule.period}</TableCell>
+            <TableCell>{rule.description}</TableCell>
+            <TableCell><Button size="small" color="primary" onClick={onDelete(rule.id)}>Delete</Button></TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+PrometheusRulesTable.propTypes = {
+  rules: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onDelete: PropTypes.func.isRequired,
+}
+
+export default PrometheusRulesTable

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -41,3 +41,9 @@ export const loadPrometheusResources = async ({ context, setContext, reload }) =
   setContext({ prometheusInstances, prometheusServiceMonitors, prometheusRules })
   return prometheusInstances
 }
+
+export const createPrometheusInstance = async ({ data, context, setContext }) => {
+  console.log('createPrometheusInstance')
+  const createdInstance = await context.apiClient.qbert.createPrometheusInstance(data.cluster, data)
+  console.log('createdInstance', createdInstance)
+}

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -45,3 +45,8 @@ export const createPrometheusInstance = async ({ data, context, setContext }) =>
   const createdInstance = await context.apiClient.qbert.createPrometheusInstance(data.cluster, data)
   console.log('createdPrometheusInstance', createdInstance)
 }
+
+export const loadServiceAccounts = async ({ data, context, setContext }) => {
+  const serviceAccounts = await context.apiClient.qbert.getServiceAccounts(data.cluster)
+  return serviceAccounts
+}

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -1,0 +1,27 @@
+export const loadPrometheusInstances = async ({ context, setContext, reload }) => {
+  if (!reload && context.prometheusInstances) { return context.prometheusInstances }
+
+  // TODO: fetch the data from actual API
+  // const prometheusInstances = await context.apiClient.qbert.getPrometheusInstances()
+
+  // Mocking out data for now:
+  const mockData = [
+    {
+      name: 'dev-stageprom1',
+      namespace: 'development',
+      serviceMonitor: { prometheus: 'staging', project: 'dev' },
+      alertManager: 'database-pager',
+      disk: 8,
+      retention: 15,
+      version: 'v2.6',
+      status: 'healthy',
+      age: '21 hrs',
+      numInstances: 4,
+    },
+  ]
+
+  const prometheusInstances = mockData
+
+  setContext({ prometheusInstances })
+  return prometheusInstances
+}

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -30,7 +30,6 @@ export const loadPrometheusResources = async ({ context, setContext, reload }) =
 
   const instancesResponse = await context.apiClient.qbert.getPrometheusInstances('e8f1d175-2e7d-40fa-a475-ed20b8d8c66d')
   const prometheusInstances = instancesResponse.items.map(mapPrometheusInstance)
-  console.log(prometheusInstances)
 
   const serviceMonitorsResponse = await context.apiClient.qbert.getPrometheusServiceMonitors('e8f1d175-2e7d-40fa-a475-ed20b8d8c66d')
   const prometheusServiceMonitors = serviceMonitorsResponse.items.map(mapServiceMonitor)

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -42,7 +42,6 @@ export const loadPrometheusResources = async ({ context, setContext, reload }) =
 }
 
 export const createPrometheusInstance = async ({ data, context, setContext }) => {
-  console.log('createPrometheusInstance')
   const createdInstance = await context.apiClient.qbert.createPrometheusInstance(data.cluster, data)
-  console.log('createdInstance', createdInstance)
+  console.log('createdPrometheusInstance', createdInstance)
 }

--- a/src/app/plugins/kubernetes/index.js
+++ b/src/app/plugins/kubernetes/index.js
@@ -189,6 +189,7 @@ Kubernetes.registerPlugin = pluginManager => {
     {
       name: 'Infrastructure',
       link: { path: '/infrastructure' },
+      icon: 'building',
       nestedLinks: [
         { name: 'Clusters', link: { path: '/infrastructure#clusters' } },
         { name: 'Nodes', link: { path: '/infrastructure#nodes' } },
@@ -198,6 +199,7 @@ Kubernetes.registerPlugin = pluginManager => {
     {
       name: 'App Catalog',
       link: { path: '/apps' },
+      icon: 'th',
       nestedLinks: [
         { name: 'App Catalog', link: { path: '/apps#appCatalog' } },
         { name: 'Deployed Apps', link: { path: '/apps#deployedApps' } },
@@ -207,18 +209,20 @@ Kubernetes.registerPlugin = pluginManager => {
     {
       name: 'Pods, Deployments, Services',
       link: { path: '/pods' },
+      icon: 'cubes',
       nestedLinks: [
         { name: 'Pods', link: { path: '/pods#pods' } },
         { name: 'Deployments', link: { path: '/pods#deployments' } },
         { name: 'Services', link: { path: '/pods#services' } },
       ]
     },
-    { name: 'Storage Classes', link: { path: '/storage_classes' } },
-    { name: 'Namespaces', link: { path: '/namespaces' } },
-    { name: 'API Access', link: { path: '/api_access' } },
+    { name: 'Storage Classes', icon: 'hdd', link: { path: '/storage_classes' } },
+    { name: 'Namespaces', icon: 'object-group', link: { path: '/namespaces' } },
+    { name: 'API Access', icon: 'key', link: { path: '/api_access' } },
     {
       name: 'Tenants & Users',
       link: { path: '/user_management' },
+      icon: 'user',
       nestedLinks: [
         { name: 'Tenants', link: { path: '/user_management#tenants' } },
         { name: 'Users', link: { path: '/user_management#users' } },

--- a/src/app/plugins/kubernetes/index.js
+++ b/src/app/plugins/kubernetes/index.js
@@ -16,6 +16,7 @@ import StorageClassesPage from './components/storage/StorageClassesPage'
 import UpdateCloudProviderPage from './components/infrastructure/UpdateCloudProviderPage'
 import UserManagementIndexPage from './components/userManagement/UserManagementIndexPage'
 import AppDetailsPage from 'core/components/appCatalog/AppDetailsPage'
+import PrometheusMonitoringPage from './components/prometheus/PrometheusMonitoringPage'
 
 class Kubernetes extends React.Component {
   render () {
@@ -113,6 +114,11 @@ Kubernetes.registerPlugin = pluginManager => {
         name: 'Tenants & Users',
         link: { path: '/user_management', exact: true },
         component: UserManagementIndexPage
+      },
+      {
+        name: 'Monitoring',
+        link: { path: '/monitoring', exact: true },
+        component: PrometheusMonitoringPage,
       },
     ]
   )
@@ -216,8 +222,17 @@ Kubernetes.registerPlugin = pluginManager => {
     },
   ]
 
-  const links = useClarityLinks ? clarityNavItems : devNavItems
-  plugin.registerNavItems(links)
+  const navItems = useClarityLinks ? clarityNavItems : devNavItems
+  const commonNavItems = [
+    {
+      name: 'Monitoring',
+      icon: 'chart-area',
+      link: { path: '/monitoring' },
+
+    }
+  ]
+  const allNavItems = [...commonNavItems, ...navItems]
+  plugin.registerNavItems(allNavItems)
 }
 
 export default Kubernetes

--- a/src/app/plugins/kubernetes/index.js
+++ b/src/app/plugins/kubernetes/index.js
@@ -16,6 +16,7 @@ import StorageClassesPage from './components/storage/StorageClassesPage'
 import UpdateCloudProviderPage from './components/infrastructure/UpdateCloudProviderPage'
 import UserManagementIndexPage from './components/userManagement/UserManagementIndexPage'
 import AppDetailsPage from 'core/components/appCatalog/AppDetailsPage'
+import AddPrometheusInstancePage from './components/prometheus/AddPrometheusInstancePage'
 import PrometheusMonitoringPage from './components/prometheus/PrometheusMonitoringPage'
 
 class Kubernetes extends React.Component {
@@ -117,8 +118,13 @@ Kubernetes.registerPlugin = pluginManager => {
       },
       {
         name: 'Monitoring',
-        link: { path: '/monitoring', exact: true },
+        link: { path: '/prometheus', exact: true },
         component: PrometheusMonitoringPage,
+      },
+      {
+        name: 'Create Prometheus Instance',
+        link: { path: '/prometheus/instances/add', exact: true },
+        component: AddPrometheusInstancePage,
       },
     ]
   )
@@ -227,11 +233,11 @@ Kubernetes.registerPlugin = pluginManager => {
     {
       name: 'Monitoring',
       icon: 'chart-area',
-      link: { path: '/monitoring' },
+      link: { path: '/prometheus' },
 
     }
   ]
-  const allNavItems = [...commonNavItems, ...navItems]
+  const allNavItems = [...navItems, ...commonNavItems]
   plugin.registerNavItems(allNavItems)
 }
 

--- a/src/app/utils/fp.js
+++ b/src/app/utils/fp.js
@@ -126,7 +126,7 @@ export const asyncFlatMap = async (arr, callback) => {
   return newArr
 }
 
-export const pathOrNull = pathStr => pathOr(null, pathStr.split('.'))
+export const pathOrNull = curry((pathStr, obj) => pathOr(null, pathStr.split('.'), obj))
 
 // I didn't see anything in Ramda that would allow me to create a "Maybe"
 // composition so creating a simple version here.

--- a/src/app/utils/fp.js
+++ b/src/app/utils/fp.js
@@ -12,6 +12,11 @@ export const propExists = curry((key, obj) => obj[key] !== undefined)
 // Works for arrays and strings.  All other types return false.
 export const notEmpty = arr => !!(arr && arr.length)
 
+export const hasKeys = obj => {
+  if (!(obj instanceof Object)) { return false }
+  return Object.keys(obj).length > 0
+}
+
 export const pluckAsync = key => promise => promise.then(obj => obj[key])
 
 export const compose = (...fns) =>


### PR DESCRIPTION
This is the first version of the Managed Prometheus solution.  Currently it is very alpha.  The backend will be changing to consolidate the API into 1 call instead of 4.

The way the API is currently structured we need to create 4 CRD objects (`prometheuses`, `servicemonitors`, `prometheusrules`, and `alertmanagers`) for each Prometheus Instance in the UI.  They are associated using the standard Kubernetes `labels` / `selector` paradigm.

The UI makes the assumption of a 1-to-1 relation between the different CRDs but that is not the case in the backend.  As a result, deleting is difficult because we don't know which objects to delete.

No simulator endpoints were created due to the fact that the API will be radically changing.