### PR TITLE
Refactoring and simplification using a composable approach to load data

### DIFF
--- a/src/app/core/DataLoader.js
+++ b/src/app/core/DataLoader.js
@@ -1,13 +1,11 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import { pick, intersection, flatten, head } from 'ramda'
 import { ensureArray } from 'app/utils/fp'
 import DisplayError from './components/DisplayError'
 import Progress from './components/Progress'
 import { withAppContext } from 'core/AppContext'
-import moize from 'moize'
 
-class MultiLoaderBase extends PureComponent {
+class DataLoaderBase extends PureComponent {
   state = {
     loading: false,
     error: null,
@@ -22,52 +20,11 @@ class MultiLoaderBase extends PureComponent {
     window.removeEventListener('scopeChanged', this.listener)
   }
 
-  getLoaderPairs = loaders => Array.isArray(loaders)
-    ? loaders
-    : Object.entries(loaders)
-
-  /**
-   * Returns a map of [loaderKeys, promise] arrays that rely one on another and will wait for the
-   * dependant loaders regardless of the order on which they are called
-   * @param loaders
-   */
-  getLinkedLoaders = moize(loaders => {
-    const loaderPairs = this.getLoaderPairs(loaders)
-    const linkedLoaders = loaderPairs.map(([loaderKeys, loaderSpec]) => {
-      const { loaderFn, requires } =
-        typeof loaderSpec === 'function'
-          ? { loaderFn: loaderSpec }
-          : loaderSpec
-
-      // If the loader has dependencies, create a promise that will wait for the dependencies to be resolved
-      return [
-        loaderKeys,
-        async (params, reloadAll = true) => {
-          const prevResults = requires
-            ? await Promise.all(
-              linkedLoaders
-                .filter(([lnkLoaderKeys]) =>
-                  intersection(lnkLoaderKeys, ensureArray(requires)).length > 0,
-                )
-                .map(([, loaderFn]) => loaderFn({ setContext, context, params, reload: reloadAll })),
-            ) : undefined
-
-          const { setContext, context } = this.props
-
-          return loaderFn({ setContext, context, prevResults, params, reload: reloadAll })
-        },
-      ]
-    })
-    return linkedLoaders
-  })
-
   loadAll = async () =>
     this.setState({ loading: true }, async () => {
       const { loaders } = this.props
       try {
-        await Promise.all(this.getLinkedLoaders(loaders)
-          .map(([, callback]) => callback()),
-        )
+        await Promise.all(ensureArray(loaders).map(loader => loader(this.props)))
         this.setState({ loading: false })
       } catch (err) {
         console.log(err)
@@ -75,15 +32,10 @@ class MultiLoaderBase extends PureComponent {
       }
     })
 
-  loadOne = (key, params, reloadAll = false) => {
-    const { loaders } = this.props
-    const [, loaderFn] = this.getLinkedLoaders(loaders).find(([keys]) =>
-      Array.isArray(keys) ? keys.includes(key) : keys === key,
-    )
-
+  reloadData = (loaderFn, params, reload, cascade = false) => {
     this.setState({ loading: true }, async () => {
       try {
-        await loaderFn(params, reloadAll)
+        await loaderFn({ ...this.props, params, reload, cascade })
         this.setState({ loading: false })
       } catch (err) {
         console.log(err)
@@ -97,75 +49,37 @@ class MultiLoaderBase extends PureComponent {
     if (error) {
       return <DisplayError error={error} />
     }
-    const { context, loaders, children, options } = this.props
-    const loaderPairs = this.getLoaderPairs(loaders)
-    const dataKeys = flatten(loaderPairs.map(head))
-    const data = dataKeys.length === 1 ? context[dataKeys[0]] : pick(dataKeys, context)
-    return <Progress inline={options.inlineProgress} overlay loading={loading || !data}>
-      {children({ data, loading, error, context, reload: this.loadOne })}
+    const { children, options } = this.props
+    return <Progress inline={options.inlineProgress} overlay loading={loading}>
+      {children({ loading, error, reloadData: this.reloadData })}
     </Progress>
   }
 }
 
-const MultiLoader = withAppContext(MultiLoaderBase)
+// FIXME: for now we assign app context here but ideally this component
+// should not be aware of anything about the app
+const DataLoader = withAppContext(DataLoaderBase)
 
-const DataLoader = ({ dataKey, loaderFn, children, options }) => (
-  <MultiLoader loaders={[[ensureArray(dataKey), loaderFn]]} options={options}>
-    {children}
-  </MultiLoader>
-)
 DataLoader.propTypes = {
-  /**
-   * Used to determine if data already exists in context.
-   * If `context[dataKey]` exists it does not run the `loaderFn`.
-   * Once the data has been loaded `context[dataKey]` is passed
-   * to the child component in the `data` prop.
-   * Can also take an array of multiple dataKeys to check.
-   */
-  dataKey: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
-  ]).isRequired,
-
-  /**
-   * This function is invoked when the data does not yet exist.
-   * It is passed `setContext` to use for updating.
-   * Can also take an array of multiple loaders.
-   */
-  loaderFn: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.arrayOf(PropTypes.func),
-  ]).isRequired,
-}
-
-MultiLoader.propTypes = {
   /**
    * Object with key value pairs where key is the dataKey and
    * value is a loaderFn or a spec of { requires, loaderFn }
    */
-  loaders: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
+  loaders: PropTypes.oneOfType([PropTypes.array, PropTypes.func]).isRequired,
 
   options: PropTypes.shape({
     inlineProgress: PropTypes.bool,
   }),
 }
 
-MultiLoader.defaultProps = {
+DataLoader.defaultProps = {
   options: {},
 }
 
-export const withDataLoader = ({ dataKey, loaderFn }, options) => Component => props => (
-  <DataLoader dataKey={dataKey} loaderFn={loaderFn} options={options}>
+export const withDataLoader = (loaders, options) => Component => props => (
+  <DataLoader loaders={loaders} options={options}>
     {loaderProps => <Component {...loaderProps} {...props} />}
   </DataLoader>
 )
-
-export const withMultiLoader = (loaders, options) => Component => props => (
-  <MultiLoader loaders={loaders} options={options}>
-    {loaderProps => <Component {...loaderProps} {...props} />}
-  </MultiLoader>
-)
-
-export { MultiLoader }
 
 export default DataLoader

--- a/src/app/core/DataUpdater.js
+++ b/src/app/core/DataUpdater.js
@@ -23,11 +23,11 @@ class DataUpdater extends React.Component {
   render () {
     const { loaderFn, objId, children } = this.props
     return (
-      <DataLoader loaders={loaderFn}>
+      <DataLoader loaders={{ updaterData: loaderFn }}>
         {({ data }) => {
-          if (!data) { return null }
+          if (!data.updaterData) { return null }
           return children({
-            data: this.findById(data, objId),
+            data: this.findById(data.updaterData, objId),
             onSubmit: this.handleSubmit,
           })
         }}

--- a/src/app/core/DataUpdater.js
+++ b/src/app/core/DataUpdater.js
@@ -6,9 +6,6 @@ import { compose } from 'ramda'
 import { withRouter } from 'react-router'
 
 /* This is a convenience HOC to make updating the in-memory cache easier.
- * After updating we need to replace the in-memory cache that is normally an
- * array of items.  We do this by looping through the array and finding the
- * entity with `objId` and replacing it with the result of `updateFn`
  *
  * Additionally, it handles loading as well through `DataLoader`.
  */
@@ -16,25 +13,22 @@ class DataUpdater extends React.Component {
   findById = (arr = [], id) => arr.find(x => x.id === id)
 
   handleSubmit = async data => {
-    const { dataKey, updateFn, objId, backUrl, context, setContext, history } = this.props
-    const updatedEntity = await updateFn(data, { context, setContext, objId, dataKey })
-    setContext({
-      [dataKey]: context[dataKey].map(x => x.id === objId ? updatedEntity : x)
-    })
-    if (updatedEntity && backUrl) {
+    const { updateFn, objId, backUrl, context, setContext, history } = this.props
+    await updateFn({ data, context, setContext, objId })
+    if (backUrl) {
       history.push(backUrl)
     }
   }
 
   render () {
-    const { dataKey, loaderFn, objId, children } = this.props
+    const { loaderFn, objId, children } = this.props
     return (
-      <DataLoader dataKey={dataKey} loaderFn={loaderFn}>
+      <DataLoader loaders={loaderFn}>
         {({ data }) => {
           if (!data) { return null }
           return children({
             data: this.findById(data, objId),
-            onSubmit: this.handleSubmit
+            onSubmit: this.handleSubmit,
           })
         }}
       </DataLoader>
@@ -44,17 +38,9 @@ class DataUpdater extends React.Component {
 
 DataUpdater.propTypes = {
   /**
-   * Used to determine if data already exists in context.
-   * If `context[dataKey]` exists it does not run the `loaderFn`.
-   * Once the data has been loaded `context[dataKey]` is passed
-   * to the child component in the `data` prop.
-   */
-  dataKey: PropTypes.string.isRequired,
-
-  /**
    * This function is invoked when the data does not yet exist.
    * It is passed `setContext` to use for updating.
-  */
+   */
   loaderFn: PropTypes.func.isRequired,
 
   updateFn: PropTypes.func.isRequired,

--- a/src/app/core/components/Picklist.js
+++ b/src/app/core/components/Picklist.js
@@ -54,6 +54,9 @@ class Picklist extends React.Component {
           variant={filled ? 'filled' : 'standard'}
           label={label}
           value={nonEmptyValue}
+          SelectProps={{
+            displayEmpty: true
+          }}
           onChange={this.handleChange}
           inputProps={{ name: label, id: name }}
         >

--- a/src/app/core/helpers/clusterContextLoader.js
+++ b/src/app/core/helpers/clusterContextLoader.js
@@ -1,0 +1,24 @@
+import { pathOr, chain } from 'ramda'
+import { loadClusters } from 'k8s/components/infrastructure/actions'
+import contextLoader from 'core/helpers/contextLoader'
+
+// Returns a contextLoaded function contextualized by selected cluster (given by clusterId param)
+const clusterContextLoader = (key, loaderFn, defaultValue = []) =>
+  async ({ context, params = {}, ...rest }) => {
+    const clusters = (await loadClusters({ context, params, ...rest, reload: false }))
+      .filter(cluster => cluster.hasMasterNode)
+    const { clusterId = pathOr('__all__', [0, 'uuid'], clusters) } = params
+
+    // loaderFn will receive "clusters" and "clusterId" in "params" object
+    const data = await contextLoader([key, clusterId], loaderFn, defaultValue)(
+      { context, params: { ...params, clusterId }, clusters, ...rest },
+    )
+    return clusterId === '__all__'
+      ? chain(([clusterId, values]) => values.map(value => ({
+        ...value,
+        clusterId,
+      })), Object.entries(data))
+      : data[clusterId]
+  }
+
+export default clusterContextLoader

--- a/src/app/core/helpers/clusterContextUpdater.js
+++ b/src/app/core/helpers/clusterContextUpdater.js
@@ -1,0 +1,18 @@
+import { loadClusters } from 'k8s/components/infrastructure/actions'
+import { pathOr } from 'ramda'
+import contextUpdater from 'core/helpers/contextUpdater'
+
+// Returns a contextUpdater function contextualized by selected cluster (given by clusterId param)
+const clusterContextUpdater = (key, updaterFn, returnLast = false) =>
+  async ({ context, params = {}, ...rest }) => {
+    const clusters = (await loadClusters({ context, params, ...rest, reload: false }))
+      .filter(cluster => cluster.hasMasterNode)
+    const { clusterId = pathOr('__all__', [0, 'uuid'], clusters) } = params
+
+    // updaterFn will receive "clusters" and "clusterId" in "params" object
+    return contextUpdater([key, clusterId], updaterFn, returnLast)(
+      { context, params: { ...params, clusterId }, clusters, ...rest },
+    )
+  }
+
+export default clusterContextUpdater

--- a/src/app/core/helpers/contextLoader.js
+++ b/src/app/core/helpers/contextLoader.js
@@ -1,0 +1,35 @@
+const pendingPromises = {}
+
+/**
+ * Returns a function that will use context to load and cache values
+ * @param key Context key
+ * @param loaderFn Function returning the data to be assigned to the context
+ * @param defaultValue Default value assigned to the context
+ * @returns {Function}
+ */
+const contextLoader = (key, loaderFn, defaultValue = []) =>
+  async ({ context, setContext, reload = false, cascade = false, ...rest }) => {
+    if (pendingPromises[key]) {
+      return pendingPromises[key]
+    }
+    let output = context[key]
+
+    if (reload || !output) {
+      pendingPromises[key] = loaderFn({
+        context,
+        setContext,
+        reload: reload && cascade,
+        cascade,
+        ...rest,
+      })
+      if (!output && defaultValue) {
+        await setContext({ [key]: defaultValue })
+      }
+      output = await pendingPromises[key]
+      await setContext({ [key]: output })
+      delete pendingPromises[key]
+    }
+    return output
+  }
+
+export default contextLoader

--- a/src/app/core/helpers/contextLoader.js
+++ b/src/app/core/helpers/contextLoader.js
@@ -1,35 +1,47 @@
-const pendingPromises = {}
+import { path, assocPath, dissocPath } from 'ramda'
+import moize from 'moize'
+import { ensureFunction, ensureArray } from 'utils/fp'
+
+let pendingPromises = {}
 
 /**
  * Returns a function that will use context to load and cache values
- * @param key Context key
+ * @param pathResolver Context path on which the resolved value will be cached, it can be a function
  * @param loaderFn Function returning the data to be assigned to the context
  * @param defaultValue Default value assigned to the context
  * @returns {Function}
  */
-const contextLoader = (key, loaderFn, defaultValue = []) =>
-  async ({ context, setContext, reload = false, cascade = false, ...rest }) => {
-    if (pendingPromises[key]) {
-      return pendingPromises[key]
+const contextLoader = (pathResolver, loaderFn, defaultValue = []) => {
+  const moizedPathResolver = moize(ensureFunction(pathResolver))
+
+  return async ({ context, setContext, params = {}, reload = false, cascade = false, ...rest }) => {
+    const resolvedPath = ensureArray(moizedPathResolver(params))
+    let promise = path(resolvedPath, pendingPromises)
+    if (promise) {
+      return promise
     }
-    let output = context[key]
+    let output = path(resolvedPath, context)
 
     if (reload || !output) {
-      pendingPromises[key] = loaderFn({
+      if (!output && defaultValue) {
+        await setContext(assocPath(resolvedPath, defaultValue))
+      }
+      promise = loaderFn({
         context,
         setContext,
+        params,
         reload: reload && cascade,
         cascade,
         ...rest,
       })
-      if (!output && defaultValue) {
-        await setContext({ [key]: defaultValue })
-      }
-      output = await pendingPromises[key]
-      await setContext({ [key]: output })
-      delete pendingPromises[key]
+      console.log(resolvedPath)
+      pendingPromises = assocPath(resolvedPath, promise, pendingPromises)
+      output = await promise
+      await setContext(assocPath(resolvedPath, output))
+      dissocPath(resolvedPath, pendingPromises)
     }
     return output
   }
+}
 
 export default contextLoader

--- a/src/app/core/helpers/contextLoader.js
+++ b/src/app/core/helpers/contextLoader.js
@@ -34,7 +34,6 @@ const contextLoader = (pathResolver, loaderFn, defaultValue = []) => {
         cascade,
         ...rest,
       })
-      console.log(resolvedPath)
       pendingPromises = assocPath(resolvedPath, promise, pendingPromises)
       output = await promise
       await setContext(assocPath(resolvedPath, output))

--- a/src/app/core/helpers/contextUpdater.js
+++ b/src/app/core/helpers/contextUpdater.js
@@ -1,21 +1,26 @@
-import { last } from 'ramda'
+import { last, assocPath } from 'ramda'
+import { ensureFunction, ensureArray } from 'utils/fp'
+import moize from 'moize'
 
 /**
  * Returns a function that will be used to add values to existing context arrays
- * @param key Context key
+ * @param pathResolver Context pathResolver
  * @param updaterFn Function whose return value will be used to update the context
  * @param returnLast Whether or not to return the last value of the updated list
  * @returns {Function}
  */
-const contextUpdater = (key, updaterFn, returnLast = false) =>
-  async ({ context, setContext, ...rest }) => {
+const contextUpdater = (pathResolver, updaterFn, returnLast = false) => {
+  const moizedPathResolver = moize(ensureFunction(pathResolver))
+  return async ({ context, setContext, params = {}, ...rest }) => {
+    const resolvedPath = ensureArray(moizedPathResolver(params))
     const output = await updaterFn({
       context,
       setContext,
       ...rest,
     })
-    await setContext({ [key]: output })
+    await setContext(assocPath(resolvedPath, output))
     return returnLast && Array.isArray(output) ? last(output) : output
   }
+}
 
 export default contextUpdater

--- a/src/app/core/helpers/contextUpdater.js
+++ b/src/app/core/helpers/contextUpdater.js
@@ -1,0 +1,21 @@
+import { last } from 'ramda'
+
+/**
+ * Returns a function that will be used to add values to existing context arrays
+ * @param key Context key
+ * @param updaterFn Function whose return value will be used to update the context
+ * @param returnLast Whether or not to return the last value of the updated list
+ * @returns {Function}
+ */
+const contextUpdater = (key, updaterFn, returnLast = false) =>
+  async ({ context, setContext, ...rest }) => {
+    const output = await updaterFn({
+      context,
+      setContext,
+      ...rest,
+    })
+    await setContext({ [key]: output })
+    return returnLast && Array.isArray(output) ? last(output) : output
+  }
+
+export default contextUpdater

--- a/src/app/core/helpers/contextUpdater.js
+++ b/src/app/core/helpers/contextUpdater.js
@@ -11,6 +11,7 @@ import moize from 'moize'
  */
 const contextUpdater = (pathResolver, updaterFn, returnLast = false) => {
   const moizedPathResolver = moize(ensureFunction(pathResolver))
+
   return async ({ context, setContext, params = {}, ...rest }) => {
     const resolvedPath = ensureArray(moizedPathResolver(params))
     const output = await updaterFn({

--- a/src/app/core/helpers/createCRUDActions.js
+++ b/src/app/core/helpers/createCRUDActions.js
@@ -7,27 +7,29 @@ const createCRUDActions = (options = {}) => {
     entity,
     dataKey = options.entity,
     uniqueIdentifier = 'id',
+    customContextLoader = contextLoader,
+    customContextUpdater = contextUpdater,
   } = options
 
   return {
     // Wrap standard CRUD operations to include updating the AppContext
-    create: contextUpdater(dataKey, async ({ data, context }) => {
+    create: customContextUpdater(dataKey, async ({ data, context }) => {
       const existing = await context.apiClient[service][entity].list()
       const created = await context.apiClient[service][entity].create(data)
       return [...existing, created]
     }, true),
 
-    list: contextLoader(dataKey, async ({ params, context }) => {
+    list: customContextLoader(dataKey, async ({ params, context }) => {
       return context.apiClient[service][entity].list(params)
     }),
 
-    update: contextUpdater(dataKey, async ({ id, data, context }) => {
+    update: customContextUpdater(dataKey, async ({ id, data, context }) => {
       const existing = await context.apiClient[service][entity].list()
       const updated = await context.apiClient[service][entity].update(id, data)
       return existing.map(x => x[uniqueIdentifier] === id ? x : updated)
     }),
 
-    delete: contextUpdater(dataKey, async ({ id, context }) => {
+    delete: customContextUpdater(dataKey, async ({ id, context }) => {
       await context.apiClient[service][entity].delete(id)
       return context[dataKey].filter(x => x[uniqueIdentifier] !== id)
     }),

--- a/src/app/core/helpers/createCRUDActions.js
+++ b/src/app/core/helpers/createCRUDActions.js
@@ -1,39 +1,36 @@
-const createCRUDActions = (options={}) => {
+import contextLoader from 'core/helpers/contextLoader'
+import contextUpdater from 'core/helpers/contextUpdater'
+
+const createCRUDActions = (options = {}) => {
   const {
     service,
     entity,
     dataKey = options.entity,
-    uniqueIdentifier = 'id'
+    uniqueIdentifier = 'id',
   } = options
 
   return {
     // Wrap standard CRUD operations to include updating the AppContext
-    create: async ({ data, context, setContext }) => {
+    create: contextUpdater(dataKey, async ({ data, context }) => {
       const existing = await context.apiClient[service][entity].list()
       const created = await context.apiClient[service][entity].create(data)
-      setContext({ [dataKey]: [ ...existing, created ] })
-      return created
-    },
+      return [...existing, created]
+    }, true),
 
-    list: async ({ params, context, setContext, reload }) => {
-      if (!reload && context[dataKey]) { return context[dataKey] }
-      const entities = await context.apiClient[service][entity].list(params)
-      await setContext({ [dataKey]: entities })
-      return entities
-    },
+    list: contextLoader(dataKey, async ({ params, context }) => {
+      return context.apiClient[service][entity].list(params)
+    }),
 
-    update: async ({ id, data, context, setContext }) => {
+    update: contextUpdater(dataKey, async ({ id, data, context }) => {
       const existing = await context.apiClient[service][entity].list()
       const updated = await context.apiClient[service][entity].update(id, data)
-      const newList = existing.map(x => x[uniqueIdentifier] === id ? x : updated)
-      setContext({ [dataKey]: newList })
-    },
+      return existing.map(x => x[uniqueIdentifier] === id ? x : updated)
+    }),
 
-    delete: async ({ id, context, setContext }) => {
+    delete: contextUpdater(dataKey, async ({ id, context }) => {
       await context.apiClient[service][entity].delete(id)
-      const newList = context[dataKey].filter(x => x[uniqueIdentifier] !== id)
-      setContext({ [dataKey]: newList })
-    }
+      return context[dataKey].filter(x => x[uniqueIdentifier] !== id)
+    }),
   }
 }
 

--- a/src/app/core/helpers/createCRUDComponents.js
+++ b/src/app/core/helpers/createCRUDComponents.js
@@ -56,7 +56,7 @@ const createCRUDComponents = options => {
   const List = withScopedPreferences(name)(({
     onAdd, onDelete, onEdit, rowActions, data,
     preferences: { visibleColumns, columnsOrder, rowsPerPage },
-    updatePreferences
+    updatePreferences,
   }) => {
     if (!data || data.length === 0) {
       return <h1>No data found.</h1>
@@ -118,16 +118,18 @@ const createCRUDComponents = options => {
 
   // ListPage
   const StandardListPage = () => (
-    <DataLoader dataKey={dataKey} loaders={loaderFn || crudActions.list}>
+    <DataLoader loaders={{ [dataKey]: loaderFn || crudActions.list }}>
       {({ data }) =>
         <React.Fragment>
-          <ListContainer data={data} />
-          {debug && <pre>{JSON.stringify(data, null, 4)}</pre>}
+          <ListContainer data={data[dataKey]} />
+          {debug && <pre>{JSON.stringify(data[dataKey], null, 4)}</pre>}
         </React.Fragment>
       }
     </DataLoader>
   )
-  const ListPage = requiresAuthentication(options.ListPage ? options.ListPage({ ListContainer }) : StandardListPage)
+  const ListPage = requiresAuthentication(options.ListPage
+    ? options.ListPage({ ListContainer })
+    : StandardListPage)
   ListPage.displayName = `${name}ListPage`
 
   return {

--- a/src/app/core/helpers/createCRUDComponents.js
+++ b/src/app/core/helpers/createCRUDComponents.js
@@ -118,7 +118,7 @@ const createCRUDComponents = options => {
 
   // ListPage
   const StandardListPage = () => (
-    <DataLoader dataKey={dataKey} loaderFn={loaderFn || crudActions.list}>
+    <DataLoader dataKey={dataKey} loaders={loaderFn || crudActions.list}>
       {({ data }) =>
         <React.Fragment>
           <ListContainer data={data} />

--- a/src/app/core/helpers/withCluster.js
+++ b/src/app/core/helpers/withCluster.js
@@ -1,8 +1,0 @@
-import { pathOr } from 'ramda'
-import { loadClusters } from 'k8s/components/infrastructure/actions'
-
-export const withCluster = cb => async ({ context, params = {}, ...rest }) => {
-  const clusters = (await loadClusters({ context, ...rest })).filter(x => x.hasMasterNode)
-  const { clusterId = pathOr('__all__', [0, 'uuid'], clusters) } = params
-  return cb({ params: { ...params, clusterId }, clusters, context, ...rest })
-}

--- a/src/app/core/helpers/withCluster.js
+++ b/src/app/core/helpers/withCluster.js
@@ -1,7 +1,8 @@
 import { pathOr } from 'ramda'
+import { loadClusters } from 'k8s/components/infrastructure/actions'
 
-export const withCluster = cb => ({ context, params = {}, ...rest }) => {
-  const clusters = (context.clusters || []).filter(x => x.hasMasterNode)
+export const withCluster = cb => async ({ context, params = {}, ...rest }) => {
+  const clusters = (await loadClusters({ context, ...rest })).filter(x => x.hasMasterNode)
   const { clusterId = pathOr('__all__', [0, 'uuid'], clusters) } = params
-  return cb({ params: { ...params, clusterId }, context, ...rest })
+  return cb({ params: { ...params, clusterId }, clusters, context, ...rest })
 }

--- a/src/app/plugins/kubernetes/components/apps/AppCatalogPage.js
+++ b/src/app/plugins/kubernetes/components/apps/AppCatalogPage.js
@@ -1,6 +1,5 @@
-import { withMultiLoader } from 'core/DataLoader'
 import { loadApps } from 'k8s/components/apps/actions'
-import { loadInfrastructure } from 'k8s/components/infrastructure/actions'
+import { loadClusters } from 'k8s/components/infrastructure/actions'
 import requiresAuthentication from 'openstack/util/requiresAuthentication'
 import { compose } from 'ramda'
 import React from 'react'
@@ -8,6 +7,7 @@ import { projectAs } from 'utils/fp'
 import CardTable from 'core/components/cardTable/CardTable'
 import ApplicationCard from 'core/components/appCatalog/AppCard'
 import moment from 'moment'
+import { withDataLoader } from 'core/DataLoader'
 
 class AppCatalogPage extends React.Component {
   sortingConfig = [
@@ -29,13 +29,13 @@ class AppCatalogPage extends React.Component {
       type: 'select',
       label: 'Cluster',
       onChange: async clusterId => {
-        this.props.reload('apps', { clusterId })
+        this.props.reloadData(loadApps, { clusterId })
       },
       items: projectAs(
         { label: 'name', value: 'uuid' },
         [
           { name: 'all', uuid: '__all__' },
-          ...(this.props.context.clusters || []).filter(cluster => cluster.hasMasterNode),
+          ...this.props.context.clusters.filter(cluster => cluster.hasMasterNode),
         ],
       ),
     },
@@ -62,12 +62,8 @@ class AppCatalogPage extends React.Component {
 
 export default compose(
   requiresAuthentication,
-  withMultiLoader(
-    {
-      clusters: loadInfrastructure,
-      apps: {
-        requires: 'clusters',
-        loaderFn: loadApps,
-      },
-    }),
+  withDataLoader([
+    loadClusters,
+    loadApps,
+  ]),
 )(AppCatalogPage)

--- a/src/app/plugins/kubernetes/components/apps/AppCatalogPage.js
+++ b/src/app/plugins/kubernetes/components/apps/AppCatalogPage.js
@@ -10,8 +10,6 @@ import moment from 'moment'
 import { withDataLoader } from 'core/DataLoader'
 
 class AppCatalogPage extends React.Component {
-  state = { clusterId: '__all__' }
-
   sortingConfig = [
     {
       field: 'attributes.name',
@@ -31,14 +29,13 @@ class AppCatalogPage extends React.Component {
       type: 'select',
       label: 'Cluster',
       onChange: async clusterId => {
-        this.setState({ clusterId })
-        this.props.reloadData(loadApps, { clusterId })
+        this.props.reloadData('apps', { clusterId })
       },
       items: projectAs(
         { label: 'name', value: 'uuid' },
         [
           { name: 'all', uuid: '__all__' },
-          ...this.props.context.clusters.filter(cluster => cluster.hasMasterNode),
+          ...this.props.data.clusters.filter(cluster => cluster.hasMasterNode),
         ],
       ),
     },
@@ -46,18 +43,17 @@ class AppCatalogPage extends React.Component {
 
   render () {
     const {
-      context: { apps = {} },
+      data: { apps },
     } = this.props
-    const { clusterId } = this.state
     return (
       <div className="applications">
         <CardTable
-          data={apps[clusterId]}
+          data={apps}
           sorting={this.sortingConfig}
           filters={this.filtersConfig()}
           searchTarget="attributes.name"
         >
-          {item => <ApplicationCard application={item} key={item.id} />}
+          {item => <ApplicationCard application={item} keyf={item.id} />}
         </CardTable>
       </div>
     )
@@ -66,8 +62,8 @@ class AppCatalogPage extends React.Component {
 
 export default compose(
   requiresAuthentication,
-  withDataLoader([
-    loadClusters,
-    loadApps,
-  ]),
+  withDataLoader({
+    clusters: loadClusters,
+    apps: loadApps,
+  }),
 )(AppCatalogPage)

--- a/src/app/plugins/kubernetes/components/apps/AppCatalogPage.js
+++ b/src/app/plugins/kubernetes/components/apps/AppCatalogPage.js
@@ -10,6 +10,8 @@ import moment from 'moment'
 import { withDataLoader } from 'core/DataLoader'
 
 class AppCatalogPage extends React.Component {
+  state = { clusterId: '__all__' }
+
   sortingConfig = [
     {
       field: 'attributes.name',
@@ -29,6 +31,7 @@ class AppCatalogPage extends React.Component {
       type: 'select',
       label: 'Cluster',
       onChange: async clusterId => {
+        this.setState({ clusterId })
         this.props.reloadData(loadApps, { clusterId })
       },
       items: projectAs(
@@ -43,12 +46,13 @@ class AppCatalogPage extends React.Component {
 
   render () {
     const {
-      context: { apps = [] },
+      context: { apps = {} },
     } = this.props
+    const { clusterId } = this.state
     return (
       <div className="applications">
         <CardTable
-          data={apps}
+          data={apps[clusterId]}
           sorting={this.sortingConfig}
           filters={this.filtersConfig()}
           searchTarget="attributes.name"

--- a/src/app/plugins/kubernetes/components/apps/DeployedAppsListPage.js
+++ b/src/app/plugins/kubernetes/components/apps/DeployedAppsListPage.js
@@ -2,7 +2,7 @@ import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import React from 'react'
 import SimpleLink from 'core/components/SimpleLink'
 import { loadReleases, deleteRelease } from 'k8s/components/apps/actions'
-import { loadInfrastructure } from 'k8s/components/infrastructure/actions'
+import { loadClusters } from 'k8s/components/infrastructure/actions'
 import { withAppContext } from 'core/AppContext'
 import Picklist from 'core/components/Picklist'
 import { compose, pathOr } from 'ramda'
@@ -123,5 +123,5 @@ const { ListPage: DeployedAppsListPage } = createCRUDComponents(options)
 
 export default compose(
   requiresAuthentication,
-  withDataLoader({ dataKey: 'clusters', loaderFn: loadInfrastructure }),
+  withDataLoader(loadClusters),
 )(DeployedAppsListPage)

--- a/src/app/plugins/kubernetes/components/apps/DeployedAppsListPage.js
+++ b/src/app/plugins/kubernetes/components/apps/DeployedAppsListPage.js
@@ -44,9 +44,9 @@ const ListPage = ({ ListContainer }) => {
     }
 
     async componentDidMount () {
-      const { context } = this.props
-      // Make sure to use a new reference to props.context since it has now changed
-      const clusters = context.clusters.filter(x => x.hasMasterNode)
+      const { data } = this.props
+      // Make sure to use a new reference to props.data since it has now changed
+      const clusters = data.clusters.filter(x => x.hasMasterNode)
       const clusterId = pathOr('__all__', [0, 'uuid'], clusters)
 
       await this.handleClusterChange(clusterId)
@@ -64,13 +64,13 @@ const ListPage = ({ ListContainer }) => {
     }
 
     findClusterName = clusterId => {
-      const cluster = this.props.context.clusters.find(x => x.uuid === clusterId)
+      const cluster = this.props.data.clusters.find(x => x.uuid === clusterId)
       return (cluster && cluster.name) || ''
     }
 
     render () {
       const { activeCluster } = this.state
-      const { releases = [], clusters = [] } = this.props.context
+      const { releases = [], clusters = [] } = this.props.data
       const filteredReleases = activeCluster === '__all__'
         ? releases
         : releases.filter(pod => pod.clusterId === activeCluster)
@@ -123,5 +123,5 @@ const { ListPage: DeployedAppsListPage } = createCRUDComponents(options)
 
 export default compose(
   requiresAuthentication,
-  withDataLoader(loadClusters),
+  withDataLoader({ clusters: loadClusters, releases: loadReleases }),
 )(DeployedAppsListPage)

--- a/src/app/plugins/kubernetes/components/apps/RepositoriesListPage.js
+++ b/src/app/plugins/kubernetes/components/apps/RepositoriesListPage.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import { loadRepositories, deleteRepository } from 'k8s/components/apps/actions'
-import { loadInfrastructure } from 'k8s/components/infrastructure/actions'
-import { withMultiLoader } from 'core/DataLoader'
+import { withDataLoader } from 'core/DataLoader'
+import { loadClusters } from 'k8s/components/infrastructure/actions'
 
 const ListPage = ({ ListContainer }) =>
-  ({ data: { repositories } }) => <ListContainer data={repositories} />
+  ({ context: { repositories } }) => <ListContainer data={repositories} />
 
 export const options = {
   columns: [
@@ -25,10 +25,6 @@ export const options = {
 
 const { ListPage: RepositoriesListPage } = createCRUDComponents(options)
 
-export default withMultiLoader({
-  clusters: loadInfrastructure,
-  repositories: {
-    requires: 'clusters',
-    loaderFn: loadRepositories
-  }
-})(RepositoriesListPage)
+export default withDataLoader(
+  [loadClusters, loadRepositories],
+)(RepositoriesListPage)

--- a/src/app/plugins/kubernetes/components/apps/RepositoriesListPage.js
+++ b/src/app/plugins/kubernetes/components/apps/RepositoriesListPage.js
@@ -26,5 +26,5 @@ export const options = {
 const { ListPage: RepositoriesListPage } = createCRUDComponents(options)
 
 export default withDataLoader(
-  [loadClusters, loadRepositories],
+  { clusters: loadClusters, repositories: loadRepositories },
 )(RepositoriesListPage)

--- a/src/app/plugins/kubernetes/components/apps/actions.js
+++ b/src/app/plugins/kubernetes/components/apps/actions.js
@@ -1,30 +1,32 @@
 import { flatten, prop, propEq } from 'ramda'
-import { withCluster } from 'core/helpers/withCluster'
+import clusterContextLoader from 'core/helpers/clusterContextLoader'
 import contextLoader from 'core/helpers/contextLoader'
 
 const getClusterApps = context => async cluster => {
   return context.apiClient.qbert.getCharts(cluster.uuid).then(prop('data'))
 }
 
-export const loadApps = contextLoader(({ clusterId }) => {
-  return ['apps', clusterId || '__all__']
-}, withCluster(async ({ context, clusters, params: { clusterId } }) => {
-  const loadClusterAppsFromContext = getClusterApps(context)
-  return clusterId === '__all__'
-    ? Promise.all(clusters.map(loadClusterAppsFromContext)).then(flatten)
-    : loadClusterAppsFromContext(clusters.find(propEq('uuid', clusterId)))
-}))
+export const loadApps = clusterContextLoader(
+  'apps',
+  async ({ context, clusters, params: { clusterId } }) => {
+    const loadClusterAppsFromContext = getClusterApps(context)
+    return clusterId === '__all__'
+      ? Promise.all(clusters.map(loadClusterAppsFromContext)).then(flatten)
+      : loadClusterAppsFromContext(clusters.find(propEq('uuid', clusterId)))
+  })
 
 const getClusterReleases = context => async cluster => {
   return context.apiClient.qbert.getReleases(cluster.uuid).then(prop('data'))
 }
 
-export const loadReleases = contextLoader('releases', withCluster(async ({ context, clusters, params: { clusterId } }) => {
-  const loadClusterReleasesFromContext = getClusterReleases(context)
-  return clusterId === '__all__'
-    ? Promise.all(clusters.map(loadClusterReleasesFromContext)).then(flatten)
-    : loadClusterReleasesFromContext(clusters.find(propEq('uuid', clusterId)))
-}))
+export const loadReleases = clusterContextLoader(
+  'releases',
+  async ({ context, clusters, params: { clusterId } }) => {
+    const loadClusterReleasesFromContext = getClusterReleases(context)
+    return clusterId === '__all__'
+      ? Promise.all(clusters.map(loadClusterReleasesFromContext)).then(flatten)
+      : loadClusterReleasesFromContext(clusters.find(propEq('uuid', clusterId)))
+  })
 
 export const deleteRelease = async ({ data, context, setContext, reload }) => {
   // TODO

--- a/src/app/plugins/kubernetes/components/apps/actions.js
+++ b/src/app/plugins/kubernetes/components/apps/actions.js
@@ -6,7 +6,9 @@ const getClusterApps = context => async cluster => {
   return context.apiClient.qbert.getCharts(cluster.uuid).then(prop('data'))
 }
 
-export const loadApps = contextLoader('apps', withCluster(async ({ context, clusters, params: { clusterId } }) => {
+export const loadApps = contextLoader(({ clusterId }) => {
+  return ['apps', clusterId || '__all__']
+}, withCluster(async ({ context, clusters, params: { clusterId } }) => {
   const loadClusterAppsFromContext = getClusterApps(context)
   return clusterId === '__all__'
     ? Promise.all(clusters.map(loadClusterAppsFromContext)).then(flatten)

--- a/src/app/plugins/kubernetes/components/infrastructure/AddClusterPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/AddClusterPage.js
@@ -14,7 +14,7 @@ import { compose, prop, propEq } from 'ramda'
 import { loadCloudProviders } from './actions'
 import { projectAs } from 'utils/fp'
 import { withAppContext } from 'core/AppContext'
-import { withMultiLoader } from 'core/DataLoader'
+import { withDataLoader } from 'core/DataLoader'
 
 const initialContext = {
   manualDeploy: false,
@@ -248,7 +248,7 @@ class AddClusterPage extends React.Component {
 }
 
 export default compose(
-  withMultiLoader({
+  withDataLoader({
     cloudProviders: loadCloudProviders,
     flavors: createCRUDActions({ service: 'nova', entity: 'flavors' }).list,
     regions: createCRUDActions({ service: 'keystone', entity: 'regions' }).list,

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
@@ -3,20 +3,13 @@ import ExternalLink from 'core/components/ExternalLink'
 import { compose } from 'ramda'
 import { withAppContext } from 'core/AppContext'
 import { withDataLoader } from 'core/DataLoader'
-import { attachNodesToCluster, loadInfrastructure } from './actions'
+import { attachNodesToCluster } from './actions'
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab'
 import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Table,
-  TableBody,
-  TableRow,
-  TableCell,
+  Button, Dialog, DialogActions, DialogContent, DialogTitle, Table, TableBody, TableRow, TableCell,
   Typography,
 } from '@material-ui/core'
+import { loadNodes } from 'k8s/components/infrastructure/actions'
 
 // The modal is technically inside the row, so clicking anything inside
 // the modal window will cause the table row to be toggled.
@@ -109,6 +102,6 @@ class ClusterAttachNodeDialog extends React.Component {
 }
 
 export default compose(
-  withDataLoader({ dataKey: 'nodes', loaderFn: loadInfrastructure }),
+  withDataLoader(loadNodes),
   withAppContext,
 )(ClusterAttachNodeDialog)

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterAttachNodeDialog.js
@@ -63,8 +63,8 @@ class ClusterAttachNodeDialog extends React.Component {
   }
 
   render () {
-    const { data } = this.props
-    const freeNodes = data.filter(x => !x.clusterUuid)
+    const { data: { nodes } } = this.props
+    const freeNodes = nodes.filter(x => !x.clusterUuid)
     return (
       <Dialog open onClose={this.handleClose} onClick={stopPropagation}>
         <DialogTitle>Attach Node to Cluster</DialogTitle>
@@ -72,15 +72,17 @@ class ClusterAttachNodeDialog extends React.Component {
           <p>
             <b>IMPORTANT</b>:
             Before adding nodes to a cluster, please ensure that you have followed the requirements
-            in <ExternalLink url="https://docs.platform9.com/getting-started/managed-container-cloud-requirements-checklist/">this article</ExternalLink> for
+            in <ExternalLink url="https://docs.platform9.com/getting-started/managed-container-cloud-requirements-checklist/">this
+            article</ExternalLink> for
             each node.
           </p>
 
           <p>
-            Choose the nodes you would like to add to this cluster as well as their corresponding role.
+            Choose the nodes you would like to add to this cluster as well as their corresponding
+            role.
           </p>
           {freeNodes.length === 0 &&
-            <Typography variant="h5">No nodes available to attach</Typography>
+          <Typography variant="h5">No nodes available to attach</Typography>
           }
           <Table>
             <TableBody>
@@ -102,6 +104,6 @@ class ClusterAttachNodeDialog extends React.Component {
 }
 
 export default compose(
-  withDataLoader(loadNodes),
+  withDataLoader({ nodes: loadNodes }),
   withAppContext,
 )(ClusterAttachNodeDialog)

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterDetachNodeDialog.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterDetachNodeDialog.js
@@ -2,20 +2,13 @@ import React from 'react'
 import { compose } from 'ramda'
 import { withAppContext } from 'core/AppContext'
 import { withDataLoader } from 'core/DataLoader'
-import { detachNodesFromCluster, loadInfrastructure } from './actions'
+import { detachNodesFromCluster } from './actions'
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab'
 import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Table,
-  TableBody,
-  TableRow,
-  TableCell,
+  Button, Dialog, DialogActions, DialogContent, DialogTitle, Table, TableBody, TableRow, TableCell,
   Typography,
 } from '@material-ui/core'
+import { loadNodes } from 'k8s/components/infrastructure/actions'
 
 // The modal is technically inside the row, so clicking anything inside
 // the modal window will cause the table row to be toggled.
@@ -114,6 +107,6 @@ class ClusterDetachNodeDialog extends React.Component {
 }
 
 export default compose(
-  withDataLoader({ dataKey: 'nodes', loaderFn: loadInfrastructure }),
+  withDataLoader(loadNodes),
   withAppContext,
 )(ClusterDetachNodeDialog)

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterDetachNodeDialog.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterDetachNodeDialog.js
@@ -62,7 +62,7 @@ class ClusterDetachNodeDialog extends React.Component {
   render () {
     const { data, row } = this.props
     const { name } = row
-    const attachedNodes = data.filter(node => node.clusterUuid === row.uuid)
+    const attachedNodes = data.nodes.filter(node => node.clusterUuid === row.uuid)
     return (
       <Dialog open onClose={this.handleClose} onClick={stopPropagation}>
         <DialogTitle>Detach node from cluster ({name})</DialogTitle>
@@ -107,6 +107,6 @@ class ClusterDetachNodeDialog extends React.Component {
 }
 
 export default compose(
-  withDataLoader(loadNodes),
+  withDataLoader({ nodes: loadNodes }),
   withAppContext,
 )(ClusterDetachNodeDialog)

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterInfo.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterInfo.js
@@ -36,7 +36,7 @@ const styles = theme => ({
 })
 
 const ClusterInfo = ({ match, data, context, classes }) => {
-  const cluster = data.find(x => x.uuid === match.params.id)
+  const cluster = data.clusters.find(x => x.uuid === match.params.id)
   const { usage } = clusterUsageStats(cluster, context)
   return (
     <React.Fragment>
@@ -67,5 +67,5 @@ export default compose(
   withStyles(styles),
   withRouter,
   withAppContext,
-  withDataLoader(loadClusters),
+  withDataLoader({ clusters: loadClusters }),
 )(ClusterInfo)

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterInfo.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterInfo.js
@@ -4,7 +4,7 @@ import UsageWidget from 'core/components/dashboardGraphs/UsageWidget'
 import clusterUsageStats from './clusterUsageStats'
 import { Grid } from '@material-ui/core'
 import { compose } from 'ramda'
-import { loadInfrastructure } from './actions'
+import { loadClusters } from './actions'
 import { withAppContext } from 'core/AppContext'
 import { withDataLoader } from 'core/DataLoader'
 import { withRouter } from 'react-router'
@@ -67,5 +67,5 @@ export default compose(
   withStyles(styles),
   withRouter,
   withAppContext,
-  withDataLoader({ dataKey: 'clusters', loaderFn: loadInfrastructure }),
+  withDataLoader(loadClusters),
 )(ClusterInfo)

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterNodes.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterNodes.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { withRouter } from 'react-router'
-import { withAppContext } from 'core/AppContext'
 import { compose } from 'ramda'
 import { loadClusters } from './actions'
 import { withDataLoader } from 'core/DataLoader'
@@ -8,6 +7,7 @@ import { withDataLoader } from 'core/DataLoader'
 // except that it is only the nodes from the a single cluster.
 import { columns } from './NodesListPage'
 import createListTableComponent from 'core/helpers/createListTableComponent'
+import { loadNodes } from 'k8s/components/infrastructure/actions'
 
 const ListTable = createListTableComponent({
   title: 'Cluster Nodes',
@@ -17,14 +17,13 @@ const ListTable = createListTableComponent({
   uniqueIdentifier: 'uuid',
 })
 
-const ClusterNodes = ({ context, data, match }) => {
-  const cluster = data.find(x => x.uuid === match.params.id)
-  const nodes = cluster.nodes.map(node => context.nodes.find(x => x.uuid === node.uuid))
+const ClusterNodes = ({ data, match }) => {
+  const cluster = data.clusters.find(x => x.uuid === match.params.id)
+  const nodes = cluster.nodes.map(node => data.nodes.find(x => x.uuid === node.uuid))
   return <ListTable data={nodes} />
 }
 
 export default compose(
   withRouter,
-  withAppContext,
-  withDataLoader(loadClusters),
+  withDataLoader({ clusters: loadClusters, nodes: loadNodes }),
 )(ClusterNodes)

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterNodes.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterNodes.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { withRouter } from 'react-router'
 import { withAppContext } from 'core/AppContext'
 import { compose } from 'ramda'
-import { loadInfrastructure } from './actions'
+import { loadClusters } from './actions'
 import { withDataLoader } from 'core/DataLoader'
 // This table essentially has the same functionality as the <NodesList>
 // except that it is only the nodes from the a single cluster.
@@ -26,5 +26,5 @@ const ClusterNodes = ({ context, data, match }) => {
 export default compose(
   withRouter,
   withAppContext,
-  withDataLoader({ dataKey: 'clusters', loaderFn: loadInfrastructure }),
+  withDataLoader(loadClusters),
 )(ClusterNodes)

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterScaleDialog.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterScaleDialog.js
@@ -5,9 +5,9 @@ import ValidatedForm from 'core/components/validatedForm/ValidatedForm'
 import { Slider } from '@material-ui/lab'
 import { compose, pick } from 'ramda'
 import { withAppContext } from 'core/AppContext'
-import { withDataLoader } from 'core/DataLoader'
-import { scaleCluster, loadInfrastructure } from './actions'
+import { scaleCluster, loadClusters } from './actions'
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@material-ui/core'
+import { withDataLoader } from 'core/DataLoader'
 
 // The modal is technically inside the row, so clicking anything inside
 // the modal window will cause the table row to be toggled.
@@ -64,6 +64,6 @@ class ClusterScaleDialog extends React.Component {
 }
 
 export default compose(
-  withDataLoader({ dataKey: 'clusters', loaderFn: loadInfrastructure }),
+  withDataLoader(loadClusters),
   withAppContext,
 )(ClusterScaleDialog)

--- a/src/app/plugins/kubernetes/components/infrastructure/ClusterScaleDialog.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClusterScaleDialog.js
@@ -64,6 +64,6 @@ class ClusterScaleDialog extends React.Component {
 }
 
 export default compose(
-  withDataLoader(loadClusters),
+  withDataLoader({ clusters: loadClusters }),
   withAppContext,
 )(ClusterScaleDialog)

--- a/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/ClustersListPage.js
@@ -9,7 +9,7 @@ import AttachIcon from '@material-ui/icons/AddToQueue'
 import DetachIcon from '@material-ui/icons/RemoveFromQueue'
 import ScaleIcon from '@material-ui/icons/TrendingUp'
 import UpgradeIcon from '@material-ui/icons/PresentToAll'
-import { deleteCluster, loadInfrastructure } from './actions'
+import { deleteCluster, loadClusters } from './actions'
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import ClusterAttachNodeDialog from './ClusterAttachNodeDialog'
 import ClusterDetachNodeDialog from './ClusterDetachNodeDialog'
@@ -77,7 +77,7 @@ export const options = {
   ],
   dataKey: 'clusters',
   editUrl: '/ui/kubernetes/infrastructure/clusters/edit',
-  loaderFn: loadInfrastructure,
+  loaderFn: loadClusters,
   deleteFn: deleteCluster,
   name: 'Clusters',
   title: 'Clusters',

--- a/src/app/plugins/kubernetes/components/infrastructure/NodesChooser.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/NodesChooser.js
@@ -2,9 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import MultiSelect from 'core/components/MultiSelect'
 import { allPass, compose } from 'ramda'
-import { loadInfrastructure } from './actions'
 import { withDataLoader } from 'core/DataLoader'
 import { withInfoTooltip } from 'core/components/InfoTooltip'
+import { loadCombinedHosts } from 'k8s/components/infrastructure/actions'
 
 class NodesChooser extends React.Component {
   state = {
@@ -52,6 +52,6 @@ NodesChooser.propTypes = {
 }
 
 export default compose(
-  withDataLoader({ dataKey: 'combinedHosts', loaderFn: loadInfrastructure }),
+  withDataLoader(loadCombinedHosts),
   withInfoTooltip,
 )(NodesChooser)

--- a/src/app/plugins/kubernetes/components/infrastructure/NodesChooser.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/NodesChooser.js
@@ -52,6 +52,6 @@ NodesChooser.propTypes = {
 }
 
 export default compose(
-  withDataLoader(loadCombinedHosts),
+  withDataLoader({ combinedHosts: loadCombinedHosts }),
   withInfoTooltip,
 )(NodesChooser)

--- a/src/app/plugins/kubernetes/components/infrastructure/NodesListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/NodesListPage.js
@@ -7,7 +7,7 @@ import ProgressBar from 'core/components/ProgressBar'
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import { pathOr, pipe } from 'ramda'
 import { castBoolToStr, castFuzzyBool, columnPathLookup } from 'utils/misc'
-import { loadInfrastructure } from './actions'
+import { loadNodes } from 'k8s/components/infrastructure/actions'
 
 const renderStatus = (_, node) => (<HostStatus host={node.combined} />)
 const isMaster = pipe(castFuzzyBool, castBoolToStr())
@@ -64,7 +64,7 @@ export const options = {
   columns,
   dataKey: 'nodes',
   editUrl: '/ui/kubernetes/infrastructure/nodes/edit',
-  loaderFn: loadInfrastructure,
+  loaderFn: loadNodes,
   name: 'Nodes',
   title: 'Nodes',
   uniqueIdentifier: 'uuid',

--- a/src/app/plugins/kubernetes/components/infrastructure/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/actions.js
@@ -1,30 +1,21 @@
-import { asyncFlatMap, asyncMap, pathOrNull, pipeWhenTruthy, tap } from 'app/utils/fp'
+import { asyncFlatMap, asyncMap, pathOrNull, pipeWhenTruthy } from 'app/utils/fp'
 import { find, pathOr, pluck, prop, propEq } from 'ramda'
 import { castFuzzyBool } from 'utils/misc'
 import { combineHost } from './combineHosts'
-
-export const loadClusters = async ({ context, setContext, reload }) => {
-  if (!reload && context.clusters) { return context.clusters }
-  const clusters = await context.apiClient.qbert.getClusters()
-  setContext({ clusters })
-  return clusters
-}
+import contextLoader from 'core/helpers/contextLoader'
+import contextUpdater from 'core/helpers/contextUpdater'
 
 export const deleteCluster = async ({ id, context, setContext }) => {
   await context.apiClient.qbert.deleteCluster(id)
-  const clusters = context.clusters.filter(x => x.uuid !== id)
-  setContext({ clusters })
-  // Force refresh using 'loadInfrastructure' since combinedHosts will still
+  // Refresh clusters since combinedHosts will still
   // have references to the deleted cluster.
-  loadInfrastructure({ context, setContext, reload: true })
+  const clusters = await loadClusters({ context })
+  setContext({ clusters })
 }
 
-export const loadCloudProviders = async ({ context, setContext, reload }) => {
-  if (!reload && context.cloudProviders) { return context.cloudProviders }
-  const cloudProviders = await context.apiClient.qbert.getCloudProviders()
-  setContext({ cloudProviders })
-  return cloudProviders
-}
+export const loadCloudProviders = contextLoader('cloudProviders', async ({ context }) => {
+  return context.apiClient.qbert.getCloudProviders()
+})
 
 export const createCloudProvider = ({ data, context }) =>
   context.apiClient.qbert.createCloudProvider(data)
@@ -32,46 +23,34 @@ export const createCloudProvider = ({ data, context }) =>
 export const updateCloudProvider = ({ id, data, context }) =>
   context.apiClient.qbert.updateCloudProvider(id, data)
 
-export const deleteCloudProvider = async ({ id, context, setContext }) => {
+export const deleteCloudProvider = contextUpdater('cloudProviders', async ({ id, context }) => {
   await context.apiClient.qbert.deleteCloudProvider(id)
-  const newCps = context.cloudProviders.filter(x => x.uuid !== id)
-  setContext({ cloudProviders: newCps })
-}
-
-export const loadNodes = async ({ context, setContext, reload }) => {
-  if (!reload && context.nodes) { return context.nodes }
-  // TODO: Get nodes is not yet implemented
-  // const nodes = await context.apiClient.qbert.getNodes()
-  const nodes = []
-  setContext({ nodes })
-  return nodes
-}
+  return context.cloudProviders.filter(x => x.uuid !== id)
+})
 
 export const createCluster = async ({ data, context }) => {
   console.log('createCluster TODO')
   console.log(data)
 }
 
-export const attachNodesToCluster = async ({ data, context, setContext }) => {
+export const attachNodesToCluster = contextUpdater('nodes', async ({ data, context }) => {
   const { clusterUuid, nodes } = data
   const nodeUuids = pluck('uuid', nodes)
   await context.apiClient.qbert.attach(clusterUuid, nodes)
   // Assign nodes to their clusters in the context as well so the user
   // can't add the same node to another cluster.
-  const newNodes = context.nodes.map(node =>
+  return context.nodes.map(node =>
     nodeUuids.includes(node.uuid) ? ({ ...node, clusterUuid }) : node)
-  setContext({ nodes: newNodes })
-}
+})
 
-export const detachNodesFromCluster = async ({ data, context, setContext }) => {
+export const detachNodesFromCluster = contextUpdater('nodes', async ({ data, context, setContext }) => {
   const { clusterUuid, nodeUuids } = data
   await context.apiClient.qbert.detach(clusterUuid, nodeUuids)
-  const newNodes = context.nodes.map(node =>
+  return context.nodes.map(node =>
     nodeUuids.includes(node.uuid) ? ({ ...node, clusterUuid: null }) : node)
-  setContext({ nodes: newNodes })
-}
+})
 
-export const scaleCluster = async ({ data, context, setContext }) => {
+export const scaleCluster = async ({ data, context }) => {
   const { cluster, numSpotWorkers, numWorkers, spotPrice } = data
   const body = {
     numWorkers,
@@ -82,136 +61,131 @@ export const scaleCluster = async ({ data, context, setContext }) => {
   await context.apiClient.qbert.updateCluster(cluster.uuid, body)
 }
 
-/*
- * The data model needed in the UI requires interwoven dependencies between
- * nodes, clusters, and namespaces.  Ideally the API would be more aligned
- * with the use case but in the meanwhile we are going to put the business
- * logic here.
- *
- * Also, inasmuch as possible, we `setContext` with a bare minimum version of
- * the data so the UI can display something sooner.  Then we make additional
- * API calls and use additional `setContext` calls to fill in the remaining
- * details.
- */
-export const loadInfrastructure = async ({ context, setContext, reload }) => {
-  if (reload || !context.namespaces || !context.clusters || !context.nodes) {
-    const { qbert, resmgr } = context.apiClient
+const loadRawNodes = contextLoader('rawNodes', async ({ context }) => {
+  const { qbert } = context.apiClient
+  return qbert.getNodes()
+})
 
-    // First `setContext` as the data arrive so we can at least render something.
-    const [rawClusters, nodes] = await Promise.all([
-      qbert.getClusters().then(tap(clusters => setContext({ clusters }))),
-      qbert.getNodes().then(tap(nodes => setContext({ nodes }))),
-    ])
-    const qbertEndpoint = await qbert.baseUrl()
+export const loadClusters = contextLoader('clusters', async (params) => {
+  const { context } = params
+  const { qbert } = context.apiClient
+  const [rawNodes, rawClusters, qbertEndpoint] = await Promise.all([
+    loadRawNodes(params),
+    qbert.getClusters(),
+    qbert.baseUrl(),
+  ])
 
-    // Then fill out the derived data
-    const clusters = rawClusters.map(cluster => {
-      const nodesInCluster = nodes.filter(node => node.clusterUuid === cluster.uuid)
-      const masterNodes = nodesInCluster.filter(node => node.isMaster === 1)
-      const healthyMasterNodes = masterNodes.filter(node => node.status === 'ok' && node.api_responding === 1)
-      const clusterOk = nodesInCluster.length > 0 && cluster.status === 'ok'
-      const dashboardLink =`${qbertEndpoint}/clusters/${cluster.uuid}/k8sapi/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:443/proxy/`
-      const host = qbertEndpoint.match(/(.*?)\/qbert/)[1]
-      const fuzzyBools = ['allowWorkloadsOnMaster', 'privileged', 'appCatalogEnabled'].reduce(
-        (accum, key) => {
-          accum[key] = castFuzzyBool(cluster[key])
-          return accum
-        },
-        {}
-      )
-      return {
-        ...cluster,
-        nodes: nodesInCluster,
-        masterNodes,
-        healthyMasterNodes,
-        hasMasterNode: healthyMasterNodes.length > 0,
-        highlyAvailable: healthyMasterNodes.length > 2,
-        links: {
-          dashboard: clusterOk ? dashboardLink : null,
-          // Rendering happens in <DownloadKubeConfigLink />
-          kubeconfig: clusterOk ? { cluster }: null,
-          // Rendering happens in <ClusterCLI />
-          cli: clusterOk ? { host, cluster }: null,
-        },
-        ...fuzzyBools,
-        hasVpn: castFuzzyBool(pathOr(false, ['cloudProperties', 'internalElb'], cluster)),
-        hasLoadBalancer: castFuzzyBool(cluster.enableMetallb || pathOr(false, ['cloudProperties', 'enableLbaas'], cluster))
-      }
-    })
-    setContext({ clusters })
-
-    let _clusters = clusters.slice()
-    asyncMap(_clusters, async cluster => {
-      if (cluster.hasMasterNode) {
-        try {
-          const version = await qbert.getKubernetesVersion(cluster.uuid)
-          return {
-            ...cluster,
-            version: version && version.gitVersion && version.gitVersion.substr(1),
-          }
-        } catch (err) {
-          console.log(err)
-          return cluster
-        }
-      } else {
-        return cluster
-      }
-    }).then(clustersWithVersions => setContext({ clusters: clustersWithVersions }))
-
-    const masterNodeClusters = clusters.filter(x => x.hasMasterNode)
-    asyncFlatMap(masterNodeClusters, cluster => qbert.getClusterNamespaces(cluster.uuid))
-      .then(namespaces => setContext({ namespaces }))
-
-    let hostsById = {}
-    // We don't want to perform a check to see if the object exists yet for each type of host
-    // so make a utility to make it cleaner.
-    const setHost = (type, id, value) => {
-      hostsById[id] = hostsById[id] || {}
-      hostsById[id][type] = value
-    }
-    nodes.forEach(node => setHost('qbert', node.uuid, node))
-    await Promise.all([
-      resmgr.getHosts().then(
-        resmgrHosts => {
-          resmgrHosts.forEach(resmgrHost => setHost('resmgr', resmgrHost.id, resmgrHost))
-          setContext({ resmgrHosts })
-        }
-      ),
-      // TODO: include nova hosts here as well
-    ])
-
-    // Convert it back to array form
-    const combinedHosts = Object.values(hostsById).map(combineHost)
-    const combinedHostsObj = combinedHosts.reduce(
-      (accum, host) => {
-        const id = pathOrNull('resmgr.id')(host) || pathOrNull('qbert.uuid')(host)
-        accum[id] = host
+  const clusters = rawClusters.map(cluster => {
+    const nodesInCluster = rawNodes.filter(node => node.clusterUuid === cluster.uuid)
+    const masterNodes = nodesInCluster.filter(node => node.isMaster === 1)
+    const healthyMasterNodes = masterNodes.filter(
+      node => node.status === 'ok' && node.api_responding === 1)
+    const clusterOk = nodesInCluster.length > 0 && cluster.status === 'ok'
+    const dashboardLink = `${qbertEndpoint}/clusters/${cluster.uuid}/k8sapi/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:443/proxy/`
+    const host = qbertEndpoint.match(/(.*?)\/qbert/)[1]
+    const fuzzyBools = ['allowWorkloadsOnMaster', 'privileged', 'appCatalogEnabled'].reduce(
+      (accum, key) => {
+        accum[key] = castFuzzyBool(cluster[key])
         return accum
       },
-      {}
+      {},
     )
+    return {
+      ...cluster,
+      nodes: nodesInCluster,
+      masterNodes,
+      healthyMasterNodes,
+      hasMasterNode: healthyMasterNodes.length > 0,
+      highlyAvailable: healthyMasterNodes.length > 2,
+      links: {
+        dashboard: clusterOk ? dashboardLink : null,
+        // Rendering happens in <DownloadKubeConfigLink />
+        kubeconfig: clusterOk ? { cluster } : null,
+        // Rendering happens in <ClusterCLI />
+        cli: clusterOk ? { host, cluster } : null,
+      },
+      ...fuzzyBools,
+      hasVpn: castFuzzyBool(pathOr(false, ['cloudProperties', 'internalElb'], cluster)),
+      hasLoadBalancer: castFuzzyBool(cluster.enableMetallb || pathOr(false, ['cloudProperties', 'enableLbaas'], cluster)),
+    }
+  })
+  // Get the cluster versions in parallel
+  return asyncMap(clusters, async cluster => {
+    if (cluster.hasMasterNode) {
+      try {
+        const version = await qbert.getKubernetesVersion(cluster.uuid)
+        return {
+          ...cluster,
+          version: version && version.gitVersion && version.gitVersion.substr(1),
+        }
+      } catch (err) {
+        console.log(err)
+        return cluster
+      }
+    } else {
+      return cluster
+    }
+  }, true)
+})
 
-    setContext({ combinedHosts })
+export const loadResMgrHosts = contextLoader('resmgrHosts', async ({ context }) => {
+  const { resmgr } = context.apiClient
+  return resmgr.getHosts()
+})
 
-    const qbertUrl = pipeWhenTruthy(
-      find(propEq('name', 'qbert')),
-      prop('url')
-    )(context.serviceCatalog) || ''
+export const loadCombinedHosts = contextLoader('combinedHosts', async params => {
+  const [rawNodes, resmgrHosts] = Promise.all([
+    loadRawNodes(params),
+    loadResMgrHosts(params),
+  ])
 
-    // associate nodes with the combinedHost entry
-    const nodesCombined = nodes.map(node => ({
-      ...node,
-      combined: combinedHostsObj[node.uuid],
-      logs: `${qbertUrl}/logs/${node.uuid}`
-    }))
-    setContext({ nodes: nodesCombined })
-
-    return { nodes: nodesCombined, clusters, namespaces: [] }
+  let hostsById = {}
+  // We don't want to perform a check to see if the object exists yet for each type of host
+  // so make a utility to make it cleaner.
+  const setHost = (type, id, value) => {
+    hostsById[id] = hostsById[id] || {}
+    hostsById[id][type] = value
   }
+  rawNodes.forEach(node => setHost('qbert', node.uuid, node))
+  resmgrHosts.forEach(resmgrHost => setHost('resmgr', resmgrHost.id, resmgrHost))
 
-  return {
-    nodes: context.nodes,
-    namespaces: context.namespaces,
-    clusters: context.clusters,
-  }
-}
+  // Convert it back to array form
+  return Object.values(hostsById).map(combineHost)
+})
+
+export const loadNamespaces = contextLoader('namespaces', async params => {
+  const { context } = params
+  const { qbert } = context.apiClient
+  const clusters = await loadClusters(params)
+  const masterNodeClusters = clusters.filter(x => x.hasMasterNode)
+
+  return asyncFlatMap(masterNodeClusters, cluster => qbert.getClusterNamespaces(cluster.uuid))
+})
+
+export const loadNodes = contextLoader('nodes', async params => {
+  const [rawNodes, combinedHosts] = await Promise.all([
+    loadRawNodes(params),
+    loadCombinedHosts(params),
+  ])
+
+  const combinedHostsObj = combinedHosts.reduce(
+    (accum, host) => {
+      const id = pathOrNull('resmgr.id')(host) || pathOrNull('qbert.uuid')(host)
+      accum[id] = host
+      return accum
+    },
+    {},
+  )
+
+  const qbertUrl = pipeWhenTruthy(
+    find(propEq('name', 'qbert')),
+    prop('url'),
+  )(context.serviceCatalog) || ''
+
+  // associate nodes with the combinedHost entry
+  return rawNodes.map(node => ({
+    ...node,
+    combined: combinedHostsObj[node.uuid],
+    logs: `${qbertUrl}/logs/${node.uuid}`,
+  }))
+})

--- a/src/app/plugins/kubernetes/components/infrastructure/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/actions.js
@@ -134,7 +134,7 @@ export const loadResMgrHosts = contextLoader('resmgrHosts', async ({ context }) 
 })
 
 export const loadCombinedHosts = contextLoader('combinedHosts', async params => {
-  const [rawNodes, resmgrHosts] = Promise.all([
+  const [rawNodes, resmgrHosts] = await Promise.all([
     loadRawNodes(params),
     loadResMgrHosts(params),
   ])

--- a/src/app/plugins/kubernetes/components/infrastructure/combineHosts.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/combineHosts.js
@@ -1,5 +1,5 @@
 import { condLiteral, pathOrNull, pipe } from 'app/utils/fp'
-import { __, both, contains, T } from 'ramda'
+import { __, both, includes, T } from 'ramda'
 import { localizeRoles } from 'api-client/ResMgr'
 import moment from 'moment'
 
@@ -20,8 +20,8 @@ const k8sRoles = ['Containervisor']
 
 export const annotateCloudStack = host => {
   const localizedRoles = localizeRoles(host.roles)
-  const isOpenStack = () => localizedRoles.some(contains(__, openstackRoles))
-  const isK8s = () => localizedRoles.some(contains(__, k8sRoles))
+  const isOpenStack = () => localizedRoles.some(includes(__, openstackRoles))
+  const isK8s = () => localizedRoles.some(includes(__, k8sRoles))
   const cloudStack =
     condLiteral(
       [both(isOpenStack, isK8s), 'both'],

--- a/src/app/plugins/kubernetes/components/namespaces/AddNamespacePage.js
+++ b/src/app/plugins/kubernetes/components/namespaces/AddNamespacePage.js
@@ -4,7 +4,7 @@ import PicklistField from 'core/components/validatedForm/PicklistField'
 import SubmitButton from 'core/components/SubmitButton'
 import TextField from 'core/components/validatedForm/TextField'
 import createAddComponents from 'core/helpers/createAddComponents'
-import { loadInfrastructure } from '../infrastructure/actions'
+import { loadClusters } from '../infrastructure/actions'
 import { createNamespace } from './actions'
 
 export class AddNamespaceForm extends React.Component {
@@ -14,8 +14,6 @@ export class AddNamespaceForm extends React.Component {
   }
 
   async componentDidMount () {
-    const { context, setContext } = this.props
-    await loadInfrastructure({ context, setContext })
     // Make sure to use the new reference to context.  It changes after loadInfrastucture.
     const clusterOptions = this.props.context.clusters.map(c => ({ value: c.uuid, label: c.name }))
     this.setState({ clusterOptions })
@@ -46,7 +44,7 @@ export class AddNamespaceForm extends React.Component {
 export const options = {
   FormComponent: AddNamespaceForm,
   createFn: createNamespace,
-  loaderFn: loadInfrastructure,
+  loaderFn: loadClusters,
   listUrl: '/ui/kubernetes/namespaces',
   name: 'AddNamespace',
   title: 'Add Namespace',

--- a/src/app/plugins/kubernetes/components/namespaces/NamespacesListPage.js
+++ b/src/app/plugins/kubernetes/components/namespaces/NamespacesListPage.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import Picklist from 'core/components/Picklist'
-import createCRUDComponents from 'core/helpers/createCRUDComponents'
-import { loadInfrastructure } from '../infrastructure/actions'
-import { deleteNamespace } from './actions'
-import { withDataLoader } from 'core/DataLoader'
 import { projectAs } from 'utils/fp'
 import { prop, head } from 'ramda'
+import { loadClusters, loadNamespaces } from 'k8s/components/infrastructure/actions'
+import Picklist from 'core/components/Picklist'
+import { withDataLoader } from 'core/DataLoader'
+import { deleteNamespace } from 'k8s/components/namespaces/actions'
+import createCRUDComponents from 'core/helpers/createCRUDComponents'
 
 const ListPage = ({ ListContainer }) => {
   class ListPage extends React.Component {
@@ -53,11 +53,10 @@ const ListPage = ({ ListContainer }) => {
     }
   }
 
-  return withDataLoader(
-    {
-      dataKey: 'clusters',
-      loaderFn: loadInfrastructure,
-    })(ListPage)
+  return withDataLoader({
+    clusters: loadClusters,
+    namespaces: loadNamespaces,
+  })(ListPage)
 }
 
 export const options = {

--- a/src/app/plugins/kubernetes/components/namespaces/actions.js
+++ b/src/app/plugins/kubernetes/components/namespaces/actions.js
@@ -1,14 +1,14 @@
-export const createNamespace = async ({ data, context, setContext }) => {
+import contextUpdater from 'core/helpers/contextUpdater'
+
+export const createNamespace = contextUpdater('namespaces', async ({ data, context }) => {
   const { clusterId, name } = data
   const body = { metadata: { name } }
   const created = await context.apiClient.qbert.createNamespace(clusterId, body)
-  setContext({ namespaces: [ ...context.namespaces, created ] })
-  return created
-}
+  return [...context.namespaces, created]
+}, true)
 
-export const deleteNamespace = async ({ id, context, setContext }) => {
+export const deleteNamespace = contextUpdater('namespaces', async ({ id, context }) => {
   const { clusterId, name } = await context.namespaces.find(x => x.id === id)
   await context.apiClient.qbert.deleteNamespace(clusterId, name)
-  const newList = context.namespaces.filter(x => x.id !== id)
-  setContext({ namespaces: newList })
-}
+  return context.namespaces.filter(x => x.id !== id)
+})

--- a/src/app/plugins/kubernetes/components/pods/AddDeploymentPage.js
+++ b/src/app/plugins/kubernetes/components/pods/AddDeploymentPage.js
@@ -24,13 +24,13 @@ export class AddDeploymentForm extends React.Component {
 
   render () {
     const { namespaceOptions } = this.state
-    const { context, onComplete } = this.props
+    const { data, onComplete } = this.props
 
     const codeMirrorOptions = {
       mode: 'yaml',
     }
 
-    const clusterOptions = context.clusters ? projectAs({ value: 'uuid', label: 'name' }, context.clusters) : []
+    const clusterOptions = data.clusters ? projectAs({ value: 'uuid', label: 'name' }, data.clusters) : []
 
     return (
       <ValidatedForm onSubmit={onComplete}>
@@ -66,5 +66,5 @@ export const options = {
 const { AddPage } = createAddComponents(options)
 
 export default compose(
-  withDataLoader(loadClusters),
+  withDataLoader({ clusters: loadClusters }),
 )(AddPage)

--- a/src/app/plugins/kubernetes/components/pods/AddDeploymentPage.js
+++ b/src/app/plugins/kubernetes/components/pods/AddDeploymentPage.js
@@ -4,7 +4,7 @@ import PicklistField from 'core/components/validatedForm/PicklistField'
 import SubmitButton from 'core/components/SubmitButton'
 import createAddComponents from 'core/helpers/createAddComponents'
 import { projectAs } from 'utils/fp'
-import { loadInfrastructure } from '../infrastructure/actions'
+import { loadClusters } from '../infrastructure/actions'
 import { loadDeployments, createDeployment } from './actions'
 import { withDataLoader } from 'core/DataLoader'
 import CodeMirror from 'core/components/validatedForm/CodeMirror'
@@ -66,5 +66,5 @@ export const options = {
 const { AddPage } = createAddComponents(options)
 
 export default compose(
-  withDataLoader({ dataKey: 'clusters', loaderFn: loadInfrastructure }),
+  withDataLoader(loadClusters),
 )(AddPage)

--- a/src/app/plugins/kubernetes/components/pods/AddPodPage.js
+++ b/src/app/plugins/kubernetes/components/pods/AddPodPage.js
@@ -4,7 +4,7 @@ import PicklistField from 'core/components/validatedForm/PicklistField'
 import SubmitButton from 'core/components/SubmitButton'
 import createAddComponents from 'core/helpers/createAddComponents'
 import { projectAs } from 'utils/fp'
-import { loadClusters } from '../infrastructure/actions'
+import { loadClusters, loadNamespaces } from '../infrastructure/actions'
 import { loadPods, createPod } from './actions'
 import { withDataLoader } from 'core/DataLoader'
 import CodeMirror from 'core/components/validatedForm/CodeMirror'
@@ -17,20 +17,20 @@ export class AddPodForm extends React.Component {
   }
 
   handleClusterChange = value => {
-    const { context } = this.props
-    const namespaceOptions = context.namespaces.filter(n => n.clusterId === value).map(n => ({ value: n.name, label: n.name }))
+    const { data } = this.props
+    const namespaceOptions = data.namespaces.filter(n => n.clusterId === value).map(n => ({ value: n.name, label: n.name }))
     this.setState({ namespaceOptions })
   }
 
   render () {
     const { namespaceOptions } = this.state
-    const { context, onComplete } = this.props
+    const { data, onComplete } = this.props
 
     const codeMirrorOptions = {
       mode: 'yaml',
     }
 
-    const clusterOptions = context.clusters ? projectAs({ value: 'uuid', label: 'name' }, context.clusters) : []
+    const clusterOptions = data.clusters ? projectAs({ value: 'uuid', label: 'name' }, data.clusters) : []
 
     return (
       <ValidatedForm onSubmit={onComplete}>
@@ -69,5 +69,5 @@ export const options = {
 const { AddPage } = createAddComponents(options)
 
 export default compose(
-  withDataLoader(loadClusters),
+  withDataLoader({ clusters: loadClusters, namespaces: loadNamespaces }),
 )(AddPage)

--- a/src/app/plugins/kubernetes/components/pods/AddPodPage.js
+++ b/src/app/plugins/kubernetes/components/pods/AddPodPage.js
@@ -4,7 +4,7 @@ import PicklistField from 'core/components/validatedForm/PicklistField'
 import SubmitButton from 'core/components/SubmitButton'
 import createAddComponents from 'core/helpers/createAddComponents'
 import { projectAs } from 'utils/fp'
-import { loadInfrastructure } from '../infrastructure/actions'
+import { loadClusters } from '../infrastructure/actions'
 import { loadPods, createPod } from './actions'
 import { withDataLoader } from 'core/DataLoader'
 import CodeMirror from 'core/components/validatedForm/CodeMirror'
@@ -69,5 +69,5 @@ export const options = {
 const { AddPage } = createAddComponents(options)
 
 export default compose(
-  withDataLoader({ dataKey: 'clusters', loaderFn: loadInfrastructure }),
+  withDataLoader(loadClusters),
 )(AddPage)

--- a/src/app/plugins/kubernetes/components/pods/AddServicePage.js
+++ b/src/app/plugins/kubernetes/components/pods/AddServicePage.js
@@ -4,11 +4,11 @@ import PicklistField from 'core/components/validatedForm/PicklistField'
 import SubmitButton from 'core/components/SubmitButton'
 import createAddComponents from 'core/helpers/createAddComponents'
 import { projectAs } from 'utils/fp'
-import { loadInfrastructure } from '../infrastructure/actions'
 import { loadServices, createService } from './actions'
 import { withDataLoader } from 'core/DataLoader'
 import CodeMirror from 'core/components/validatedForm/CodeMirror'
 import { compose } from 'ramda'
+import { loadClusters } from 'k8s/components/infrastructure/actions'
 
 export class AddServiceForm extends React.Component {
   state = {
@@ -66,5 +66,5 @@ export const options = {
 const { AddPage } = createAddComponents(options)
 
 export default compose(
-  withDataLoader({ dataKey: 'clusters', loaderFn: loadInfrastructure }),
+  withDataLoader(loadClusters),
 )(AddPage)

--- a/src/app/plugins/kubernetes/components/pods/AddServicePage.js
+++ b/src/app/plugins/kubernetes/components/pods/AddServicePage.js
@@ -8,7 +8,7 @@ import { loadServices, createService } from './actions'
 import { withDataLoader } from 'core/DataLoader'
 import CodeMirror from 'core/components/validatedForm/CodeMirror'
 import { compose } from 'ramda'
-import { loadClusters } from 'k8s/components/infrastructure/actions'
+import { loadClusters, loadNamespaces } from 'k8s/components/infrastructure/actions'
 
 export class AddServiceForm extends React.Component {
   state = {
@@ -17,20 +17,20 @@ export class AddServiceForm extends React.Component {
   }
 
   handleClusterChange = value => {
-    const { context } = this.props
-    const namespaceOptions = context.namespaces.filter(n => n.clusterId === value).map(n => ({ value: n.name, label: n.name }))
+    const { data } = this.props
+    const namespaceOptions = data.namespaces.filter(n => n.clusterId === value).map(n => ({ value: n.name, label: n.name }))
     this.setState({ namespaceOptions })
   }
 
   render () {
     const { namespaceOptions } = this.state
-    const { context, onComplete } = this.props
+    const { data, onComplete } = this.props
 
     const codeMirrorOptions = {
       mode: 'yaml',
     }
 
-    const clusterOptions = context.clusters ? projectAs({ value: 'uuid', label: 'name' }, context.clusters) : []
+    const clusterOptions = data.clusters ? projectAs({ value: 'uuid', label: 'name' }, data.clusters) : []
 
     return (
       <ValidatedForm onSubmit={onComplete}>
@@ -66,5 +66,5 @@ export const options = {
 const { AddPage } = createAddComponents(options)
 
 export default compose(
-  withDataLoader(loadClusters),
+  withDataLoader({ clusters: loadClusters, namespaces: loadNamespaces }),
 )(AddPage)

--- a/src/app/plugins/kubernetes/components/pods/DeploymentsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/DeploymentsListPage.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import Picklist from 'core/components/Picklist'
-import createCRUDComponents from 'core/helpers/createCRUDComponents'
-import { loadInfrastructure } from '../infrastructure/actions'
-import { loadDeployments } from './actions'
-import { withMultiLoader } from 'core/DataLoader'
 import { projectAs } from 'utils/fp'
 import { prop, head } from 'ramda'
+import { loadClusters } from 'k8s/components/infrastructure/actions'
+import { withDataLoader } from 'core/DataLoader'
+import Picklist from 'core/components/Picklist'
+import { loadDeployments } from 'k8s/components/pods/actions'
+import createCRUDComponents from 'core/helpers/createCRUDComponents'
 
 const ListPage = ({ ListContainer }) => {
   class ListPage extends React.Component {
@@ -16,7 +16,7 @@ const ListPage = ({ ListContainer }) => {
     handleChangeCluster = clusterId => {
       this.setState({ activeCluster: clusterId },
         () => {
-          this.props.reload('deployments', { clusterId })
+          this.props.reloadData(loadDeployments, { clusterId })
         })
     }
 
@@ -56,14 +56,11 @@ const ListPage = ({ ListContainer }) => {
     }
   }
 
-  return withMultiLoader(
-    {
-      clusters: loadInfrastructure,
-      deployments: {
-        requires: 'clusters',
-        loaderFn: loadDeployments,
-      },
-    })(ListPage)
+  return withDataLoader(
+    [
+      loadClusters,
+      loadDeployments,
+    ])(ListPage)
 }
 
 export const options = {

--- a/src/app/plugins/kubernetes/components/pods/DeploymentsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/DeploymentsListPage.js
@@ -16,18 +16,18 @@ const ListPage = ({ ListContainer }) => {
     handleChangeCluster = clusterId => {
       this.setState({ activeCluster: clusterId },
         () => {
-          this.props.reloadData(loadDeployments, { clusterId })
+          this.props.reloadData('deployments', { clusterId })
         })
     }
 
     findClusterName = clusterId => {
-      const cluster = this.props.context.clusters.find(x => x.uuid === clusterId)
+      const cluster = this.props.data.clusters.find(x => x.uuid === clusterId)
       return (cluster && cluster.name) || ''
     }
 
     render () {
       const { activeCluster } = this.state
-      const { deployments = [], clusters = [] } = this.props.context
+      const { deployments = [], clusters = [] } = this.props.data
       const withClusterNames = deployments.map(ns => ({
         ...ns,
         clusterName: this.findClusterName(ns.clusterId),
@@ -57,10 +57,10 @@ const ListPage = ({ ListContainer }) => {
   }
 
   return withDataLoader(
-    [
-      loadClusters,
-      loadDeployments,
-    ])(ListPage)
+    {
+      clusters: loadClusters,
+      deployments: loadDeployments,
+    })(ListPage)
 }
 
 export const options = {

--- a/src/app/plugins/kubernetes/components/pods/PodsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/PodsListPage.js
@@ -16,18 +16,18 @@ const ListPage = ({ ListContainer }) => {
     handleChangeCluster = clusterId => {
       this.setState({ activeCluster: clusterId },
         () => {
-          this.props.reloadData(loadPods, { clusterId })
+          this.props.reloadData('pods', { clusterId })
         })
     }
 
     findClusterName = clusterId => {
-      const cluster = this.props.context.clusters.find(x => x.uuid === clusterId)
+      const cluster = this.props.data.clusters.find(x => x.uuid === clusterId)
       return (cluster && cluster.name) || ''
     }
 
     render () {
       const { activeCluster } = this.state
-      const { pods = [], clusters = [] } = this.props.context
+      const { pods = [], clusters = [] } = this.props.data
       const withClusterNames = pods.map(ns => ({
         ...ns,
         clusterName: this.findClusterName(ns.clusterId),
@@ -56,7 +56,7 @@ const ListPage = ({ ListContainer }) => {
     }
   }
 
-  return withDataLoader([loadClusters, loadPods])(ListPage)
+  return withDataLoader({ clusters: loadClusters, pods: loadPods })(ListPage)
 }
 
 export const options = {

--- a/src/app/plugins/kubernetes/components/pods/PodsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/PodsListPage.js
@@ -1,22 +1,22 @@
 import React from 'react'
-import Picklist from 'core/components/Picklist'
-import createCRUDComponents from 'core/helpers/createCRUDComponents'
-import { loadInfrastructure } from '../infrastructure/actions'
-import { loadPods, deletePod } from './actions'
-import { withMultiLoader } from 'core/DataLoader'
 import { projectAs } from 'utils/fp'
 import { head, prop } from 'ramda'
+import { loadClusters } from 'k8s/components/infrastructure/actions'
+import createCRUDComponents from 'core/helpers/createCRUDComponents'
+import { deletePod, loadPods } from 'k8s/components/pods/actions'
+import { withDataLoader } from 'core/DataLoader'
+import Picklist from 'core/components/Picklist'
 
 const ListPage = ({ ListContainer }) => {
   class ListPage extends React.Component {
     state = {
-      activeCluster: null
+      activeCluster: null,
     }
 
     handleChangeCluster = clusterId => {
       this.setState({ activeCluster: clusterId },
         () => {
-          this.props.reload('pods', { clusterId })
+          this.props.reloadData(loadPods, { clusterId })
         })
     }
 
@@ -43,8 +43,8 @@ const ListPage = ({ ListContainer }) => {
               [
                 // TODO: Figure out a way to query for all clusters
                 // { name: 'all', uuid: '__all__' },
-                ...clusters.filter(
-                  cluster => cluster.hasMasterNode)],
+                ...clusters.filter(cluster => cluster.hasMasterNode),
+              ],
             )}
             value={activeCluster || prop('uuid', head(clusters))}
             onChange={this.handleChangeCluster}
@@ -56,14 +56,7 @@ const ListPage = ({ ListContainer }) => {
     }
   }
 
-  return withMultiLoader(
-    {
-      clusters: loadInfrastructure,
-      pods: {
-        requires: 'clusters',
-        loaderFn: loadPods,
-      },
-    })(ListPage)
+  return withDataLoader([loadClusters, loadPods])(ListPage)
 }
 
 export const options = {

--- a/src/app/plugins/kubernetes/components/pods/ServicesListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/ServicesListPage.js
@@ -3,10 +3,10 @@ import Picklist from 'core/components/Picklist'
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import { deleteService } from './actions'
 import { projectAs } from 'utils/fp'
-import { withMultiLoader } from 'core/DataLoader'
-import { loadInfrastructure } from 'k8s/components/infrastructure/actions'
 import { loadServices } from 'k8s/components/pods/actions'
 import { prop, head } from 'ramda'
+import { loadClusters } from 'k8s/components/infrastructure/actions'
+import { withDataLoader } from 'core/DataLoader'
 
 const ListPage = ({ ListContainer }) => {
   class ListPage extends React.Component {
@@ -17,7 +17,7 @@ const ListPage = ({ ListContainer }) => {
     handleChangeCluster = clusterId => {
       this.setState({ activeCluster: clusterId },
         () => {
-          this.props.reload('services', { clusterId })
+          this.props.reloadData(loadServices, { clusterId })
         })
     }
 
@@ -58,14 +58,9 @@ const ListPage = ({ ListContainer }) => {
     }
   }
 
-  return withMultiLoader(
-    {
-      clusters: loadInfrastructure,
-      services: {
-        requires: 'clusters',
-        loaderFn: loadServices,
-      },
-    })(ListPage)
+  return withDataLoader(
+    [loadClusters, loadServices],
+  )(ListPage)
 }
 
 export const options = {

--- a/src/app/plugins/kubernetes/components/pods/ServicesListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/ServicesListPage.js
@@ -17,18 +17,18 @@ const ListPage = ({ ListContainer }) => {
     handleChangeCluster = clusterId => {
       this.setState({ activeCluster: clusterId },
         () => {
-          this.props.reloadData(loadServices, { clusterId })
+          this.props.reloadData('services', { clusterId })
         })
     }
 
     findClusterName = clusterId => {
-      const cluster = this.props.context.clusters.find(x => x.uuid === clusterId)
+      const cluster = this.props.data.clusters.find(x => x.uuid === clusterId)
       return (cluster && cluster.name) || ''
     }
 
     render () {
       const { activeCluster } = this.state
-      const { kubeServices = [], clusters = [] } = this.props.context
+      const { kubeServices = [], clusters = [] } = this.props.data
 
       const withClusterNames = kubeServices.map(ns => ({
         ...ns,
@@ -59,7 +59,7 @@ const ListPage = ({ ListContainer }) => {
   }
 
   return withDataLoader(
-    [loadClusters, loadServices],
+    { clusters: loadClusters, services: loadServices },
   )(ListPage)
 }
 

--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -77,7 +77,8 @@ class AddPrometheusInstancePage extends React.Component {
                     <TextField id="numInstances" label="# of instances" info="Number of Prometheus instances" type="number" />
                     <TextField id="cpu" label="CPU" info="Expressed in millicores (1m = 1/1000th of a core)" type="number" />
                     <TextField id="memory" label="Memory" info="MiB of memory to allocate" type="number" />
-                    {enableStorage && <TextField id="storage" label="Storage" info="The storage allocation.  Default is 8 GiB" type="number" />}
+                    {enableStorage &&
+                    <TextField id="storage" label="Storage" info="The storage allocation.  Default is 8 GiB" type="number" />}
 
                     <PicklistField
                       id="cluster"
@@ -88,30 +89,32 @@ class AddPrometheusInstancePage extends React.Component {
                     />
 
                     {namespaceOptions.length > 0 &&
-                      <PicklistField
-                        id="namespace"
-                        onChange={this.handleNamespaceChange}
-                        options={namespaceOptions}
-                        label="Namespace"
-                        info="Which namespace to use"
-                      />}
+                    <PicklistField
+                      id="namespace"
+                      onChange={this.handleNamespaceChange}
+                      options={namespaceOptions}
+                      label="Namespace"
+                      info="Which namespace to use"
+                    />}
 
                     {serviceAccountOptions.length > 0 &&
-                      <PicklistField
-                        id="serviceAccount"
-                        options={serviceAccountOptions}
-                        label="Service Account"
-                        info="Which service account to use"
-                      />}
+                    <PicklistField
+                      id="serviceAccount"
+                      options={serviceAccountOptions}
+                      label="Service Account"
+                      info="Which service account to use"
+                    />}
 
-                    {enableStorage && <CheckboxField id="enablePersistentStorage" label="Enable persistent storage" />}
+                    {enableStorage &&
+                    <CheckboxField id="enablePersistentStorage" label="Enable persistent storage" />}
                     <TextField id="retention" label="Storage Retention (days)" info="Defaults to 15 days if nothing is set" type="number" />
                     <TextField id="port" label="Service Monitor Port" info="Port for the service monitor" />
                     <KeyValuesField id="appLabels" label="App Labels" info="Key/value pairs for app that Prometheus will monitor" />
                   </ValidatedForm>
                 </WizardStep>
                 <WizardStep stepId="config" label="Configure Alerting">
-                  {rules.length > 0 && <PrometheusRulesTable rules={this.state.rules} onDelete={this.handleDeleteRule} />}
+                  {rules.length > 0 &&
+                  <PrometheusRulesTable rules={this.state.rules} onDelete={this.handleDeleteRule} />}
                   <PrometheusRuleForm onSubmit={this.handleAddRule} />
                 </WizardStep>
               </React.Fragment>
@@ -124,6 +127,6 @@ class AddPrometheusInstancePage extends React.Component {
 }
 
 export default compose(
-  withDataLoader(loadClusters),
+  withDataLoader({ clusters: loadClusters }),
   withAppContext,
 )(AddPrometheusInstancePage)

--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -12,10 +12,10 @@ import WizardStep from 'core/components/WizardStep'
 import uuid from 'uuid'
 import { compose, propEq } from 'ramda'
 import { loadServiceAccounts, createPrometheusInstance } from './actions'
-import { loadInfrastructure } from '../infrastructure/actions'
 import { projectAs } from 'utils/fp'
 import { withAppContext } from 'core/AppContext'
 import { withDataLoader } from 'core/DataLoader'
+import { loadClusters } from 'k8s/components/infrastructure/actions'
 
 const initialContext = {
   numInstances: 1,
@@ -124,6 +124,6 @@ class AddPrometheusInstancePage extends React.Component {
 }
 
 export default compose(
-  withDataLoader({ dataKey: 'clusters', loaderFn: loadInfrastructure }),
+  withDataLoader(loadClusters),
   withAppContext,
 )(AddPrometheusInstancePage)

--- a/src/app/plugins/openstack/components/api-access/ApiAccessListPage.js
+++ b/src/app/plugins/openstack/components/api-access/ApiAccessListPage.js
@@ -24,7 +24,7 @@ const ListTable = createListTableComponent({
 
 const ApiAccessPage = () => {
   return (
-    <DataLoader dataKey="serviceCatalog" loaderFn={loadServiceCatalog}>
+    <DataLoader loaders={loadServiceCatalog}>
       {({ data }) => <ListTable data={data} />}
     </DataLoader>
   )

--- a/src/app/plugins/openstack/components/api-access/ApiAccessListPage.js
+++ b/src/app/plugins/openstack/components/api-access/ApiAccessListPage.js
@@ -24,8 +24,8 @@ const ListTable = createListTableComponent({
 
 const ApiAccessPage = () => {
   return (
-    <DataLoader loaders={loadServiceCatalog}>
-      {({ data }) => <ListTable data={data} />}
+    <DataLoader loaders={{ serviceCatalog: loadServiceCatalog }}>
+      {({ data }) => <ListTable data={data.serviceCatalog} />}
     </DataLoader>
   )
 }

--- a/src/app/plugins/openstack/components/api-access/actions.js
+++ b/src/app/plugins/openstack/components/api-access/actions.js
@@ -1,30 +1,31 @@
 /* eslint-disable key-spacing */
 // which endpoint to use for each service (internal, public, admin)
+import contextLoader from 'core/helpers/contextLoader'
+
 const serviceMappings = {
-  aodh:       'internal',
-  azmanager:  'admin',
+  aodh: 'internal',
+  azmanager: 'admin',
   ceilometer: 'internal',
-  cinder:     'internal',
-  credsmgr:   'admin',
-  glance:     'admin',
-  gnocchi:    'internal',
-  ironic:     'public',
-  mors:       'internal',
-  murano:     'internal',
-  neutron:    'internal',
-  nova:       'internal',
-  panko:      'internal',
-  qbert:      'internal',
-  resmgr:     'internal',
-  tasker:     'admin',
+  cinder: 'internal',
+  credsmgr: 'admin',
+  glance: 'admin',
+  gnocchi: 'internal',
+  ironic: 'public',
+  mors: 'internal',
+  murano: 'internal',
+  neutron: 'internal',
+  nova: 'internal',
+  panko: 'internal',
+  qbert: 'internal',
+  resmgr: 'internal',
+  tasker: 'admin',
 }
 
 const whichInterface = serviceName => serviceMappings[serviceName] || 'internal'
 
-export const loadServiceCatalog = async ({ context, setContext, reload }) => {
-  if (!reload && context.serviceCatalog) { return context.serviceCatalog }
+export const loadServiceCatalog = contextLoader('serviceCatalog', async ({ context }) => {
   const services = await context.apiClient.keystone.getServicesForActiveRegion()
-  const serviceCatalog = Object.keys(services).map(x => {
+  return Object.keys(services).map(x => {
     const service = services[x]
     const iface = whichInterface(service)
     const endpoint = (service && service[iface]) || service[Object.keys(service)[0]]
@@ -36,6 +37,4 @@ export const loadServiceCatalog = async ({ context, setContext, reload }) => {
       iface: endpoint.iface,
     }
   })
-  setContext({ serviceCatalog })
-  return serviceCatalog
-}
+})

--- a/src/app/plugins/openstack/components/floatingips/actions.js
+++ b/src/app/plugins/openstack/components/floatingips/actions.js
@@ -1,24 +1,22 @@
-export const loadFloatingIps = async ({ context, setContext, reload }) => {
-  if (!reload && context.floatingIps) { return context.floatingIps }
-  const floatingIps = await context.apiClient.neutron.getFloatingIps()
-  setContext({ floatingIps })
-  return floatingIps
-}
+import contextLoader from 'core/helpers/contextLoader'
+import contextUpdater from 'core/helpers/contextUpdater'
 
-export const createFloatingIp = async ({ data, context, setContext }) => {
+export const loadFloatingIps = contextLoader('floatingIps', async ({ context }) => {
+  return context.apiClient.neutron.getFloatingIps()
+})
+
+export const createFloatingIp = contextUpdater('floatingIps', async ({ data, context }) => {
   const existing = await context.apiClient.neutron.getFloatingIps()
   const created = await context.apiClient.neutron.createFloatingIp(data)
-  setContext({ floatingIps: [ ...existing, created ] })
-  return created
-}
+  return [...existing, created]
+}, true)
 
-export const deleteFloatingIp = async ({ id, context, setContext }) => {
+export const deleteFloatingIp = contextUpdater('floatingIps', async ({ id, context }) => {
   await context.apiClient.neutron.deleteFloatingIp(id)
-  const newList = context.floatingIps.filter(x => x.id !== id)
-  setContext({ floatingIps: newList })
-}
+  return context.floatingIps.filter(x => x.id !== id)
+})
 
-export const updateFloatingIp = async ({ data, context, setContext }) => {
+export const updateFloatingIp = contextUpdater('floatingIps', async ({ data, context, setContext }) => {
   console.error('TODO: Update Floating IP not yet implemented')
   /*
   const { id } = data
@@ -27,4 +25,4 @@ export const updateFloatingIp = async ({ data, context, setContext }) => {
   const newList = existing.map(x => x.id === id ? x : updated)
   setContext({ floatingIps: newList })
   */
-}
+})

--- a/src/app/plugins/openstack/components/hosts/HostsListPage.js
+++ b/src/app/plugins/openstack/components/hosts/HostsListPage.js
@@ -11,7 +11,7 @@ const loadHosts = async ({ setContext, context }) => {
 }
 
 const HostsListPage = () =>
-  <DataLoader dataKey="hosts" loaderFn={loadHosts}>
+  <DataLoader dataKey="hosts" loaders={loadHosts}>
     {({ data }) => <HostsListContainer hosts={data} />}
   </DataLoader>
 

--- a/src/app/plugins/openstack/components/hosts/HostsListPage.js
+++ b/src/app/plugins/openstack/components/hosts/HostsListPage.js
@@ -3,16 +3,16 @@ import { compose } from 'app/utils/fp'
 import DataLoader from 'core/DataLoader'
 import requiresAuthentication from '../../util/requiresAuthentication'
 import HostsListContainer from './HostsListContainer'
+import contextLoader from 'core/helpers/contextLoader'
 
-const loadHosts = async ({ setContext, context }) => {
+const loadHosts = contextLoader('hosts', async ({ context }) => {
   // const hosts = await context.apiClient.resmgr.getHosts()
-  const hosts = await context.apiClient.nova.getHypervisors()
-  setContext({ hosts })
-}
+  return context.apiClient.nova.getHypervisors()
+})
 
 const HostsListPage = () =>
-  <DataLoader dataKey="hosts" loaders={loadHosts}>
-    {({ data }) => <HostsListContainer hosts={data} />}
+  <DataLoader loaders={{ hosts: loadHosts }}>
+    {({ data }) => <HostsListContainer hosts={data.hosts} />}
   </DataLoader>
 
 export default compose(

--- a/src/app/plugins/openstack/components/images/ImageListPage.js
+++ b/src/app/plugins/openstack/components/images/ImageListPage.js
@@ -6,7 +6,7 @@ import { loadImages } from './actions'
 import ImageListContainer from './ImageListContainer'
 
 const ImageListPage = () =>
-  <DataLoader dataKey="images" loaderFn={loadImages}>
+  <DataLoader dataKey="images" loaders={loadImages}>
     {({ data }) => <ImageListContainer images={data} />}
   </DataLoader>
 

--- a/src/app/plugins/openstack/components/images/ImageListPage.js
+++ b/src/app/plugins/openstack/components/images/ImageListPage.js
@@ -6,8 +6,8 @@ import { loadImages } from './actions'
 import ImageListContainer from './ImageListContainer'
 
 const ImageListPage = () =>
-  <DataLoader dataKey="images" loaders={loadImages}>
-    {({ data }) => <ImageListContainer images={data} />}
+  <DataLoader loaders={{ images: loadImages }}>
+    {({ data }) => <ImageListContainer images={data.images} />}
   </DataLoader>
 
 export default compose(

--- a/src/app/plugins/openstack/components/images/UpdateImagePage.js
+++ b/src/app/plugins/openstack/components/images/UpdateImagePage.js
@@ -8,7 +8,6 @@ import UpdateImageForm from './UpdateImageForm'
 
 const UpdateImagePage = props => (
   <DataUpdater
-    dataKey="images"
     loaderFn={loadImages}
     updateFn={updateImage}
     objId={props.match.params.imageId}

--- a/src/app/plugins/openstack/components/images/actions.js
+++ b/src/app/plugins/openstack/components/images/actions.js
@@ -1,9 +1,8 @@
-export const loadImages = async ({ setContext, context, reload }) => {
-  if (!reload && context.images) { return context.images }
-  const images = await context.apiClient.glance.getImages()
-  setContext({ images })
-  return images
-}
+import contextLoader from 'core/helpers/contextLoader'
+
+export const loadImages = contextLoader('images', async ({ context }) => {
+  return context.apiClient.glance.getImages()
+})
 
 export const updateImage = async (data, helpers) => {
   const { context, dataKey, objId } = helpers

--- a/src/app/plugins/openstack/components/instances/InstancesListPage.js
+++ b/src/app/plugins/openstack/components/instances/InstancesListPage.js
@@ -3,15 +3,15 @@ import DataLoader from 'core/DataLoader'
 import React from 'react'
 import requiresAuthentication from '../../util/requiresAuthentication'
 import InstancesListContainer from './InstancesListContainer'
+import contextLoader from 'core/helpers/contextLoader'
 
-const loadInstances = async ({ setContext, context }) => {
-  const instances = await context.apiClient.nova.getInstances()
-  setContext({ instances })
-}
+const loadInstances = contextLoader('instances', async ({ context }) => {
+  return context.apiClient.nova.getInstances()
+})
 
 const InstancesListPage = () =>
-  <DataLoader loaders={loadInstances}>
-    {({ data }) => <InstancesListContainer instances={data} />}
+  <DataLoader loaders={{ instances: loadInstances }}>
+    {({ data }) => <InstancesListContainer instances={data.instances} />}
   </DataLoader>
 
 export default compose(

--- a/src/app/plugins/openstack/components/instances/InstancesListPage.js
+++ b/src/app/plugins/openstack/components/instances/InstancesListPage.js
@@ -10,7 +10,7 @@ const loadInstances = async ({ setContext, context }) => {
 }
 
 const InstancesListPage = () =>
-  <DataLoader dataKey="instances" loaderFn={loadInstances}>
+  <DataLoader loaders={loadInstances}>
     {({ data }) => <InstancesListContainer instances={data} />}
   </DataLoader>
 

--- a/src/app/plugins/openstack/components/networks/actions.js
+++ b/src/app/plugins/openstack/components/networks/actions.js
@@ -1,27 +1,24 @@
-export const loadNetworks = async ({ context, setContext, reload }) => {
-  if (!reload && context.networks) { return context.networks }
-  const networks = await context.apiClient.neutron.getNetworks()
-  setContext({ networks })
-  return networks
-}
+import contextLoader from 'core/helpers/contextLoader'
+import contextUpdater from 'core/helpers/contextUpdater'
 
-export const createNetwork = async ({ data, context, setContext }) => {
+export const loadNetworks = contextLoader('networks', async ({ context }) => {
+  return context.apiClient.neutron.getNetworks()
+})
+
+export const createNetwork = contextUpdater('networks', async ({ data, context }) => {
   const existing = await context.apiClient.neutron.getNetworks()
   const created = await context.apiClient.neutron.createNetwork(data)
-  setContext({ networks: [ ...existing, created ] })
-  return created
-}
+  return [...existing, created]
+}, true)
 
-export const deleteNetwork = async ({ id, context, setContext }) => {
+export const deleteNetwork = contextUpdater('networks', async ({ id, context }) => {
   await context.apiClient.neutron.deleteNetwork(id)
-  const newList = context.networks.filter(x => x.id !== id)
-  setContext({ networks: newList })
-}
+  return context.networks.filter(x => x.id !== id)
+})
 
-export const updateNetwork = async ({ data, context, setContext }) => {
+export const updateNetwork = contextUpdater('networks', async ({ data, context }) => {
   const { id } = data
   const existing = await context.apiClient.neutron.getNetworks()
   const updated = await context.apiClient.neutron.updateNetwork(id, data)
-  const newList = existing.map(x => x.id === id ? x : updated)
-  setContext({ networks: newList })
-}
+  return existing.map(x => x.id === id ? x : updated)
+})

--- a/src/app/plugins/openstack/components/regions/RegionChooser.js
+++ b/src/app/plugins/openstack/components/regions/RegionChooser.js
@@ -4,13 +4,11 @@ import { appUrlRoot } from 'app/constants'
 import { compose, pluck, propEq } from 'ramda'
 import { withDataLoader } from 'core/DataLoader'
 import { withScopedPreferences } from 'core/providers/PreferencesProvider'
+import contextLoader from 'core/helpers/contextLoader'
 
-const loadRegions = async ({ context, setContext, reload }) => {
-  if (!reload && context.regions) { return context.regions }
-  const regions = await context.apiClient.keystone.getRegions()
-  setContext({ regions })
-  return regions
-}
+const loadRegions = contextLoader('regions', async ({ context }) => {
+  return context.apiClient.keystone.getRegions()
+})
 
 class RegionChooser extends React.Component {
   state = {
@@ -58,6 +56,6 @@ class RegionChooser extends React.Component {
 }
 
 export default compose(
-  withDataLoader({ dataKey: 'regions', loaderFn: loadRegions }, { inlineProgress: true }),
+  withDataLoader(loadRegions, { inlineProgress: true }),
   withScopedPreferences('RegionChooser'),
 )(RegionChooser)

--- a/src/app/plugins/openstack/components/regions/RegionChooser.js
+++ b/src/app/plugins/openstack/components/regions/RegionChooser.js
@@ -27,7 +27,7 @@ class RegionChooser extends React.Component {
     this.setState({ curRegion: region })
     // Future Todo: Update the Selector component or create a variant of the component
     // that can take a list of objects
-    const fullRegionObj = this.props.data.find(propEq('id', region))
+    const fullRegionObj = this.props.data.regions.find(propEq('id', region))
     this.props.updatePreferences({ lastRegion: fullRegionObj })
 
     // Initial loading of the app is tightly coupled to knowing the region to use.
@@ -37,9 +37,9 @@ class RegionChooser extends React.Component {
 
   render () {
     const { curRegion, regionSearch } = this.state
-    const { data = [], className } = this.props
+    const { data: { regions = [] }, className } = this.props
 
-    const regionNames = pluck('id', data)
+    const regionNames = pluck('id', regions)
 
     return (
       <Selector
@@ -56,6 +56,6 @@ class RegionChooser extends React.Component {
 }
 
 export default compose(
-  withDataLoader(loadRegions, { inlineProgress: true }),
+  withDataLoader({ regions: loadRegions }, { inlineProgress: true }),
   withScopedPreferences('RegionChooser'),
 )(RegionChooser)

--- a/src/app/plugins/openstack/components/routers/actions.js
+++ b/src/app/plugins/openstack/components/routers/actions.js
@@ -1,27 +1,24 @@
-export const loadRouters = async ({ context, setContext, reload }) => {
-  if (!reload && context.routers) { return context.routers }
-  const routers = await context.apiClient.neutron.getRouters()
-  setContext({ routers })
-  return routers
-}
+import contextLoader from 'core/helpers/contextLoader'
+import contextUpdater from 'core/helpers/contextUpdater'
 
-export const createRouter = async ({ data, context, setContext }) => {
+export const loadRouters = contextLoader('routers', async ({ context }) => {
+  return context.apiClient.neutron.getRouters()
+})
+
+export const createRouter = contextUpdater('routers', async ({ data, context }) => {
   const existing = await context.apiClient.neutron.getRouters()
   const created = await context.apiClient.neutron.createRouter(data)
-  setContext({ routers: [ ...existing, created ] })
-  return created
-}
+  return [...existing, created]
+}, true)
 
-export const deleteRouter = async ({ id, context, setContext }) => {
+export const deleteRouter = contextUpdater('routers', async ({ id, context }) => {
   await context.apiClient.neutron.deleteRouter(id)
-  const newList = context.routers.filter(x => x.id !== id)
-  setContext({ routers: newList })
-}
+  return context.routers.filter(x => x.id !== id)
+})
 
-export const updateRouter = async ({ data, context, setContext }) => {
+export const updateRouter = contextUpdater('routers', async ({ data, context }) => {
   const { id } = data
   const existing = await context.apiClient.neutron.getRouters()
   const updated = await context.apiClient.neutron.updateRouter(id, data)
-  const newList = existing.map(x => x.id === id ? x : updated)
-  setContext({ routers: newList })
-}
+  return existing.map(x => x.id === id ? x : updated)
+})

--- a/src/app/plugins/openstack/components/tenants/actions.js
+++ b/src/app/plugins/openstack/components/tenants/actions.js
@@ -1,36 +1,30 @@
+import contextLoader from 'core/helpers/contextLoader'
+import contextUpdater from 'core/helpers/contextUpdater'
+
 const dataKey = 'tenants'
 
-export const loadUserTenants = async ({ context, setContext, reload }) => {
-  if (!reload && context.userTenants) { return context.userTenants }
-  const userTenants = await context.apiClient.keystone.getProjectsAuth()
-  setContext({ userTenants })
-  return userTenants
-}
+export const loadUserTenants = contextLoader('userTenants', async ({ context }) => {
+  return context.apiClient.keystone.getProjectsAuth()
+})
 
-export const loadTenants = async ({ context, setContext, reload }) => {
-  if (!reload && context[dataKey]) { return context[dataKey] }
-  const existing = await context.apiClient.keystone.getProjects()
-  setContext({ [dataKey]: existing })
-  return existing
-}
+export const loadTenants = contextLoader(dataKey, async ({ context }) => {
+  return context.apiClient.keystone.getProjects()
+})
 
-export const createTenant = async ({ data, context, setContext }) => {
+export const createTenant = contextUpdater(dataKey, async ({ data, context, setContext }) => {
   const created = await context.apiClient.keystone.createTenant(data)
   const existing = await loadTenants({ context, setContext })
-  setContext({ [dataKey]: [ ...existing, created ] })
-  return created
-}
+  return [...existing, created]
+}, true)
 
-export const deleteTenant = async ({ id, context, setContext }) => {
+export const deleteTenant = contextUpdater(dataKey, async ({ id, context }) => {
   await context.apiClient.keystone.deleteTenant(id)
-  const newList = context[dataKey].filter(x => x.id !== id)
-  setContext({ [dataKey]: newList })
-}
+  return context[dataKey].filter(x => x.id !== id)
+})
 
-export const updateTenant = async ({ data, context, setContext }) => {
+export const updateTenant = contextUpdater(dataKey, async ({ data, context, setContext }) => {
   const { id } = data
   const existing = await loadTenants({ context, setContext })
   const updated = await context.apiClient.keystone.updateTenant(id, data)
-  const newList = existing.map(x => x.id === id ? x : updated)
-  setContext({ [dataKey]: newList })
-}
+  return existing.map(x => x.id === id ? x : updated)
+})

--- a/src/app/plugins/openstack/components/users/actions.js
+++ b/src/app/plugins/openstack/components/users/actions.js
@@ -1,23 +1,21 @@
-export const loadUsers = async ({ context, setContext, reload }) => {
-  if (!reload && context.users) { return context.users }
-  const users = await context.apiClient.keystone.getUsers()
-  setContext({ users })
-  return users
-}
+import contextLoader from 'core/helpers/contextLoader'
+import contextUpdater from 'core/helpers/contextUpdater'
 
-export const createUser = async ({ data, context, setContext }) => {
+export const loadUsers = contextLoader('users', async ({ context }) => {
+  return context.apiClient.keystone.getUsers()
+})
+
+export const createUser = contextUpdater('users', async ({ data, context }) => {
   const created = await context.apiClient.keystone.createUser(data)
   const existing = await context.apiClient.keystone.getUsers()
-  setContext({ users: [ ...existing, created ] })
-  return created
-}
+  return [ ...existing, created ]
+}, true)
 
-export const deleteUser = async ({ id, context, setContext }) => {
+export const deleteUser = contextUpdater('users', async ({ id, context }) => {
   await context.apiClient.keystone.deleteUser(id)
-  const newList = context.users.filter(x => x.id !== id)
-  setContext({ users: newList })
-}
+  return context.users.filter(x => x.id !== id)
+})
 
 export const updateUser = () => {
-  console.log('TODO')
+  // TODO
 }

--- a/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
+++ b/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
@@ -66,7 +66,7 @@ class AddVolumeForm extends React.Component {
                 <Picklist name="sourceType" label="Volume Source" value={sourceType} onChange={this.setField('sourceType')} options={sourceTypes} />
                 {sourceType === 'Snapshot' &&
                   <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
-                    <DataLoader dataKey="volumeSnapshots" loaderFn={loadVolumeSnapshots}>
+                    <DataLoader dataKey="volumeSnapshots" loaders={loadVolumeSnapshots}>
                       {({ data }) =>
                         <VolumeSnapshotChooser data={data} onChange={value => setWizardContext({ snapshot_id: value })} initialValue={wizardContext.snapshot_id} />
                       }
@@ -75,7 +75,7 @@ class AddVolumeForm extends React.Component {
                 }
                 {sourceType === 'Another Volume' &&
                   <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
-                    <DataLoader dataKey="volumes" loaderFn={loadVolumes}>
+                    <DataLoader dataKey="volumes" loaders={loadVolumes}>
                       {({ data }) =>
                         <VolumeChooser data={data} onChange={value => setWizardContext({ volume_id: value })} initialValue={wizardContext.volume_id} />
                       }
@@ -84,7 +84,7 @@ class AddVolumeForm extends React.Component {
                 }
                 {sourceType === 'Image' &&
                   <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
-                    <DataLoader dataKey="images" loaderFn={loadImages}>
+                    <DataLoader dataKey="images" loaders={loadImages}>
                       {({ data }) =>
                         <ImageChooser data={data} onChange={value => setWizardContext({ imageRef: value })} initialValue={wizardContext.imageRef} />
                       }
@@ -94,7 +94,7 @@ class AddVolumeForm extends React.Component {
               </WizardStep>
 
               <WizardStep stepId="basic" label="Basic">
-                <DataLoader dataKey="volumeTypes" loaderFn={loadVolumeTypes}>
+                <DataLoader dataKey="volumeTypes" loaders={loadVolumeTypes}>
                   {({ data }) =>
                     <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
                       <TextField id="name" label="Volume Name" onChange={this.setField('name')} />

--- a/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
+++ b/src/app/plugins/openstack/components/volumes/AddVolumeForm.js
@@ -66,27 +66,27 @@ class AddVolumeForm extends React.Component {
                 <Picklist name="sourceType" label="Volume Source" value={sourceType} onChange={this.setField('sourceType')} options={sourceTypes} />
                 {sourceType === 'Snapshot' &&
                   <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
-                    <DataLoader dataKey="volumeSnapshots" loaders={loadVolumeSnapshots}>
+                    <DataLoader loaders={{ volumeSnapshots: loadVolumeSnapshots }}>
                       {({ data }) =>
-                        <VolumeSnapshotChooser data={data} onChange={value => setWizardContext({ snapshot_id: value })} initialValue={wizardContext.snapshot_id} />
+                        <VolumeSnapshotChooser data={data.volumeSnapshots} onChange={value => setWizardContext({ snapshot_id: value })} initialValue={wizardContext.snapshot_id} />
                       }
                     </DataLoader>
                   </ValidatedForm>
                 }
                 {sourceType === 'Another Volume' &&
                   <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
-                    <DataLoader dataKey="volumes" loaders={loadVolumes}>
+                    <DataLoader loaders={{ volumes: loadVolumes }}>
                       {({ data }) =>
-                        <VolumeChooser data={data} onChange={value => setWizardContext({ volume_id: value })} initialValue={wizardContext.volume_id} />
+                        <VolumeChooser data={data.volumes} onChange={value => setWizardContext({ volume_id: value })} initialValue={wizardContext.volume_id} />
                       }
                     </DataLoader>
                   </ValidatedForm>
                 }
                 {sourceType === 'Image' &&
                   <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
-                    <DataLoader dataKey="images" loaders={loadImages}>
+                    <DataLoader loaders={{ images: loadImages }}>
                       {({ data }) =>
-                        <ImageChooser data={data} onChange={value => setWizardContext({ imageRef: value })} initialValue={wizardContext.imageRef} />
+                        <ImageChooser data={data.images} onChange={value => setWizardContext({ imageRef: value })} initialValue={wizardContext.imageRef} />
                       }
                     </DataLoader>
                   </ValidatedForm>
@@ -94,7 +94,7 @@ class AddVolumeForm extends React.Component {
               </WizardStep>
 
               <WizardStep stepId="basic" label="Basic">
-                <DataLoader dataKey="volumeTypes" loaders={loadVolumeTypes}>
+                <DataLoader loaders={{ volumeTypes: loadVolumeTypes }}>
                   {({ data }) =>
                     <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
                       <TextField id="name" label="Volume Name" onChange={this.setField('name')} />

--- a/src/app/plugins/openstack/components/volumes/UpdateVolumePage.js
+++ b/src/app/plugins/openstack/components/volumes/UpdateVolumePage.js
@@ -8,7 +8,6 @@ import UpdateVolumeForm from './UpdateVolumeForm'
 
 const UpdateVolumePage = props => (
   <DataUpdater
-    dataKey="volumes"
     loaderFn={loadVolumes}
     updateFn={updateVolume}
     objId={props.match.params.volumeId}

--- a/src/app/plugins/openstack/components/volumes/UpdateVolumeSnapshotPage.js
+++ b/src/app/plugins/openstack/components/volumes/UpdateVolumeSnapshotPage.js
@@ -8,7 +8,6 @@ import UpdateVolumeSnapshotForm from './UpdateVolumeSnapshotForm'
 
 const UpdateVolumeSnapshotPage = props => (
   <DataUpdater
-    dataKey="volumeSnapshots"
     loaderFn={loadVolumeSnapshots}
     updateFn={updateVolumeSnapshot}
     objId={props.match.params.volumeSnapshotId}

--- a/src/app/plugins/openstack/components/volumes/UpdateVolumeTypePage.js
+++ b/src/app/plugins/openstack/components/volumes/UpdateVolumeTypePage.js
@@ -8,7 +8,6 @@ import UpdateVolumeTypeForm from './UpdateVolumeTypeForm'
 
 const UpdateVolumeTypePage = props => (
   <DataUpdater
-    dataKey="volumeTypes"
     loaderFn={loadVolumeTypes}
     updateFn={updateVolumeType}
     objId={props.match.params.volumeTypeId}

--- a/src/app/plugins/openstack/components/volumes/VolumeSnapshotsListPage.js
+++ b/src/app/plugins/openstack/components/volumes/VolumeSnapshotsListPage.js
@@ -6,7 +6,7 @@ import { loadVolumeSnapshots } from './actions'
 import VolumeSnapshotsListContainer from './VolumeSnapshotsListContainer'
 
 const VolumeSnapshotsListPage = () =>
-  <DataLoader dataKey="volumeSnapshots" loaderFn={loadVolumeSnapshots}>
+  <DataLoader dataKey="volumeSnapshots" loaders={loadVolumeSnapshots}>
     {({ data }) => <VolumeSnapshotsListContainer volumeSnapshots={data} />}
   </DataLoader>
 

--- a/src/app/plugins/openstack/components/volumes/VolumeSnapshotsListPage.js
+++ b/src/app/plugins/openstack/components/volumes/VolumeSnapshotsListPage.js
@@ -6,8 +6,8 @@ import { loadVolumeSnapshots } from './actions'
 import VolumeSnapshotsListContainer from './VolumeSnapshotsListContainer'
 
 const VolumeSnapshotsListPage = () =>
-  <DataLoader dataKey="volumeSnapshots" loaders={loadVolumeSnapshots}>
-    {({ data }) => <VolumeSnapshotsListContainer volumeSnapshots={data} />}
+  <DataLoader loaders={{ volumeSnapshots: loadVolumeSnapshots }}>
+    {({ data }) => <VolumeSnapshotsListContainer volumeSnapshots={data.volumeSnapshots} />}
   </DataLoader>
 
 export default compose(

--- a/src/app/plugins/openstack/components/volumes/VolumeTypesListPage.js
+++ b/src/app/plugins/openstack/components/volumes/VolumeTypesListPage.js
@@ -6,7 +6,7 @@ import { loadVolumeTypes } from './actions'
 import VolumeTypesListContainer from './VolumeTypesListContainer'
 
 const VolumesListPage = () =>
-  <DataLoader dataKey="volumeTypes" loaderFn={loadVolumeTypes}>
+  <DataLoader dataKey="volumeTypes" loaders={loadVolumeTypes}>
     {({ data }) => <VolumeTypesListContainer volumeTypes={data} />}
   </DataLoader>
 

--- a/src/app/plugins/openstack/components/volumes/VolumeTypesListPage.js
+++ b/src/app/plugins/openstack/components/volumes/VolumeTypesListPage.js
@@ -6,8 +6,8 @@ import { loadVolumeTypes } from './actions'
 import VolumeTypesListContainer from './VolumeTypesListContainer'
 
 const VolumesListPage = () =>
-  <DataLoader dataKey="volumeTypes" loaders={loadVolumeTypes}>
-    {({ data }) => <VolumeTypesListContainer volumeTypes={data} />}
+  <DataLoader loaders={{ volumeTypes: loadVolumeTypes }}>
+    {({ data }) => <VolumeTypesListContainer volumeTypes={data.volumeTypes} />}
   </DataLoader>
 
 export default compose(

--- a/src/app/plugins/openstack/components/volumes/VolumesListPage.js
+++ b/src/app/plugins/openstack/components/volumes/VolumesListPage.js
@@ -6,8 +6,8 @@ import { loadVolumes } from './actions'
 import VolumesListContainer from './VolumesListContainer'
 
 const VolumesListPage = () =>
-  <DataLoader dataKey="volumes" loaders={loadVolumes}>
-    {({ data }) => <VolumesListContainer volumes={data} />}
+  <DataLoader loaders={{ volumes: loadVolumes }}>
+    {({ data }) => <VolumesListContainer volumes={data.volumes} />}
   </DataLoader>
 
 export default compose(

--- a/src/app/plugins/openstack/components/volumes/VolumesListPage.js
+++ b/src/app/plugins/openstack/components/volumes/VolumesListPage.js
@@ -6,7 +6,7 @@ import { loadVolumes } from './actions'
 import VolumesListContainer from './VolumesListContainer'
 
 const VolumesListPage = () =>
-  <DataLoader dataKey="volumes" loaderFn={loadVolumes}>
+  <DataLoader dataKey="volumes" loaders={loadVolumes}>
     {({ data }) => <VolumesListContainer volumes={data} />}
   </DataLoader>
 

--- a/src/app/utils/__tests__/fp.test.js
+++ b/src/app/utils/__tests__/fp.test.js
@@ -1,19 +1,9 @@
 import { T } from 'ramda'
 import {
-  compose,
-  condLiteral,
-  filterFields,
-  identity,
-  mergeKey,
-  notEmpty,
-  pick,
-  pickMultiple,
-  pipe,
-  pipeWhenTruthy,
-  projectAs,
-  pluck,
-  pluckAsync,
+  compose, condLiteral, filterFields, identity, mergeKey, notEmpty, pick, pickMultiple, pipe,
+  pipeWhenTruthy, projectAs, pluck, pluckAsync,
 } from '../fp'
+import { asyncProps } from 'utils/fp'
 
 describe('functional programming utils', () => {
   it('identity', () => {
@@ -30,6 +20,20 @@ describe('functional programming utils', () => {
     const promise = Promise.resolve({ foo: 'value' })
     const value = await pluckAsync('foo')(promise)
     expect(value).toEqual('value')
+  })
+
+  it('asyncProps', async () => {
+    const promises = {
+      a: Promise.resolve('A value'),
+      b: Promise.resolve('B value'),
+      c: Promise.resolve('C value'),
+    }
+    const result = await asyncProps(promises)
+    expect(result).toEqual({
+      a: 'A value',
+      b: 'B value',
+      c: 'C value',
+    })
   })
 
   it('compose', () => {


### PR DESCRIPTION
`loadInfrastructure` action has been decoupled into smaller data loader functions.

For that regard I created 2 helpers to simplify the process of updating/retrieving values from the context:
* `contextLoader`
* `contextUpdater`

I also refactored all the actions of the app to use these 2 helpers, reducing the overall boilerplate.

Moreover, I could greatly simplify the logic from the DataLoader component because now  the dependencies will be handled from the actions themselves rather than when calling the `withDataLoader` HoC.

Example 1:
![image](https://user-images.githubusercontent.com/339539/56974500-90843180-6ba1-11e9-98fb-045119e24329.png)


Example 2:
![image](https://user-images.githubusercontent.com/339539/56974280-210e4200-6ba1-11e9-8f6b-5fc7db9197d8.png)

In this case we want to cache rawClusters into the context as we will be reusing it as a "dependency" in a couple of other places.

[UPDATED] Example 3 (using the HoC)
![image](https://user-images.githubusercontent.com/339539/57197942-34e9e780-6f97-11e9-96d6-ce74ac09451c.png)

The idea of this is to use `data` instead of `context` in the view, as the latter will be used purely to cache raw data while `data` will be intended to have parsed/filtered data (the aim of this is to be able to create custom contextLoaders that might do some data manipulation in the future)
