### PR TITLE
Prometheus monitoring

### DIFF
--- a/src/api-client/ApiClient.js
+++ b/src/api-client/ApiClient.js
@@ -1,5 +1,6 @@
 import axios from 'axios'
 
+import Appbert from './Appbert'
 import Cinder from './Cinder'
 import Glance from './Glance'
 import Keystone from './Keystone'
@@ -15,6 +16,7 @@ class ApiClient {
     if (!options.keystoneEndpoint) {
       throw new Error('keystoneEndpoint required')
     }
+    this.appbert = new Appbert(this)
     this.cinder = new Cinder(this)
     this.glance = new Glance(this)
     this.keystone = new Keystone(this)

--- a/src/api-client/Appbert.js
+++ b/src/api-client/Appbert.js
@@ -4,7 +4,7 @@ class Appbert {
     this.client = client
   }
 
-  async endpoint () {
+  endpoint = async () => {
     const services = await this.client.keystone.getServicesForActiveRegion()
     const endpoint = services.appbert.admin.url
     return endpoint
@@ -12,7 +12,7 @@ class Appbert {
 
   baseUrl = async () => `${await this.endpoint()}`
 
-  async getClusterTags () {
+  getClusterTags = async () => {
     return this.client.basicGet(`${await this.baseUrl()}/clusters`)
   }
 }

--- a/src/api-client/Appbert.js
+++ b/src/api-client/Appbert.js
@@ -1,0 +1,20 @@
+// Appbert provides information about clusters and the managed apps (packages) installed on them.
+class Appbert {
+  constructor (client) {
+    this.client = client
+  }
+
+  async endpoint () {
+    const services = await this.client.keystone.getServicesForActiveRegion()
+    const endpoint = services.appbert.admin.url
+    return endpoint
+  }
+
+  baseUrl = async () => `${await this.endpoint()}`
+
+  async getClusterTags () {
+    return this.client.basicGet(`${await this.baseUrl()}/clusters`)
+  }
+}
+
+export default Appbert

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -322,12 +322,12 @@ class Qbert {
   }
 
   async getServiceAccounts (clusterId, namespace) {
-    return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/v1/namespaces/${namespace}/serviceaccounts`)
+    const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1/namespaces/${namespace}/serviceaccounts`)
+    return response.items
   }
 
   /* Managed Apps */
   async getPrometheusInstances (clusterUuid) {
-    console.log('Getting prometheus instances for ', clusterUuid)
     const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/prometheuses`)
     return normalizePrometheusResponse(clusterUuid, response)
   }
@@ -363,6 +363,7 @@ class Qbert {
         retention: `${data.retention}d`,
         resources: { requests },
         serviceMonitorSelector: { matchLabels: serviceMonitor },
+        serviceAccountName: data.serviceAccountName,
         ruleSelector: { matchLabels: ruleSelector },
       }
     }

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -8,13 +8,13 @@ class Qbert {
     this.client = client
   }
 
-  async endpoint () {
+  endpoint = async () => {
     const services = await this.client.keystone.getServicesForActiveRegion()
     const endpoint = services.qbert.admin.url
     return endpoint.replace(/v(1|2|3)$/, `v3/${this.client.activeProjectId}`)
   }
 
-  async monocularBaseUrl () {
+  monocularBaseUrl = async () => {
     const services = await this.client.keystone.getServicesForActiveRegion()
     return services.monocular.public.url
   }
@@ -25,27 +25,27 @@ class Qbert {
   clusterMonocularBaseUrl = async clusterId => `${await this.clusterBaseUrl(clusterId)}/namespaces/kube-system/services/monocular-api-svc:80/proxy/v1`
 
   /* Cloud Providers */
-  async getCloudProviders () {
+  getCloudProviders = async () => {
     return this.client.basicGet(`${await this.baseUrl()}/cloudProviders`)
   }
 
-  async createCloudProvider (params) {
+  createCloudProvider = async (params) => {
     return this.client.basicPost(`${await this.baseUrl()}/cloudProviders`, params)
   }
 
-  async getCloudProviderDetails (cpId) {
+  getCloudProviderDetails = async (cpId) => {
     return this.client.basicGet(`${await this.baseUrl()}/cloudProviders/${cpId}`)
   }
 
-  async getCloudProviderRegionDetails (cpId, regionId) {
+  getCloudProviderRegionDetails = async (cpId, regionId) => {
     return this.client.basicGet(`${await this.baseUrl()}/cloudProviders/${cpId}/region/${regionId}`)
   }
 
-  async updateCloudProvider (cpId, params) {
+  updateCloudProvider = async (cpId, params) => {
     return this.client.basicPut(`${await this.baseUrl()}/cloudProviders/${cpId}`, params)
   }
 
-  async deleteCloudProvider (cpId) {
+  deleteCloudProvider = async (cpId) => {
     return this.client.basicDelete(`${await this.baseUrl()}/cloudProviders/${cpId}`)
   }
 
@@ -59,7 +59,7 @@ class Qbert {
   }
 
   /* Cloud Providers Types */
-  async getCloudProviderTypes () {
+  getCloudProviderTypes = async () => {
     return this.client.basicGet(`${await this.baseUrl()}/cloudProvider/types`)
   }
 
@@ -74,7 +74,7 @@ class Qbert {
   }
 
   /* SSH Keys */
-  async importSshKey (cpId, regionId, body) {
+  importSshKey = async (cpId, regionId, body) => {
     return this.client.basicPost(`${await this.baseUrl()}/cloudProviders/${cpId}/region/${regionId}`)
   }
 
@@ -91,23 +91,23 @@ class Qbert {
     }))
   }
 
-  async getClusterDetails (clusterId) {
+  getClusterDetails = async (clusterId) => {
     return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}`)
   }
 
-  async createCluster (params) {
+  createCluster = async (params) => {
     return this.client.basicPost(`${await this.baseUrl()}/clusters`, params)
   }
 
-  async updateCluster (clusterId, params) {
+  updateCluster = async (clusterId, params) => {
     return this.client.basicPut(`${await this.baseUrl()}/clusters/${clusterId}`, params)
   }
 
-  async upgradeCluster (clusterId) {
+  upgradeCluster = async (clusterId) => {
     return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/upgrade`)
   }
 
-  async deleteCluster (clusterId) {
+  deleteCluster = async (clusterId) => {
     return this.client.basicDelete(`${await this.baseUrl()}/clusters/${clusterId}`)
   }
 
@@ -117,28 +117,28 @@ class Qbert {
 
   // @param clusterId = cluster.uuid
   // @param nodes = [{ uuid: node.uuid, isMaster: (true|false) }]
-  async attach (clusterId, nodes) {
+  attach = async (clusterId, nodes) => {
     return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/attach`, nodes)
   }
 
   // @param clusterId = cluster.uuid
   // @param nodes = [node1Uuid, node2Uuid, ...]
-  async detach (clusterId, nodeUuids) {
+  detach = async (clusterId, nodeUuids) => {
     const body = nodeUuids.map(uuid => ({ uuid }))
     return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/detach`, body)
   }
 
-  async getCliToken (clusterId, namespace) {
+  getCliToken = async (clusterId, namespace) => {
     const response = await this.client.basicPost(`${await this.baseUrl()}/webcli/${clusterId}`, { namespace })
     return response.token
   }
 
-  async getKubeConfig (clusterId) {
+  getKubeConfig = async (clusterId) => {
     return this.client.basicGet(`${await this.baseUrl()}/kubeconfig/${clusterId}`)
   }
 
   /* k8s API */
-  async getKubernetesVersion (clusterId) {
+  getKubernetesVersion = async (clusterId) => {
     return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/version`)
   }
 
@@ -151,7 +151,7 @@ class Qbert {
     namespace: cluster.metadata.namespace,
   })
 
-  async getClusterNamespaces (clusterId) {
+  getClusterNamespaces = async (clusterId) => {
     try {
       const data = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1/namespaces`)
 
@@ -162,17 +162,17 @@ class Qbert {
     }
   }
 
-  async createNamespace (clusterId, body) {
+  createNamespace = async (clusterId, body) => {
     const raw = await this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1/namespaces`, body)
     const converted = this.convertCluster(clusterId)(raw)
     return converted
   }
 
-  async deleteNamespace (clusterId, namespaceName) {
+  deleteNamespace = async (clusterId, namespaceName) => {
     return this.client.basicDelete(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1/namespaces/${namespaceName}`)
   }
 
-  async getClusterPods (params) {
+  getClusterPods = async (params) => {
     const { clusterId } = params
     try {
       const data = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1/pods`)
@@ -183,7 +183,7 @@ class Qbert {
     }
   }
 
-  async getClusterDeployments (params) {
+  getClusterDeployments = async (params) => {
     const { clusterId } = params
     try {
       const data = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/extensions/v1beta1/deployments`)
@@ -194,11 +194,11 @@ class Qbert {
     }
   }
 
-  async deleteDeployment (clusterId, namespace, name) {
+  deleteDeployment = async (clusterId, namespace, name) => {
     return this.client.basicDelete(`${await this.baseUrl()}}/k8sapi/apis/extensions/v1beta1/namespaces/${namespace}/deployments/${name}`)
   }
 
-  async getClusterKubeServices (params) {
+  getClusterKubeServices = async (params) => {
     const { clusterId } = params
     try {
       const data = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1/services`)
@@ -209,27 +209,27 @@ class Qbert {
     }
   }
 
-  async getClusterStorageClasses (clusterId) {
+  getClusterStorageClasses = async (clusterId) => {
     return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/storage.k8s.io/v1/storageclasses`)
   }
 
-  async createStorageClass (clusterId, params) {
+  createStorageClass = async (clusterId, params) => {
     return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/storage.k8s.io/v1/storageclasses`)
   }
 
-  async deleteStorageClass (clusterId, name) {
+  deleteStorageClass = async (clusterId, name) => {
     return this.client.basicDelete(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/storage.k8s.io/v1/storageclasses/${name}`)
   }
 
-  async getReplicaSets (clusterId) {
+  getReplicaSets = async (clusterId) => {
     return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/extensions/v1beta1/replicasets`)
   }
 
-  async createPod (clusterId, namespace, params) {
+  createPod = async (clusterId, namespace, params) => {
     return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1/namespaces/${namespace}/pods`, params)
   }
 
-  async deletePod (clusterId, namespace, name) {
+  deletePod = async (clusterId, namespace, name) => {
     return this.client.basicDelete(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1/namespaces/${namespace}/pods/${name}`)
   }
 
@@ -239,7 +239,7 @@ class Qbert {
     delete: this.deletePod.bind(this),
   }
 
-  async createDeployment (clusterId, namespace, params) {
+  createDeployment = async (clusterId, namespace, params) => {
     return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/extensions/v1beta1/namespaces/${namespace}/deployments`, params)
   }
 
@@ -249,11 +249,11 @@ class Qbert {
     delete: this.deleteDeployment.bind(this),
   }
 
-  async createService (clusterId, namespace, params) {
+  createService = async (clusterId, namespace, params) => {
     return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1/namespaces/${namespace}/services`, params)
   }
 
-  async deleteService (clusterId, namespace, name) {
+  deleteService = async (clusterId, namespace, name) => {
     return this.client.basicDelete(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1/namespaces/${namespace}/services/${name}`)
   }
 
@@ -263,71 +263,71 @@ class Qbert {
     delete: this.deleteService.bind(this),
   }
 
-  async createServiceAccount (clusterId, namespace, params) {
+  createServiceAccount = async (clusterId, namespace, params) => {
     return this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1/namespaces/${namespace}/serviceaccounts`)
   }
 
   /* Monocular endpoints being exposed through Qbert */
-  async getCharts (clusterId) {
+  getCharts = async (clusterId) => {
     return this.client.basicGet(`${await this.clusterMonocularBaseUrl(clusterId)}/charts`)
   }
 
-  async getChart (clusterId, chart, release, version) {
+  getChart = async (clusterId, chart, release, version) => {
     const versionStr = version ? `/versions/${version}` : ''
     return this.client.basicGet(`${await this.clusterMonocularBaseUrl(clusterId)}/charts/${chart}/${release}/${versionStr}`)
   }
 
-  async getChartVersions (clusterId, chart, release) {
+  getChartVersions = async (clusterId, chart, release) => {
     return this.client.basicGet(`${await this.clusterMonocularBaseUrl(clusterId)}/charts/${chart}/${release}/versions`)
   }
 
-  async getReleases (clusterId) {
+  getReleases = async (clusterId) => {
     return this.client.basicGet(`${await this.clusterMonocularBaseUrl(clusterId)}/releases`)
   }
 
-  async getRelease (clusterId, name) {
+  getRelease = async (clusterId, name) => {
     return this.client.basicGet(`${await this.clusterMonocularBaseUrl(clusterId)}/releases/${name}`)
   }
 
-  async deleteRelease (clusterId, name) {
+  deleteRelease = async (clusterId, name) => {
     return this.client.basicDelete(`${await this.clusterMonocularBaseUrl(clusterId)}/releases/${name}`)
   }
 
-  async deployApplication (clusterId, body) {
+  deployApplication = async (clusterId, body) => {
     return this.client.basicPost(`${await this.clusterMonocularBaseUrl(clusterId)}/releases`, body)
   }
 
-  async getRepositories () {
+  getRepositories = async () => {
     return this.client.basicGet(`${await this.monocularBaseUrl()}/repos`)
   }
 
-  async getRepositoriesForCluster (clusterId) {
+  getRepositoriesForCluster = async (clusterId) => {
     return this.client.basicGet(`${await this.clusterMonocularBaseUrl(clusterId)}/repos`)
   }
 
-  async createRepository (body) {
+  createRepository = async (body) => {
     return this.client.basicPost(`${this.monocularBaseUrl()}/repos`, body)
   }
 
-  async createRepositoryForCluster (clusterId, body) {
+  createRepositoryForCluster = async (clusterId, body) => {
     return this.client.basicGet(`${await this.clusterMonocularBaseUrl(clusterId)}/repos`, body)
   }
 
-  async deleteRepository (repoId) {
+  deleteRepository = async (repoId) => {
     return this.client.basicDelete(`${this.monocularBaseUrl()}/repos/${repoId}`)
   }
 
-  async deleteRepositoriesForCluster (clusterId, repoId) {
+  deleteRepositoriesForCluster = async (clusterId, repoId) => {
     return this.client.basicDelete(`${await this.clusterMonocularBaseUrl(clusterId)}/repos/${repoId}`)
   }
 
-  async getServiceAccounts (clusterId, namespace) {
+  getServiceAccounts = async (clusterId, namespace) => {
     const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/api/v1/namespaces/${namespace}/serviceaccounts`)
     return response.items
   }
 
   /* Managed Apps */
-  async getPrometheusInstances (clusterUuid) {
+  getPrometheusInstances = async (clusterUuid) => {
     const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/prometheuses`)
     return normalizePrometheusResponse(clusterUuid, response)
   }
@@ -335,7 +335,7 @@ class Qbert {
   // TODO: What is the API call to delete prometheus instances?  How do we uniquely identify them
   // async deletePrometheusInstances (clusterUuid, ???)
 
-  async createPrometheusInstance (clusterId, data) {
+  createPrometheusInstance = async (clusterId, data) => {
     const requests = {}
     if (data.cpu) { requests.cpu = `${data.cpu}m` }
     if (data.memory) { requests.memory = `${data.memory}Mi` }
@@ -421,17 +421,17 @@ class Qbert {
     return response
   }
 
-  async getPrometheusServiceMonitors (clusterUuid) {
+  getPrometheusServiceMonitors = async (clusterUuid) => {
     const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/servicemonitors`)
     return normalizePrometheusResponse(clusterUuid, response)
   }
 
-  async getPrometheusRules (clusterUuid) {
+  getPrometheusRules = async (clusterUuid) => {
     const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/prometheusrules`)
     return normalizePrometheusResponse(clusterUuid, response)
   }
 
-  async getPrometheusAlertManagers (clusterUuid) {
+  getPrometheusAlertManagers = async (clusterUuid) => {
     const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/alertmanagers`)
     return normalizePrometheusResponse(clusterUuid, response)
   }

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -332,6 +332,9 @@ class Qbert {
     return normalizePrometheusResponse(clusterUuid, response)
   }
 
+  // TODO: What is the API call to delete prometheus instances?  How do we uniquely identify them
+  // async deletePrometheusInstances (clusterUuid, ???)
+
   async createPrometheusInstance (clusterId, data) {
     const requests = {}
     if (data.cpu) { requests.cpu = `${data.cpu}m` }
@@ -411,10 +414,11 @@ class Qbert {
       }
     }
 
-    this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/namespaces/${data.namespace}/prometheuses`, prometheusBody)
+    const response = await this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/namespaces/${data.namespace}/prometheuses`, prometheusBody)
     this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/namespaces/${data.namespace}/servicemonitors`, serviceMonitorBody)
     this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/namespaces/${data.namespace}/prometheusrules`, prometheusRulesBody)
     // this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/alertmanagers`, alertManagerBody)
+    return response
   }
 
   async getPrometheusServiceMonitors (clusterUuid) {

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -325,6 +325,7 @@ class Qbert {
 
   /* Managed Apps */
   async getPrometheusInstances (clusterId) {
+    console.log('Getting prometheus instances for ', clusterId)
     return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/prometheuses`)
   }
 
@@ -418,6 +419,10 @@ class Qbert {
 
   async getPrometheusRules (clusterId) {
     return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/prometheusrules`)
+  }
+
+  async getPrometheusAlertManagers (clusterId) {
+    return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/alertmanagers`)
   }
 }
 

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -1,5 +1,7 @@
 import { keyValueArrToObj } from 'utils/fp'
 
+const normalizePrometheusResponse = (clusterUuid, response) => response.items.map(x => ({ ...x, clusterUuid }))
+
 /* eslint-disable camelcase */
 class Qbert {
   constructor (client) {
@@ -324,9 +326,10 @@ class Qbert {
   }
 
   /* Managed Apps */
-  async getPrometheusInstances (clusterId) {
-    console.log('Getting prometheus instances for ', clusterId)
-    return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/prometheuses`)
+  async getPrometheusInstances (clusterUuid) {
+    console.log('Getting prometheus instances for ', clusterUuid)
+    const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/prometheuses`)
+    return normalizePrometheusResponse(clusterUuid, response)
   }
 
   async createPrometheusInstance (clusterId, data) {
@@ -413,16 +416,19 @@ class Qbert {
     // this.client.basicPost(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/alertmanagers`, alertManagerBody)
   }
 
-  async getPrometheusServiceMonitors (clusterId) {
-    return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/servicemonitors`)
+  async getPrometheusServiceMonitors (clusterUuid) {
+    const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/servicemonitors`)
+    return normalizePrometheusResponse(clusterUuid, response)
   }
 
-  async getPrometheusRules (clusterId) {
-    return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/prometheusrules`)
+  async getPrometheusRules (clusterUuid) {
+    const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/prometheusrules`)
+    return normalizePrometheusResponse(clusterUuid, response)
   }
 
-  async getPrometheusAlertManagers (clusterId) {
-    return this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterId}/k8sapi/apis/monitoring.coreos.com/v1/alertmanagers`)
+  async getPrometheusAlertManagers (clusterUuid) {
+    const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/alertmanagers`)
+    return normalizePrometheusResponse(clusterUuid, response)
   }
 }
 

--- a/src/app/core/components/AutocompleteBase.js
+++ b/src/app/core/components/AutocompleteBase.js
@@ -103,7 +103,7 @@ class AutocompleteBase extends React.Component {
             value={value}
             onChange={this.handleChange}
             onBlur={this.handleClose}
-            endAdornment={suggestions && DropdownIcon}
+            endadornment={suggestions && DropdownIcon}
             {...other}
           />
         </FormControl>

--- a/src/app/core/components/CRUDListContainer.js
+++ b/src/app/core/components/CRUDListContainer.js
@@ -103,8 +103,15 @@ CRUDListContainer.propTypes = {
     For example sshKeys have unique identifier of 'name' and the APIs
     rely on using the name as part of the URI. Specify the unique identifier
     in props if it is different from 'id'
+
+    For more complicated scenarios, you can pass a funciton that receives the row data and returns the uid.
+    It has the following type signature:
+      uniqueIdentifier :: RowData -> String
   */
-  uniqueIdentifier: PropTypes.string,
+  uniqueIdentifier: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
+  ]),
 }
 
 CRUDListContainer.defaultProps = {

--- a/src/app/core/components/listTable/ListTable.js
+++ b/src/app/core/components/listTable/ListTable.js
@@ -296,12 +296,12 @@ class ListTable extends React.Component {
     )
   }
 
-  getSortedVisibleColums = () => {
+  getSortedVisibleColumns = () => {
     const { columns } = this.props
     const { columnsOrder, visibleColumns } = this.state
     return columnsOrder
       .map(columnId => columns.find(column => column.id === columnId))
-      .filter(column => visibleColumns.includes(column.id))
+      .filter(column => column && column.id && visibleColumns.includes(column.id))
   }
 
   renderRow = row => {
@@ -315,14 +315,16 @@ class ListTable extends React.Component {
       selected: isSelected
     } : {}
 
-    const uid = row[uniqueIdentifier]
+    const uid = uniqueIdentifier instanceof Function
+      ? uniqueIdentifier(row)
+      : row[uniqueIdentifier]
 
     return (
       <TableRow hover key={uid} {...checkboxProps}>
         {showCheckboxes && (<TableCell padding="checkbox">
           <Checkbox checked={isSelected} color="primary" />
         </TableCell>)}
-        {this.getSortedVisibleColums().map(columnDef =>
+        {this.getSortedVisibleColumns().map(columnDef =>
           this.renderCell(columnDef, path((columnDef.id || '').split('.'), row), row)
         )}
         {this.renderRowActions(row)}
@@ -404,7 +406,7 @@ class ListTable extends React.Component {
               <Table className={classes.table}>
                 <ListTableHead
                   canDragColumns={canDragColumns}
-                  columns={this.getSortedVisibleColums()}
+                  columns={this.getSortedVisibleColumns()}
                   onColumnsSwitch={this.handleColumnsSwitch}
                   numSelected={selected.length}
                   order={order}
@@ -477,8 +479,15 @@ ListTable.propTypes = {
    For example sshKeys have unique identifier of 'name' and the APIs
    rely on using the name as part of the URI. Specify the unique identifier
    in props if it is different from 'id'
+
+   For more complicated scenarios, you can pass a funciton that receives the row data and returns the uid.
+   It has the following type signature:
+     uniqueIdentifier :: RowData -> String
    */
-  uniqueIdentifier: PropTypes.string,
+  uniqueIdentifier: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
+  ]),
 
   /**
    * List of batch actions that can be performed

--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import CheckboxField from 'core/components/validatedForm/CheckboxField'
-import FormWrapper from 'core/components/FormWrapper'
 import KeyValuesField from 'core/components/validatedForm/KeyValuesField'
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import PrometheusRuleForm from './PrometheusRuleForm'
@@ -9,13 +8,18 @@ import TextField from 'core/components/validatedForm/TextField'
 import ValidatedForm from 'core/components/validatedForm/ValidatedForm'
 import Wizard from 'core/components/Wizard'
 import WizardStep from 'core/components/WizardStep'
+import createAddComponents from 'core/helpers/createAddComponents'
 import uuid from 'uuid'
 import { compose, propEq } from 'ramda'
-import { loadServiceAccounts, createPrometheusInstance } from './actions'
 import { projectAs } from 'utils/fp'
 import { withAppContext } from 'core/AppContext'
 import { withDataLoader } from 'core/DataLoader'
 import { loadClusters, loadNamespaces } from 'k8s/components/infrastructure/actions'
+import {
+  createPrometheusInstance,
+  loadPrometheusResources,
+  loadServiceAccounts,
+} from './actions'
 
 const initialContext = {
   numInstances: 1,
@@ -26,7 +30,7 @@ const initialContext = {
   port: 'prometheus',
 }
 
-class AddPrometheusInstancePage extends React.Component {
+class AddPrometheusInstanceFormBase extends React.Component {
   state = {
     clusterUuid: null,
     namespace: null,
@@ -34,10 +38,11 @@ class AddPrometheusInstancePage extends React.Component {
     serviceAccounts: [],
   }
 
-  handleSubmit = data => {
-    const { context, setContext } = this.props
-    data.rules = this.state.rules
-    createPrometheusInstance({ data, context, setContext })
+  handleSubmit = async data => {
+    const { onComplete } = this.props
+    const { rules } = this.state
+    data.rules = rules
+    onComplete(data)
   }
 
   handleAddRule = rule => {
@@ -70,70 +75,81 @@ class AddPrometheusInstancePage extends React.Component {
       : []
     const enableStorage = false // We are just using ephemeral storage for the first version
     return (
-      <FormWrapper title="Add Prometheus Instance">
-        <Wizard onComplete={this.handleSubmit} context={initialContext}>
-          {({ wizardContext, setWizardContext, onNext }) => {
-            return (
-              <React.Fragment>
-                <WizardStep stepId="instance" label="Prometheus Instsance">
-                  <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
-                    <TextField id="name" label="Name" info="Name of the Prometheus instance" />
-                    <TextField id="numInstances" label="# of instances" info="Number of Prometheus instances" type="number" />
-                    <TextField id="cpu" label="CPU" info="Expressed in millicores (1m = 1/1000th of a core)" type="number" />
-                    <TextField id="memory" label="Memory" info="MiB of memory to allocate" type="number" />
-                    {enableStorage &&
-                    <TextField id="storage" label="Storage" info="The storage allocation.  Default is 8 GiB" type="number" />}
+      <Wizard onComplete={this.handleSubmit} context={initialContext}>
+        {({ wizardContext, setWizardContext, onNext }) => {
+          return (
+            <React.Fragment>
+              <WizardStep stepId="instance" label="Prometheus Instsance">
+                <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
+                  <TextField id="name" label="Name" info="Name of the Prometheus instance" />
+                  <TextField id="numInstances" label="# of instances" info="Number of Prometheus instances" type="number" />
+                  <TextField id="cpu" label="CPU" info="Expressed in millicores (1m = 1/1000th of a core)" type="number" />
+                  <TextField id="memory" label="Memory" info="MiB of memory to allocate" type="number" />
+                  {enableStorage &&
+                  <TextField id="storage" label="Storage" info="The storage allocation.  Default is 8 GiB" type="number" />}
 
-                    <PicklistField
-                      id="cluster"
-                      options={clusterOptions}
-                      onChange={this.handleClusterChange}
-                      label="Cluster"
-                      info="Clusters available with RoleBinding from admin delegation"
-                    />
+                  <PicklistField
+                    id="cluster"
+                    options={clusterOptions}
+                    onChange={this.handleClusterChange}
+                    label="Cluster"
+                    info="Clusters available with RoleBinding from admin delegation"
+                  />
 
-                    {namespaceOptions.length > 0 &&
-                    <PicklistField
-                      id="namespace"
-                      onChange={this.handleNamespaceChange}
-                      options={namespaceOptions}
-                      label="Namespace"
-                      info="Which namespace to use"
-                    />}
+                  {namespaceOptions.length > 0 &&
+                  <PicklistField
+                    id="namespace"
+                    onChange={this.handleNamespaceChange}
+                    options={namespaceOptions}
+                    label="Namespace"
+                    info="Which namespace to use"
+                  />}
 
-                    {serviceAccountOptions.length > 0 &&
-                    <PicklistField
-                      id="serviceAccountName"
-                      options={serviceAccountOptions}
-                      label="Service Account Name"
-                      info="Prometheus will use this to query metrics endpoints"
-                    />}
+                  {serviceAccountOptions.length > 0 &&
+                  <PicklistField
+                    id="serviceAccountName"
+                    options={serviceAccountOptions}
+                    label="Service Account Name"
+                    info="Prometheus will use this to query metrics endpoints"
+                  />}
 
-                    {enableStorage &&
-                    <CheckboxField id="enablePersistentStorage" label="Enable persistent storage" />}
-                    <TextField id="retention" label="Storage Retention (days)" info="Defaults to 15 days if nothing is set" type="number" />
-                    <TextField id="port" label="Service Monitor Port" info="Port for the service monitor" />
-                    <KeyValuesField id="appLabels" label="App Labels" info="Key/value pairs for app that Prometheus will monitor" />
-                  </ValidatedForm>
-                </WizardStep>
-                <WizardStep stepId="config" label="Configure Alerting">
-                  {rules.length > 0 &&
-                  <PrometheusRulesTable rules={this.state.rules} onDelete={this.handleDeleteRule} />}
-                  <PrometheusRuleForm onSubmit={this.handleAddRule} />
-                </WizardStep>
-              </React.Fragment>
-            )
-          }}
-        </Wizard>
-      </FormWrapper>
+                  {enableStorage &&
+                  <CheckboxField id="enablePersistentStorage" label="Enable persistent storage" />}
+                  <TextField id="retention" label="Storage Retention (days)" info="Defaults to 15 days if nothing is set" type="number" />
+                  <TextField id="port" label="Service Monitor Port" info="Port for the service monitor" />
+                  <KeyValuesField id="appLabels" label="App Labels" info="Key/value pairs for app that Prometheus will monitor" />
+                </ValidatedForm>
+              </WizardStep>
+              <WizardStep stepId="config" label="Configure Alerting">
+                {rules.length > 0 &&
+                <PrometheusRulesTable rules={this.state.rules} onDelete={this.handleDeleteRule} />}
+                <PrometheusRuleForm onSubmit={this.handleAddRule} />
+              </WizardStep>
+            </React.Fragment>
+          )
+        }}
+      </Wizard>
     )
   }
 }
 
-export default compose(
+const AddPrometheusInstanceForm = compose(
   withDataLoader({
     clusters: loadClusters,
     namespaces: loadNamespaces,
   }),
   withAppContext,
-)(AddPrometheusInstancePage)
+)(AddPrometheusInstanceFormBase)
+
+export const options = {
+  FormComponent: AddPrometheusInstanceForm,
+  createFn: createPrometheusInstance,
+  loaderFn: loadPrometheusResources,
+  listUrl: '/ui/kubernetes/prometheus#instances',
+  name: 'AddPrometheusInstance',
+  title: 'Add Prometheus Instance',
+}
+
+const { AddPage } = createAddComponents(options)
+
+export default AddPage

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusAlertManagers.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusAlertManagers.js
@@ -16,10 +16,10 @@ export const columns = [
 export const options = {
   columns,
   dataKey: 'prometheusAlertManagers',
-  editUrl: '/ui/kubernetes/prometheus/serviceMonitors/edit',
+  editUrl: '/ui/kubernetes/prometheus/alertManagers/edit',
   loaderFn: loadPrometheusAlertManagers,
-  name: 'PrometheuServiceMonitors',
-  title: 'Prometheus Service Monitors',
+  name: 'PrometheusAlertManagers',
+  title: 'Prometheus Alert Managers',
   uniqueIdentifier: 'name',
 }
 

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusAlertManagers.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusAlertManagers.js
@@ -1,0 +1,29 @@
+import createCRUDComponents from 'core/helpers/createCRUDComponents'
+import { loadPrometheusAlertManagers } from './actions'
+
+const renderClusterName = (field, row, context) => {
+  const cluster = context.clusters.find(x => x.uuid === row.clusterUuid)
+  return cluster.name
+}
+
+export const columns = [
+  { id: 'name', label: 'Name' },
+  { id: 'clusterName', label: 'Cluster', render: renderClusterName },
+  { id: 'namespace', label: 'Namespace' },
+  { id: 'replicas', label: 'Replicas' },
+]
+
+export const options = {
+  columns,
+  dataKey: 'prometheusAlertManagers',
+  editUrl: '/ui/kubernetes/prometheus/serviceMonitors/edit',
+  loaderFn: loadPrometheusAlertManagers,
+  name: 'PrometheuServiceMonitors',
+  title: 'Prometheus Service Monitors',
+  uniqueIdentifier: 'name',
+}
+
+const { ListPage, List } = createCRUDComponents(options)
+export const PrometheusAlertManagerList = List
+
+export default ListPage

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusAlerts.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusAlerts.js
@@ -1,5 +1,0 @@
-import React from 'react'
-
-const PrometheusAlerts = () => <h1>Prometheus Alerts</h1>
-
-export default PrometheusAlerts

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
@@ -1,9 +1,12 @@
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
-import { loadPrometheusResources } from './actions'
+import {
+  deletePrometheusInstance,
+  loadPrometheusResources,
+} from './actions'
 
 const renderKeyValues = obj => Object.entries(obj)
   .map(([key, value]) => `${key}: ${value}`)
-  .join(', <br/>')
+  .join(', ')
 
 const renderClusterName = (field, row, context) => {
   const cluster = context.clusters.find(x => x.uuid === row.clusterUuid)
@@ -32,6 +35,7 @@ export const options = {
   addUrl: '/ui/kubernetes/prometheus/instances/add',
   columns,
   dataKey: 'prometheusInstances',
+  deleteFn: deletePrometheusInstance,
   editUrl: '/ui/kubernetes/prometheus/instances/edit',
   loaderFn: loadPrometheusResources,
   name: 'PrometheusInstances',

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
@@ -10,10 +10,14 @@ const renderClusterName = (field, row, context) => {
   return cluster.name
 }
 
+// Placeholder for now until the dashboard links are working
+const renderBlank = () => ''
+
 export const columns = [
   { id: 'name', label: 'Name' },
   { id: 'clusterName', label: 'cluster', render: renderClusterName },
   { id: 'namespace', label: 'Namespace' },
+  { id: 'dashboard', label: 'Dashboard', render: renderBlank },
   { id: 'serviceMonitorSelector', label: 'Service Monitor', render: renderKeyValues },
   { id: 'alertManagersSelector', label: 'Alert Managers' },
   { id: 'cpu', label: 'CPU' },

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
@@ -1,13 +1,18 @@
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import { loadPrometheusResources } from './actions'
 
-// const renderAsJson = data => JSON.stringify(data)
 const renderKeyValues = obj => Object.entries(obj)
   .map(([key, value]) => `${key}: ${value}`)
   .join(', <br/>')
 
+const renderClusterName = (field, row, context) => {
+  const cluster = context.clusters.find(x => x.uuid === row.clusterUuid)
+  return cluster.name
+}
+
 export const columns = [
   { id: 'name', label: 'Name' },
+  { id: 'clusterName', label: 'cluster', render: renderClusterName },
   { id: 'namespace', label: 'Namespace' },
   { id: 'serviceMonitorSelector', label: 'Service Monitor', render: renderKeyValues },
   { id: 'alertManagersSelector', label: 'Alert Managers' },

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusMonitoringPage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusMonitoringPage.js
@@ -1,15 +1,54 @@
 import React from 'react'
+
+import Picklist from 'core/components/Picklist'
 import Tabs from 'core/components/Tabs'
 import Tab from 'core/components/Tab'
 
 import PrometheusInstances from './PrometheusInstances'
-import PrometheusAlerts from './PrometheusAlerts'
+import PrometheusRules from './PrometheusRules'
 
-const PrometheusMonitoringPage = () => (
-  <Tabs>
-    <Tab value="instances" label="Prometheus Instances"><PrometheusInstances /></Tab>
-    <Tab value="alerts" label="Alerts"><PrometheusAlerts /></Tab>
-  </Tabs>
-)
+import { compose } from 'ramda'
+import { projectAs } from 'utils/fp'
+import { loadInfrastructure } from '../infrastructure/actions'
+import { withAppContext } from 'core/AppContext'
+import { withDataLoader } from 'core/DataLoader'
 
-export default PrometheusMonitoringPage
+const PrometheusAlerts = () => <h1>Alerts</h1>
+const PrometheusServiceMonitors = () => <h1>Service Monitors</h1>
+
+class PrometheusMonitoringPage extends React.Component {
+  state = {
+    // clusterUuid: '',
+    clusterUuid: 'e8f1d175-2e7d-40fa-a475-ed20b8d8c66d',  // hard-coding during developing to work faster
+  }
+
+  handleClusterChange = clusterUuid => this.setState({ clusterUuid })
+
+  render () {
+    const { clusterUuid } = this.state
+    const { clusters } = this.props.context
+    const clusterOptions = projectAs({ value: 'uuid', label: 'name' }, clusters)
+    return (
+      <div>
+        <Picklist
+          name="cluster"
+          options={clusterOptions}
+          onChange={this.handleClusterChange}
+          value={clusterUuid}
+          label="Cluster"
+        />
+        <Tabs>
+          <Tab value="instances" label="Prometheus Instances"><PrometheusInstances clusterUuid={clusterUuid} /></Tab>
+          <Tab value="rules" label="Rules"><PrometheusRules clusterUuid={clusterUuid} /></Tab>
+          <Tab value="serviceMonitors" label="Service Monitors"><PrometheusServiceMonitors clusterUuid={clusterUuid} /></Tab>
+          <Tab value="alerts" label="Alert Managers"><PrometheusAlerts clusterUuid={clusterUuid} /></Tab>
+        </Tabs>
+      </div>
+    )
+  }
+}
+
+export default compose(
+  withDataLoader({ dataKey: 'clusters', loaderFn: loadInfrastructure }),
+  withAppContext,
+)(PrometheusMonitoringPage)

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusMonitoringPage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusMonitoringPage.js
@@ -1,47 +1,27 @@
 import React from 'react'
 
-import Picklist from 'core/components/Picklist'
 import Tabs from 'core/components/Tabs'
 import Tab from 'core/components/Tab'
 
 import PrometheusInstances from './PrometheusInstances'
 import PrometheusRules from './PrometheusRules'
+import PrometheusServiceMonitors from './PrometheusServiceMonitors'
+import PrometheusAlertManagers from './PrometheusAlertManagers'
 
 import { compose } from 'ramda'
-import { projectAs } from 'utils/fp'
-import { loadInfrastructure } from '../infrastructure/actions'
+import { loadPrometheusResources } from './actions'
 import { withAppContext } from 'core/AppContext'
 import { withDataLoader } from 'core/DataLoader'
 
-const PrometheusAlerts = () => <h1>Alerts</h1>
-const PrometheusServiceMonitors = () => <h1>Service Monitors</h1>
-
 class PrometheusMonitoringPage extends React.Component {
-  state = {
-    // clusterUuid: '',
-    clusterUuid: 'e8f1d175-2e7d-40fa-a475-ed20b8d8c66d',  // hard-coding during developing to work faster
-  }
-
-  handleClusterChange = clusterUuid => this.setState({ clusterUuid })
-
   render () {
-    const { clusterUuid } = this.state
-    const { clusters } = this.props.context
-    const clusterOptions = projectAs({ value: 'uuid', label: 'name' }, clusters)
     return (
       <div>
-        <Picklist
-          name="cluster"
-          options={clusterOptions}
-          onChange={this.handleClusterChange}
-          value={clusterUuid}
-          label="Cluster"
-        />
         <Tabs>
-          <Tab value="instances" label="Prometheus Instances"><PrometheusInstances clusterUuid={clusterUuid} /></Tab>
-          <Tab value="rules" label="Rules"><PrometheusRules clusterUuid={clusterUuid} /></Tab>
-          <Tab value="serviceMonitors" label="Service Monitors"><PrometheusServiceMonitors clusterUuid={clusterUuid} /></Tab>
-          <Tab value="alerts" label="Alert Managers"><PrometheusAlerts clusterUuid={clusterUuid} /></Tab>
+          <Tab value="instances" label="Prometheus Instances"><PrometheusInstances /></Tab>
+          <Tab value="rules" label="Rules"><PrometheusRules /></Tab>
+          <Tab value="serviceMonitors" label="Service Monitors"><PrometheusServiceMonitors /></Tab>
+          <Tab value="alerts" label="Alert Managers"><PrometheusAlertManagers /></Tab>
         </Tabs>
       </div>
     )
@@ -49,6 +29,6 @@ class PrometheusMonitoringPage extends React.Component {
 }
 
 export default compose(
-  withDataLoader({ dataKey: 'clusters', loaderFn: loadInfrastructure }),
+  withDataLoader({ prometheusInstances: loadPrometheusResources }),
   withAppContext,
 )(PrometheusMonitoringPage)

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusRules.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusRules.js
@@ -1,0 +1,26 @@
+import createCRUDComponents from 'core/helpers/createCRUDComponents'
+import { loadPrometheusResources } from './actions'
+
+const renderKeyValues = obj => Object.entries(obj)
+  .map(([key, value]) => `${key}: ${value}`)
+  .join(', ')
+
+export const columns = [
+  { id: 'name', label: 'Name' },
+  { id: 'namespace', label: 'Namespace' },
+  { id: 'labels',  label: 'labels', render: renderKeyValues }
+]
+
+export const options = {
+  columns,
+  dataKey: 'prometheusRules',
+  editUrl: '/ui/kubernetes/prometheus/rules/edit',
+  loaderFn: args => loadPrometheusResources(),
+  name: 'PrometheusRules',
+  title: 'Prometheus Rules',
+}
+
+const { ListPage, List } = createCRUDComponents(options)
+export const PrometheusInstancesList = List
+
+export default ListPage

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
@@ -26,7 +26,7 @@ export const options = {
   loaderFn: loadPrometheusServiceMonitors,
   name: 'PrometheuServiceMonitors',
   title: 'Prometheus Service Monitors',
-  uniqueIdentifier: 'name',
+  uniqueIdentifier: sm => `${sm.clusterUuid}-${sm.namespace}-${sm.name}`,
 }
 
 const { ListPage, List } = createCRUDComponents(options)

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
@@ -1,5 +1,5 @@
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
-import { loadPrometheusRules } from './actions'
+import { loadPrometheusServiceMonitors } from './actions'
 
 const renderKeyValues = obj => Object.entries(obj)
   .map(([key, value]) => `${key}: ${value}`)
@@ -14,20 +14,22 @@ export const columns = [
   { id: 'name', label: 'Name' },
   { id: 'clusterName', label: 'cluster', render: renderClusterName },
   { id: 'namespace', label: 'Namespace' },
-  { id: 'labels',  label: 'labels', render: renderKeyValues }
+  { id: 'labels',  label: 'Labels', render: renderKeyValues },
+  { id: 'port',  label: 'Port' },
+  { id: 'selector',  label: 'Selector', render: renderKeyValues },
 ]
 
 export const options = {
   columns,
-  dataKey: 'prometheusRules',
-  editUrl: '/ui/kubernetes/prometheus/rules/edit',
-  loaderFn: loadPrometheusRules,
-  name: 'PrometheusRules',
-  title: 'Prometheus Rules',
+  dataKey: 'prometheusServiceMonitors',
+  editUrl: '/ui/kubernetes/prometheus/serviceMonitors/edit',
+  loaderFn: loadPrometheusServiceMonitors,
+  name: 'PrometheuServiceMonitors',
+  title: 'Prometheus Service Monitors',
   uniqueIdentifier: 'name',
 }
 
 const { ListPage, List } = createCRUDComponents(options)
-export const PrometheusRulesList = List
+export const PrometheusServiceMonitorsList = List
 
 export default ListPage

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
@@ -24,7 +24,7 @@ export const options = {
   dataKey: 'prometheusServiceMonitors',
   editUrl: '/ui/kubernetes/prometheus/serviceMonitors/edit',
   loaderFn: loadPrometheusServiceMonitors,
-  name: 'PrometheuServiceMonitors',
+  name: 'PrometheusServiceMonitors',
   title: 'Prometheus Service Monitors',
   uniqueIdentifier: sm => `${sm.clusterUuid}-${sm.namespace}-${sm.name}`,
 }

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -1,8 +1,15 @@
 import { pathOrNull } from 'utils/fp'
 import { pathOr, prop } from 'ramda'
+// import { loadClusters } from '../infrastructure/actions'
 
 const mapServiceMonitor = x => x
-const mapRule = x => x
+
+const mapRule = ({ metadata, spec }) => ({
+  name: metadata.name,
+  namespace: metadata.namespace,
+  labels: metadata.labels,
+})
+
 const mapAlertMonitor = prop('name')
 
 const mapPrometheusInstance = ({ metadata, spec }) => ({
@@ -25,11 +32,36 @@ const mapPrometheusInstance = ({ metadata, spec }) => ({
   spec,
 })
 
+const getPrometheusInstances = uuid => context.apiClient.qbert.getPrometheusInstances(uuid)
+
+const mapAsyncItems = async (values, loaderFn, mapFn) => {
+  const promises = values.map(loaderFn)
+  const responses = await Promise.all(promises)
+  console.log(responses)
+  const items = responses.map(prop('items')).flat()
+  console.log(items)
+  const mapped = items.map(mapFn)
+  return mapped
+}
 export const loadPrometheusResources = async ({ context, setContext, reload }) => {
   if (!reload && context.prometheusInstances) { return context.prometheusInstances }
 
-  const instancesResponse = await context.apiClient.qbert.getPrometheusInstances('e8f1d175-2e7d-40fa-a475-ed20b8d8c66d')
-  const prometheusInstances = instancesResponse.items.map(mapPrometheusInstance)
+  // const clusters = await loadClusters({ context, setContext, reload })
+  // const clusterUuids = clusters.map(prop('uuid'))
+  const clusterUuids = ['e8f1d175-2e7d-40fa-a475-ed20b8d8c66d'] // hardcode for now during development
+
+  mapAsyncItems(clusterUuids, getPrometheusInstances, mapPrometheusInstance)
+    .then(prometheusInstances => setContext({ prometheusInstances }))
+
+  /*
+  parallelFlatMap(clusterUuids, uuid => ))
+    .then(tap(x => console.log(x)))
+    .then(response => (response || []).map(prop('items')))
+    .then(tap(x => console.log(x)))
+    .then(instances => instances.map(mapPrometheusInstance))
+    .then(tap(x => console.log(x)))
+    .then(prometheusInstances => setContext({ prometheusInstances }))
+  */
 
   const serviceMonitorsResponse = await context.apiClient.qbert.getPrometheusServiceMonitors('e8f1d175-2e7d-40fa-a475-ed20b8d8c66d')
   const prometheusServiceMonitors = serviceMonitorsResponse.items.map(mapServiceMonitor)
@@ -37,8 +69,7 @@ export const loadPrometheusResources = async ({ context, setContext, reload }) =
   const rulesResponse = await context.apiClient.qbert.getPrometheusRules('e8f1d175-2e7d-40fa-a475-ed20b8d8c66d')
   const prometheusRules = rulesResponse.items.map(mapRule)
 
-  setContext({ prometheusInstances, prometheusServiceMonitors, prometheusRules })
-  return prometheusInstances
+  setContext({ prometheusServiceMonitors, prometheusRules })
 }
 
 export const createPrometheusInstance = async ({ data, context, setContext }) => {

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -1,5 +1,5 @@
 import { pathOrNull } from 'utils/fp'
-import { pathOr, prop } from 'ramda'
+import { pathOr, prop, propEq } from 'ramda'
 import { loadClusters } from '../infrastructure/actions'
 
 const mapServiceMonitor = ({ clusterUuid, metadata, spec }) => ({
@@ -26,7 +26,7 @@ const mapAlertManager = ({ clusterUuid, metadata, spec }) => ({
   labels: metadata.labels,
 })
 
-const mapPrometheusInstance = ({ clusterUuid, metadata, spec }) => ({
+export const mapPrometheusInstance = ({ clusterUuid, metadata, spec }) => ({
   clusterUuid,
   name: metadata.name,
   namespace: metadata.namespace,
@@ -112,4 +112,13 @@ export const createPrometheusInstance = async ({ data, context, setContext }) =>
 export const loadServiceAccounts = async ({ data, context, setContext }) => {
   const serviceAccounts = await context.apiClient.qbert.getServiceAccounts(data.clusterUuid, data.namespace)
   return serviceAccounts
+}
+
+export const deletePrometheusInstance = async ({ id, context, setContext }) => {
+  const instance = context.prometheusInstances.find(propEq('id', id))
+  if (!instance) {
+    console.error(`Unable to find prometheus instance with id: ${id} in deletePrometheusInstance`)
+    return // eslint-disable-line no-useless-return
+  }
+  // TODO: waiting on documentation from backend team on how to do DELETE calls
 }


### PR DESCRIPTION
This PR implements Prometheus Monitoring for clusters that have Prometheus enabled.

The old UI should now have a checkbox to enable Prometheus monitoring when creating a cluster.

Once a cluster has prometheus on it, we show the Prometheus Instances, Service Monitors, AlertManagers, and PrometheusRules.

Creating a Prometheus Instance involves creating those custom resources used by the K8s Prometheus Operator.

Right now there is no way to delete or edit anything that is created.  That will come in future versions.