### PR TITLE
Fix DataLoader refresh problem and misc Prometheus fixes

### DIFF
--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import ExternalLink from 'core/components/ExternalLink'
+// import React from 'react'
+// import ExternalLink from 'core/components/ExternalLink'
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import { deletePrometheusInstance, loadPrometheusInstances } from './actions'
 
@@ -12,16 +12,19 @@ const renderClusterName = (field, row, data) => {
   return cluster.name
 }
 
+// Disabling for now until the backend has the links for this working
+/*
 const renderDashboardLink = (field, row, context) => {
   const link = context.apiClient.qbert.getPrometheusDashboardLink(row)
   return <ExternalLink url={link}>dashboard</ExternalLink>
 }
+*/
 
 export const columns = [
   { id: 'name', label: 'Name' },
   { id: 'clusterName', label: 'cluster', render: renderClusterName },
   { id: 'namespace', label: 'Namespace' },
-  { id: 'dashboard', label: 'Dashboard', render: renderDashboardLink },
+  // { id: 'dashboard', label: 'Dashboard', render: renderDashboardLink },
   { id: 'serviceMonitorSelector', label: 'Service Monitor', render: renderKeyValues },
   { id: 'alertManagersSelector', label: 'Alert Managers' },
   { id: 'cpu', label: 'CPU' },

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -52,13 +52,13 @@ export const createPrometheusInstance = contextUpdater('prometheusInstances', as
 })
 
 export const deletePrometheusInstance = contextUpdater('prometheusInstances', async ({ id, apiClient, currentItems }) => {
-  const instance = currentItems.find(propEq('id', id))
+  const instance = currentItems.find(propEq('uid', id))
   if (!instance) {
     console.error(`Unable to find prometheus instance with id: ${id} in deletePrometheusInstance`)
     return
   }
   await apiClient.qbert.deletePrometheusInstance(instance.clusterUuid, instance.namespace, instance.name)
-  return currentItems.filter(x => x.id !== id)
+  return currentItems.filter(x => x.uid !== id)
 })
 
 export const updatePrometheusInstance = contextUpdater('prometheusInstances', async ({ apiClient, data, currentItems }) => {

--- a/src/app/plugins/kubernetes/index.js
+++ b/src/app/plugins/kubernetes/index.js
@@ -105,6 +105,11 @@ Kubernetes.registerPlugin = pluginManager => {
         component: NamespacesListPage
       },
       {
+        name: 'Prometheus Monitoring (BETA)',
+        link: { path: '/prometheus', exact: true },
+        component: PrometheusMonitoringPage,
+      },
+      {
         name: 'Add Namespace',
         link: { path: '/namespaces/add', exact: true },
         component: AddNamespacePage
@@ -118,11 +123,6 @@ Kubernetes.registerPlugin = pluginManager => {
         name: 'Tenants & Users',
         link: { path: '/user_management', exact: true },
         component: UserManagementIndexPage
-      },
-      {
-        name: 'Monitoring',
-        link: { path: '/prometheus', exact: true },
-        component: PrometheusMonitoringPage,
       },
       {
         name: 'Create Prometheus Instance',
@@ -188,6 +188,7 @@ Kubernetes.registerPlugin = pluginManager => {
     },
     { name: 'Storage Classes', icon: 'hdd', ...clarityLink('/kubernetes/storage_classes') },
     { name: 'Namespaces', icon: 'object-group', ...clarityLink('/kubernetes/namespaces') },
+    { name: 'Prometheus Monitoring (BETA)', icon: 'chart-area', link: { path: '/prometheus' } },
     { name: 'API Access', icon: 'key', ...clarityLink('/kubernetes/api_access') },
     {
       name: 'Tenants & Users',
@@ -236,6 +237,7 @@ Kubernetes.registerPlugin = pluginManager => {
     },
     { name: 'Storage Classes', icon: 'hdd', link: { path: '/storage_classes' } },
     { name: 'Namespaces', icon: 'object-group', link: { path: '/namespaces' } },
+    { name: 'Prometheus Monitoring (BETA)', icon: 'chart-area', link: { path: '/prometheus' } },
     { name: 'API Access', icon: 'key', link: { path: '/api_access' } },
     {
       name: 'Tenants & Users',
@@ -251,14 +253,7 @@ Kubernetes.registerPlugin = pluginManager => {
   ]
 
   const navItems = useClarityLinks ? clarityNavItems : devNavItems
-  const commonNavItems = [
-    {
-      name: 'Monitoring',
-      icon: 'chart-area',
-      link: { path: '/prometheus' },
-
-    }
-  ]
+  const commonNavItems = []
   const allNavItems = [...navItems, ...commonNavItems]
   plugin.registerNavItems(allNavItems)
 }


### PR DESCRIPTION
This PR makes the following changes:

* Make `Prometheus Monitoring (BETA)` sidenav item appear in the same location and the same text as the `Clarity` UI.
* Fix typo in `deletePrometheusInstance` where it was using `id` instead of `uid`.
* Fix `DataLoader` so it loads and updates its data using `context` instead of local `state`.  This fixes a bug where reloaded data was updated in the `context` but the view was not seeing the changes.