### PR TITLE
Add showToast to context and use in Prometheus

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -72,8 +72,8 @@ class App extends React.Component {
       <Router>
         <ThemeProvider theme={theme}>
           <HotKeysProvider>
-            <AppContext initialContext={{ apiClient, initialized: false, sessionLoaded: false }}>
-              <ToastProvider>
+            <ToastProvider>
+              <AppContext initialContext={{ apiClient, initialized: false, sessionLoaded: false }}>
                 <PreferencesProvider>
                   <ThemeManager>
                     <div id="_main-container">
@@ -91,8 +91,8 @@ class App extends React.Component {
                     </div>
                   </ThemeManager>
                 </PreferencesProvider>
-              </ToastProvider>
-            </AppContext>
+              </AppContext>
+            </ToastProvider>
           </HotKeysProvider>
         </ThemeProvider>
       </Router>

--- a/src/app/core/AppContext.js
+++ b/src/app/core/AppContext.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { path, assocPath, flatten, omit } from 'ramda'
 import { ensureArray } from 'utils/fp'
+import { withToast } from 'core/providers/ToastProvider'
 
 const Context = React.createContext({})
 export const Consumer = Context.Consumer
@@ -10,6 +11,7 @@ export const Provider = Context.Provider
 class AppContext extends React.Component {
   state = {
     ...this.props.initialContext,
+    showToast: this.props.showToast,
 
     session: {},
 
@@ -104,4 +106,4 @@ export const withAppContext = Component => props =>
     }
   </Consumer>
 
-export default AppContext
+export default withToast(AppContext)

--- a/src/app/core/helpers/contextUpdater.js
+++ b/src/app/core/helpers/contextUpdater.js
@@ -16,9 +16,11 @@ const contextUpdater = (contextPath, updaterFn, returnLast = false) => {
     const { getContext, setContext } = args
     const loaderFn = getLoader(resolvedPath)
     const currentItems = (await loaderFn(args)) || []
+    const context = getContext()
     const output = await updaterFn({
       ...args,
-      apiClient: getContext('apiClient'),
+      showToast: context.showToast,
+      apiClient: context.apiClient,
       currentItems,
       loadFromContext: (contextPath, customArgs) =>
         getLoader(contextPath)({ ...args, ...customArgs }),

--- a/src/app/core/providers/ToastProvider.js
+++ b/src/app/core/providers/ToastProvider.js
@@ -77,6 +77,12 @@ const ToastContent = withStyles(styles)(({onClose, type, message, classes, class
   />
 })
 
+const snackbarStyle = {
+  marginBottom: '80px',
+  // Intercom uses a ridiculously high zIndex so we have to be even more ridiculous
+  zIndex: '9999999999',
+}
+
 export class ToastProvider extends Component {
   state = {
     toasts: []
@@ -123,10 +129,11 @@ export class ToastProvider extends Component {
       <ToastContext.Provider value={this.showToast}>
         {toasts.map(({id, isOpen, text, onClose, type}) =>
           <Snackbar
+            style={snackbarStyle}
             key={id}
             anchorOrigin={{
               vertical: 'bottom',
-              horizontal: 'left',
+              horizontal: 'right',
             }}
             open={isOpen}
             autoHideDuration={toastsTimeout}

--- a/src/app/core/providers/ToastProvider.js
+++ b/src/app/core/providers/ToastProvider.js
@@ -13,6 +13,7 @@ import amber from '@material-ui/core/colors/amber'
 import WarningIcon from '@material-ui/icons/Warning'
 import SnackbarContent from '@material-ui/core/SnackbarContent/SnackbarContent'
 
+// Possible values for 'type' are ['success', 'warning', 'error', 'info']
 const variantIcon = {
   success: CheckCircleIcon,
   warning: WarningIcon,


### PR DESCRIPTION
Most of the toasts need to happen inside of the `actions.js`.  Since actions are not components, there is no way to use `showToast` so I added it to the `context`.  This makes it very convenient to use.

I added toasts to the `create`, `update`, and `delete` prometheus actions.

![Screen Shot 2019-06-05 at 6 30 55 PM](https://user-images.githubusercontent.com/289156/59000702-7c46dc00-87c0-11e9-9905-74569cb9287e.png)

![Screen Shot 2019-06-05 at 6 30 25 PM](https://user-images.githubusercontent.com/289156/59000713-849f1700-87c0-11e9-924d-67572304436e.png)
