### PR TITLE
Allow MoreMenu to work without passing cond

### DIFF
--- a/src/app/core/components/MoreMenu.js
+++ b/src/app/core/components/MoreMenu.js
@@ -58,7 +58,7 @@ class MoreMenu extends React.Component {
           onClick={e => e.stopPropagation()}
         >
           {this.props.items.map(({ action, cond, icon, label }) =>
-            <MenuItem key={label} onClick={this.handleClick(action, label)} disabled={!cond(data, context)}>
+            <MenuItem key={label} onClick={this.handleClick(action, label)} disabled={cond && !cond(data, context)}>
               {icon && icon}
               {label}
             </MenuItem>


### PR DESCRIPTION
Was getting `cond is not a function` so only calling it when it exists.