### PR TITLE
Make Prometheus Instance fields with unit values more flexible

### DIFF
--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -366,9 +366,9 @@ class Qbert {
 
   createPrometheusInstance = async (clusterId, data) => {
     const requests = {}
-    if (data.cpu) { requests.cpu = `${data.cpu}m` }
-    if (data.memory) { requests.memory = `${data.memory}Mi` }
-    // if (data.storage) { requests.storage = `${data.storage}Gi` }
+    if (data.cpu) { requests.cpu = data.cpu }
+    if (data.memory) { requests.memory = data.memory }
+    // if (data.storage) { requests.storage = data.storage }
 
     const apiVersion = 'monitoring.coreos.com/v1'
 
@@ -391,8 +391,8 @@ class Qbert {
         namespace: data.namespace,
       },
       spec: {
-        replicas: data.numInstances,
-        retention: `${data.retention}d`,
+        replicas: data.replicas,
+        retention: data.retention,
         resources: { requests },
         serviceMonitorSelector: { matchLabels: serviceMonitor },
         serviceAccountName: data.serviceAccountName,

--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -19,11 +19,11 @@ import { loadNamespaces } from 'k8s/components/namespaces/actions'
 import { createPrometheusInstance, loadPrometheusInstances, loadServiceAccounts } from './actions'
 
 const initialContext = {
-  numInstances: 1,
-  memory: 512,
-  cpu: 500,
-  storage: 8,
-  retention: 15,
+  replicas: 1,
+  memory: '512Mi',
+  cpu: '500m',
+  storage: '8Gi',
+  retention: '15d',
   port: 'prometheus',
   appLabels: []
 }
@@ -82,11 +82,11 @@ class AddPrometheusInstanceFormBase extends React.Component {
               <WizardStep stepId="instance" label="Prometheus Instsance">
                 <ValidatedForm initialValues={wizardContext} onSubmit={setWizardContext} triggerSubmit={onNext}>
                   <TextField id="name" label="Name" info="Name of the Prometheus instance" />
-                  <TextField id="numInstances" label="Replicas" info="Number of Prometheus replicas" type="number" />
-                  <TextField id="cpu" label="CPU" info="Expressed in millicores (1m = 1/1000th of a core)" type="number" />
-                  <TextField id="memory" label="Memory" info="MiB of memory to allocate" type="number" />
+                  <TextField id="replicas" label="Replicas" info="Number of Prometheus replicas" type="number" />
+                  <TextField id="cpu" label="CPU" info="Expressed in millicores (1m = 1/1000th of a core)" />
+                  <TextField id="memory" label="Memory" info="MiB of memory to allocate" />
                   {enableStorage &&
-                  <TextField id="storage" label="Storage" info="The storage allocation.  Default is 8 GiB" type="number" />}
+                  <TextField id="storage" label="Storage" info="The storage allocation.  Default is 8 GiB" />}
 
                   <PicklistField
                     id="cluster"
@@ -115,7 +115,7 @@ class AddPrometheusInstanceFormBase extends React.Component {
 
                   {enableStorage &&
                   <CheckboxField id="enablePersistentStorage" label="Enable persistent storage" />}
-                  <TextField id="retention" label="Storage Retention (days)" info="Defaults to 15 days if nothing is set" type="number" />
+                  <TextField id="retention" label="Storage Retention (days)" info="Defaults to 15 days if nothing is set" />
                   <TextField id="port" label="Service Monitor Port" info="Port for the service monitor" />
                   <KeyValuesField id="appLabels" label="App Labels" info="Key/value pairs for app that Prometheus will monitor" />
                 </ValidatedForm>


### PR DESCRIPTION
This removes the hard coding of the unit values (`Mi`, `Gi`, `d`, `w`, etc) from the values for things like memory, cpu, and storage.  Instead of being number fields, they are now just pure text fields.

There was too much inconsistency and we were fighting against how Kubernetes wants these values to be presented.  This simplifies the code, eliminates issues with unit type incompatibilities (`Mi` vs `Gi`), saves the UI from re-implementing the entire unit conversion system in Kubernetes, and provides the user more flexibility in choosing values.

The downside is that users must have more knowledge of the Prometheus operator and what these unit suffixes are.

After discussion we haven't come up with a good solution insulating the user from these unit suffix values—especially since they can be changed to a type the UI doesn't understand on the backend.  So we ultimately decided just to make the fields plain text fields.