### PR TITLE
Use outlined style for form fields

### DIFF
--- a/src/app/ThemeManager.js
+++ b/src/app/ThemeManager.js
@@ -22,28 +22,9 @@ const defaultThemeJson = {
     }
   },
   overrides: {
-    MuiTableCell: {
-      root: {
-        padding: '4px 24px',
-      },
-    },
-    MuiInputBase: {
-      root: {
-        color: 'inherit'
-      }
-    },
     MuiOutlinedInput: {
       root: {
-        padding: '3px 0',
-      },
-      input: {
-        padding: '5px 3px',
-      },
-      adornedStart: {
-        paddingLeft: 8,
-      },
-      adornedEnd: {
-        paddingRight: 8,
+        marginBottom: '16px',
       },
     },
   },

--- a/src/app/core/components/AutocompleteBase.js
+++ b/src/app/core/components/AutocompleteBase.js
@@ -99,7 +99,7 @@ class AutocompleteBase extends React.Component {
           <BaseTextField
             id={id}
             label={label}
-            variant="filled"
+            variant="outlined"
             value={value}
             onChange={this.handleChange}
             onBlur={this.handleClose}

--- a/src/app/core/components/Picklist.js
+++ b/src/app/core/components/Picklist.js
@@ -35,7 +35,7 @@ class Picklist extends React.Component {
   }
 
   render () {
-    const { className, classes, label, name, value, options, filled } = this.props
+    const { className, classes, label, name, value, options } = this.props
 
     const items = options.map(x =>
       typeof x === 'string' ? ({ value: x, label: x }) : x
@@ -51,7 +51,7 @@ class Picklist extends React.Component {
       <FormControl className={classnames(classes.formControl, className)}>
         <TextField
           select
-          variant={filled ? 'filled' : 'standard'}
+          variant="outlined"
           label={label}
           value={nonEmptyValue}
           SelectProps={{
@@ -81,7 +81,6 @@ Picklist.propTypes = {
   options: PropTypes.arrayOf(optionPropType).isRequired,
   value: PropTypes.string,
   onChange: PropTypes.func,
-  filled: PropTypes.bool,
 }
 
 export default compose(

--- a/src/app/core/components/SearchBar.js
+++ b/src/app/core/components/SearchBar.js
@@ -5,7 +5,7 @@ import { InputAdornment, TextField } from '@material-ui/core'
 import SearchIcon from '@material-ui/icons/Search'
 import ClearIcon from '@material-ui/icons/Clear'
 import grey from '@material-ui/core/colors/grey'
-import { compose } from 'ramda'
+import { compose, pick } from 'ramda'
 
 const styles = theme => ({
   SearchBar: {
@@ -19,6 +19,20 @@ const styles = theme => ({
     '&:active': {
       color: grey[200],
     },
+  },
+
+  // classes for the InputProps
+  root: {
+    padding: '3px 0',
+  },
+  input: {
+    padding: '5px 3px',
+  },
+  adornedStart: {
+    paddingLeft: 8,
+  },
+  adornedEnd: {
+    paddingRight: 8,
   },
 })
 
@@ -42,7 +56,9 @@ class SearchBar extends React.Component {
         className={classes.SearchBar}
         onChange={this.handleSearch}
         value={searchTerm}
+        type="search"
         InputProps={{
+          classes: pick(['root', 'input', 'adornedStart', 'adornedEnd'], classes),
           startAdornment: (
             <InputAdornment position="start">
               <SearchIcon />

--- a/src/app/core/components/validatedForm/PicklistField.js
+++ b/src/app/core/components/validatedForm/PicklistField.js
@@ -31,7 +31,6 @@ class PicklistField extends React.Component {
           title={title}
           className={className}
           name={id}
-          filled
           label={label}
           options={showNone ? [{ value: '', label: 'None' }, ...options] : options}
           value={value !== undefined ? value : ''}

--- a/src/app/core/components/validatedForm/TextField.js
+++ b/src/app/core/components/validatedForm/TextField.js
@@ -34,7 +34,7 @@ class TextField extends React.Component {
       <FormControl id={id} className={classes.formControl} error={hasError}>
         <BaseTextField
           {...restProps}
-          variant="filled"
+          variant="outlined"
           error={hasError}
           value={value !== undefined ? value : ''}
           onChange={this.handleChange}


### PR DESCRIPTION
Switches forms to use the `outlined` style for `Input` components.

This also removes some of the global theme overrides that messed up the styling for forms.  Looks like the previous styling was meant to target the `<SearchBar>` component in Tables so I made that styling specific to just that component.

![Screen Shot 2019-06-10 at 2 17 13 PM](https://user-images.githubusercontent.com/289156/59227724-dfeb5380-8b8a-11e9-84bb-6877d74376c8.png)
