### PR TITLE
Delete prometheus objects

### DIFF
--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -332,8 +332,10 @@ class Qbert {
     return normalizePrometheusResponse(clusterUuid, response)
   }
 
-  // TODO: What is the API call to delete prometheus instances?  How do we uniquely identify them
-  // async deletePrometheusInstances (clusterUuid, ???)
+  deletePrometheusInstance = async (clusterUuid, namespace, name) => {
+    const response = await this.client.basicDelete(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/namespaces/${namespace}/prometheuses/${name}`)
+    return response
+  }
 
   createPrometheusInstance = async (clusterId, data) => {
     const requests = {}

--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -428,14 +428,29 @@ class Qbert {
     return normalizePrometheusResponse(clusterUuid, response)
   }
 
+  deletePrometheusServiceMonitor = async (clusterUuid, namespace, name) => {
+    const response = await this.client.basicDelete(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/namespaces/${namespace}/servicemonitors/${name}`)
+    return response
+  }
+
   getPrometheusRules = async (clusterUuid) => {
     const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/prometheusrules`)
     return normalizePrometheusResponse(clusterUuid, response)
   }
 
+  deletePrometheusRule = async (clusterUuid, namespace, name) => {
+    const response = await this.client.basicDelete(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/namespaces/${namespace}/prometheusrules/${name}`)
+    return response
+  }
+
   getPrometheusAlertManagers = async (clusterUuid) => {
     const response = await this.client.basicGet(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/alertmanagers`)
     return normalizePrometheusResponse(clusterUuid, response)
+  }
+
+  deletePrometheusAlertManager = async (clusterUuid, namespace, name) => {
+    const response = await this.client.basicDelete(`${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/monitoring.coreos.com/v1/namespaces/${namespace}/alertmanagers/${name}`)
+    return response
   }
 }
 

--- a/src/app/core/DataLoader.js
+++ b/src/app/core/DataLoader.js
@@ -24,10 +24,10 @@ class DataLoaderBase extends PureComponent {
 
   loadAll = async () =>
     this.setState({ loading: true }, async () => {
-      const { loaders, options, getContext, setContext } = this.props
+      const { loaders, options, context, getContext, setContext } = this.props
       try {
         const data = await asyncProps(mapObjIndexed(loader =>
-          loader({ getContext, setContext, reload: options.reloadOnMount }), loaders,
+          loader({ context, getContext, setContext, reload: options.reloadOnMount }), loaders,
         ))
         this.setState({ loading: false, data, error: null })
       } catch (err) {
@@ -38,9 +38,9 @@ class DataLoaderBase extends PureComponent {
 
   loadOne = (loaderKey, params, reload, cascade = false) => {
     this.setState({ loading: true }, async () => {
-      const { loaders, getContext, setContext } = this.props
+      const { loaders, context, getContext, setContext } = this.props
       try {
-        const data = await loaders[loaderKey]({ getContext, setContext, params, reload, cascade })
+        const data = await loaders[loaderKey]({ context, getContext, setContext, params, reload, cascade })
         this.setState(prevState => ({
           loading: false,
           error: null,

--- a/src/app/core/components/CRUDListContainer.js
+++ b/src/app/core/components/CRUDListContainer.js
@@ -40,7 +40,12 @@ class CRUDListContainer extends React.Component {
     const { uniqueIdentifier } = this.props
     this.setState({ showConfirmation: false })
     const items = this.state.selectedItems || []
-    await asyncMap(items, item => this.handleRemove(item[uniqueIdentifier]))
+    await asyncMap(items, item => {
+      const uid = uniqueIdentifier instanceof Function
+        ? uniqueIdentifier(item)
+        : item[uniqueIdentifier]
+      this.handleRemove(uid)
+    })
 
     this.setState({ selectedItems: [] })
     // The user resolves the promise by clicking "confirm".

--- a/src/app/core/helpers/createCRUDComponents.js
+++ b/src/app/core/helpers/createCRUDComponents.js
@@ -58,9 +58,13 @@ const createCRUDComponents = options => {
     preferences: { visibleColumns, columnsOrder, rowsPerPage },
     updatePreferences,
   }) => {
-    if (!data || data.length === 0) {
-      return <h1>No data found.</h1>
-    }
+    // Disabling the "No data found" message for now because there create action is
+    // tied to the ListTable and if there are no entities there won't be any way
+    // for the user to create new ones.
+    // TODO: We need to decouple the Add functionality from the ListTable completely.
+    // if (!data || data.length === 0) {
+    //   return <h1>No data found.</h1>
+    // }
     return (
       <ListTable
         title={title}

--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -14,7 +14,8 @@ import { compose, propEq } from 'ramda'
 import { projectAs } from 'utils/fp'
 import { withAppContext } from 'core/AppContext'
 import { withDataLoader } from 'core/DataLoader'
-import { loadClusters, loadNamespaces } from 'k8s/components/infrastructure/actions'
+import { loadClusters } from 'k8s/components/infrastructure/actions'
+import { loadNamespaces } from 'k8s/components/namespaces/actions'
 import {
   createPrometheusInstance,
   loadPrometheusResources,

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusAlertManagers.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusAlertManagers.js
@@ -20,7 +20,7 @@ export const options = {
   loaderFn: loadPrometheusAlertManagers,
   name: 'PrometheusAlertManagers',
   title: 'Prometheus Alert Managers',
-  uniqueIdentifier: 'name',
+  uniqueIdentifier: ({ clusterUuid, namespace, name }) => `${clusterUuid}-${namespace}-${name}`,
 }
 
 const { ListPage, List } = createCRUDComponents(options)

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusAlertManagers.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusAlertManagers.js
@@ -1,5 +1,8 @@
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
-import { loadPrometheusAlertManagers } from './actions'
+import {
+  deletePrometheusAlertManager,
+  loadPrometheusAlertManagers,
+} from './actions'
 
 const renderClusterName = (field, row, context) => {
   const cluster = context.clusters.find(x => x.uuid === row.clusterUuid)
@@ -16,6 +19,7 @@ export const columns = [
 export const options = {
   columns,
   dataKey: 'prometheusAlertManagers',
+  deleteFn: deletePrometheusAlertManager,
   editUrl: '/ui/kubernetes/prometheus/alertManagers/edit',
   loaderFn: loadPrometheusAlertManagers,
   name: 'PrometheusAlertManagers',

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusRules.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusRules.js
@@ -1,5 +1,8 @@
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
-import { loadPrometheusRules } from './actions'
+import {
+  deletePrometheusRule,
+  loadPrometheusRules,
+} from './actions'
 
 const renderKeyValues = obj => Object.entries(obj)
   .map(([key, value]) => `${key}: ${value}`)
@@ -20,11 +23,12 @@ export const columns = [
 export const options = {
   columns,
   dataKey: 'prometheusRules',
+  deleteFn: deletePrometheusRule,
   editUrl: '/ui/kubernetes/prometheus/rules/edit',
   loaderFn: loadPrometheusRules,
   name: 'PrometheusRules',
   title: 'Prometheus Rules',
-  uniqueIdentifier: 'name',
+  uniqueIdentifier: ({ clusterUuid, namespace, name }) => `${clusterUuid}-${namespace}-${name}`,
 }
 
 const { ListPage, List } = createCRUDComponents(options)

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
@@ -1,5 +1,8 @@
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
-import { loadPrometheusServiceMonitors } from './actions'
+import {
+  deletePrometheusServiceMonitor,
+  loadPrometheusServiceMonitors,
+} from './actions'
 
 const renderKeyValues = obj => Object.entries(obj)
   .map(([key, value]) => `${key}: ${value}`)
@@ -22,6 +25,7 @@ export const columns = [
 export const options = {
   columns,
   dataKey: 'prometheusServiceMonitors',
+  deleteFn: deletePrometheusServiceMonitor,
   editUrl: '/ui/kubernetes/prometheus/serviceMonitors/edit',
   loaderFn: loadPrometheusServiceMonitors,
   name: 'PrometheusServiceMonitors',

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
@@ -26,7 +26,7 @@ export const options = {
   loaderFn: loadPrometheusServiceMonitors,
   name: 'PrometheusServiceMonitors',
   title: 'Prometheus Service Monitors',
-  uniqueIdentifier: sm => `${sm.clusterUuid}-${sm.namespace}-${sm.name}`,
+  uniqueIdentifier: ({ clusterUuid, namespace, name }) => `${clusterUuid}-${namespace}-${name}`,
 }
 
 const { ListPage, List } = createCRUDComponents(options)

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -118,7 +118,10 @@ export const deletePrometheusInstance = async ({ id, context, setContext }) => {
   const instance = context.prometheusInstances.find(propEq('id', id))
   if (!instance) {
     console.error(`Unable to find prometheus instance with id: ${id} in deletePrometheusInstance`)
-    return // eslint-disable-line no-useless-return
+    return
   }
-  // TODO: waiting on documentation from backend team on how to do DELETE calls
+  const response = await context.apiClient.qbert.deletePrometheusInstance(instance.clusterUuid, instance.namespace, instance.name)
+  const prometheusInstances = context.prometheusInstances.filter(x => x.id !== id)
+  setContext({ prometheusInstances })
+  return response
 }

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -64,12 +64,12 @@ export const loadClusterTags = async ({ context, setContext, reload }) => {
   return clusterTags
 }
 
-export const loadPrometheusResources = async ({ context, setContext, reload }) => {
+export const loadPrometheusResources = async ({ context, getContext, setContext, reload }) => {
   if (!reload && context.prometheusInstances) { return context.prometheusInstances }
 
   const [_, clusterTags] = await Promise.all([ // eslint-disable-line no-unused-vars
-    loadClusters({ context, setContext, reload }),
-    loadClusterTags({ context, setContext, reload })
+    loadClusters({ context, getContext, setContext, reload }),
+    loadClusterTags({ context, getContext, setContext, reload })
   ])
 
   const hasMonitoring = cluster => cluster.tags.includes('pf9-system:monitoring')
@@ -123,5 +123,18 @@ export const deletePrometheusInstance = async ({ id, context, setContext }) => {
   const response = await context.apiClient.qbert.deletePrometheusInstance(instance.clusterUuid, instance.namespace, instance.name)
   const prometheusInstances = context.prometheusInstances.filter(x => x.id !== id)
   setContext({ prometheusInstances })
+  return response
+}
+
+export const deletePrometheusRule = async ({ id, context, setContext }) => {
+  const calcId = x => `${x.clusterUuid}-${x.namespace}-${x.name}`
+  const rule = context.prometheusRules.find(rule => id === calcId(rule))
+  if (!rule) {
+    console.error(`Unable to find prometheus rule with id: ${id} in deletePrometheusInstance`)
+    return
+  }
+  const response = await context.apiClient.qbert.deletePrometheusRule(rule.clusterUuid, rule.namespace, rule.name)
+  const prometheusRules = context.prometheusRules.filter(x => calcId(x) !== calcId(rule))
+  setContext({ prometheusRules })
   return response
 }

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -130,11 +130,37 @@ export const deletePrometheusRule = async ({ id, context, setContext }) => {
   const calcId = x => `${x.clusterUuid}-${x.namespace}-${x.name}`
   const rule = context.prometheusRules.find(rule => id === calcId(rule))
   if (!rule) {
-    console.error(`Unable to find prometheus rule with id: ${id} in deletePrometheusInstance`)
+    console.error(`Unable to find prometheus rule with id: ${id} in deletePrometheusrule`)
     return
   }
   const response = await context.apiClient.qbert.deletePrometheusRule(rule.clusterUuid, rule.namespace, rule.name)
   const prometheusRules = context.prometheusRules.filter(x => calcId(x) !== calcId(rule))
   setContext({ prometheusRules })
+  return response
+}
+
+export const deletePrometheusServiceMonitor = async ({ id, context, setContext }) => {
+  const calcId = x => `${x.clusterUuid}-${x.namespace}-${x.name}`
+  const sm = context.prometheusServiceMonitors.find(rule => id === calcId(rule))
+  if (!sm) {
+    console.error(`Unable to find prometheus service monitor with id: ${id} in deletePrometheusServiceMonitor`)
+    return
+  }
+  const response = await context.apiClient.qbert.deletePrometheusServiceMonitor(sm.clusterUuid, sm.namespace, sm.name)
+  const prometheusServiceMonitors = context.prometheusServiceMonitors.filter(x => calcId(x) !== calcId(sm))
+  setContext({ prometheusServiceMonitors })
+  return response
+}
+
+export const deletePrometheusAlertManager = async ({ id, context, setContext }) => {
+  const calcId = x => `${x.clusterUuid}-${x.namespace}-${x.name}`
+  const am = context.prometheusAlertManagers.find(rule => id === calcId(rule))
+  if (!am) {
+    console.error(`Unable to find prometheus alert manager with id: ${id} in deletePrometheusAlertManager`)
+    return
+  }
+  const response = await context.apiClient.qbert.deletePrometheusAlertManager(am.clusterUuid, am.namespace, am.name)
+  const prometheusAlertManagers = context.prometheusAlertManagers.filter(x => calcId(x) !== calcId(am))
+  setContext({ prometheusAlertManagers })
   return response
 }


### PR DESCRIPTION
This PR updates the Managed Prometheus functionality to use the newer data loading abstractions.

This also adds delete capability for prometheus instances, rules, service monitors, and alert managers.

There seems to be a bug with `setContext` not refreshing the view.  Not sure why this is happening but it will need to be addressed in another PR.