### PR TITLE
Add Managed Prometheus to simulator

### DIFF
--- a/src/app/utils/__tests__/fp.test.js
+++ b/src/app/utils/__tests__/fp.test.js
@@ -1,9 +1,22 @@
-import { T } from 'ramda'
+import { propEq, T } from 'ramda'
 import {
-  compose, condLiteral, filterFields, identity, mergeKey, notEmpty, pick, pickMultiple, pipe,
-  pipeWhenTruthy, projectAs, pluck, pluckAsync,
-} from '../fp'
-import { asyncProps } from 'utils/fp'
+  applyJsonPatch,
+  asyncProps,
+  compose,
+  condLiteral,
+  filterFields,
+  identity,
+  mergeKey,
+  notEmpty,
+  pick,
+  pickMultiple,
+  pipe,
+  pipeWhenTruthy,
+  projectAs,
+  pluck,
+  pluckAsync,
+  updateInArray,
+} from 'utils/fp'
 
 describe('functional programming utils', () => {
   it('identity', () => {
@@ -129,5 +142,44 @@ describe('functional programming utils', () => {
     expect(notEmpty([123])).toEqual(true)
     expect(notEmpty([null])).toEqual(true)
     expect(notEmpty([undefined])).toEqual(true)
+  })
+
+  it('updateInArray', () => {
+    const items = [
+      { id: 1, name: 'foo' },
+      { id: 2, name: 'bar' },
+    ]
+    const findById = id => propEq('id', id)
+    const updateFn = obj => ({ ...obj, name: 'changed' })
+
+    const updatedItems = updateInArray(findById(2), updateFn, items)
+    expect(updatedItems).toEqual([
+      { id: 1, name: 'foo' },
+      { id: 2, name: 'changed' },
+    ])
+  })
+
+  it('applyJsonPatch', () => {
+    const original = {
+      spec: {
+        groups: [
+          { rules: [{ name: 'changeMe' }] }
+        ]
+      }
+    }
+    const expected = {
+      spec: {
+        groups: [
+          { rules: [{ name: 'I have been changed' }] }
+        ]
+      }
+    }
+    const patch = {
+      op: 'replace',
+      path: '/spec/groups/0/rules',
+      value: [{ name: 'I have been changed' }],
+    }
+    const updated = applyJsonPatch(patch, original)
+    expect(updated).toEqual(expected)
   })
 })

--- a/src/app/utils/fp.js
+++ b/src/app/utils/fp.js
@@ -1,4 +1,4 @@
-import { curry, fromPairs, mapObjIndexed, pathOr, remove, flatten } from 'ramda'
+import { assocPath, curry, fromPairs, mapObjIndexed, pathOr, remove, flatten } from 'ramda'
 import moize from 'moize'
 
 // functional programming helpers
@@ -208,3 +208,29 @@ export const condLiteral = (...conds) => value => {
     if (pred(value)) { return literal }
   }
 }
+
+// Update an object in an array using a predicateFn and an updateFn.
+//
+// updateInArray :: (obj -> Boolean) -> (obj -> obj) -> arr -> arr
+//
+// Ex: updateInArray(
+//   obj => obj.id === id,
+//   obj => ({ ...obj, name: 'changed' }),
+//   arr
+// )
+export const updateInArray = curry((predicateFn, updateFn, arr) =>
+  arr.map(item => predicateFn(item) ? updateFn(item) : item)
+)
+
+// applyJsonPatch :: oldObject -> patch -> newObject
+export const applyJsonPatch = curry((patch, obj) => {
+  const { op, path, value } = patch
+
+  // assocPath requires array indexes to be integer not string
+  const convertIntsToInts = n => !isNaN(n) ? parseInt(n, 10) : n
+
+  const pathParts = path.split('/').slice(1).map(convertIntsToInts)
+  if (op === 'replace') {
+    return assocPath(pathParts, value, obj)
+  }
+})

--- a/src/server/api/appbert/clusters.js
+++ b/src/server/api/appbert/clusters.js
@@ -1,0 +1,15 @@
+import context from '../../context'
+import Cluster from '../../models/qbert/Cluster'
+
+const mapCluster = cluster => ({
+  name: cluster.name,
+  projectId: cluster.projectId,
+  tags: Object.keys(cluster.tags),
+  uuid: cluster.uuid,
+})
+
+export const getAppbertClusters = (req, res) => {
+  const clusters = Cluster.list({ context })
+  const data = clusters.map(mapCluster)
+  return res.send(data)
+}

--- a/src/server/api/appbert/index.js
+++ b/src/server/api/appbert/index.js
@@ -1,0 +1,12 @@
+import express from 'express'
+
+import { getAppbertClusters } from './clusters'
+import { tokenValidator } from '../../middleware'
+
+const router = express.Router()
+
+const version = 'v1'
+
+router.get(`/${version}/clusters`, tokenValidator, getAppbertClusters)
+
+export default router

--- a/src/server/api/qbert/index.js
+++ b/src/server/api/qbert/index.js
@@ -28,6 +28,8 @@ import { getCharts, getChart, getChartVersions } from './charts'
 import { getReleases, getRelease, deleteRelease } from './releases'
 import { tokenValidator } from '../../middleware'
 
+import { getPrometheusInstances } from './prometheus'
+
 // TODO
 // import { deployApplication } from './applications'
 // import {
@@ -61,8 +63,9 @@ router.post(`/${version}/:tenantId/clusters/:clusterId/detach`, tokenValidator, 
 
 router.get(`/${version}/:tenantId/kubeconfig/:clusterId`, tokenValidator, getKubeConfig)
 
-const k8sapi = `/${version}/:tenantId/clusters/:clusterId/k8sapi/api/v1`
-const k8sBetaApi = `/${version}/:tenantId/clusters/:clusterId/k8sapi/apis/extensions/v1beta1`
+const clusterK8sApiBase = `/${version}/:tenantId/clusters/:clusterId/k8sapi`
+const k8sapi = `${clusterK8sApiBase}/api/v1`
+const k8sBetaApi = `${clusterK8sApiBase}/apis/extensions/v1beta1`
 
 router.get(`${k8sapi}/namespaces`, tokenValidator, getNamespaces)
 
@@ -95,5 +98,9 @@ router.get(`${monocularClusterBase}/charts/:chartName/versions`, tokenValidator,
 router.get(`${monocularClusterBase}/releases`, tokenValidator, getReleases)
 router.get(`${monocularClusterBase}/releases/:releaseName`, tokenValidator, getRelease)
 router.delete(`${monocularClusterBase}/releases/:releaseName`, tokenValidator, deleteRelease)
+
+// Managed Prometheus
+const monitoringBase = `${clusterK8sApiBase}/apis/monitoring.coreos.com/v1`
+router.get(`${monitoringBase}/prometheuses`, tokenValidator, getPrometheusInstances)
 
 export default router

--- a/src/server/api/qbert/index.js
+++ b/src/server/api/qbert/index.js
@@ -28,7 +28,7 @@ import { getCharts, getChart, getChartVersions } from './charts'
 import { getReleases, getRelease, deleteRelease } from './releases'
 import { tokenValidator } from '../../middleware'
 
-import { getPrometheusInstances } from './prometheus'
+import { getPrometheusInstances, patchPrometheusInstance, deletePrometheusInstance } from './prometheus'
 
 // TODO
 // import { deployApplication } from './applications'
@@ -102,5 +102,7 @@ router.delete(`${monocularClusterBase}/releases/:releaseName`, tokenValidator, d
 // Managed Prometheus
 const monitoringBase = `${clusterK8sApiBase}/apis/monitoring.coreos.com/v1`
 router.get(`${monitoringBase}/prometheuses`, tokenValidator, getPrometheusInstances)
+router.patch(`${monitoringBase}/namespaces/:namespace/prometheuses/:name`, tokenValidator, patchPrometheusInstance)
+router.delete(`${monitoringBase}/namespaces/:namespace/prometheuses/:name`, tokenValidator, deletePrometheusInstance)
 
 export default router

--- a/src/server/api/qbert/prometheus.js
+++ b/src/server/api/qbert/prometheus.js
@@ -1,0 +1,23 @@
+import context from '../../context'
+import PrometheusInstance from '../../models/prometheus/PrometheusInstance'
+
+const apiVersion = 'monitoring.coreos.com/v1'
+const defaultBody = {
+  apiVersion,
+  kind: 'PrometheusList',
+  items: [],
+  metadata: {
+    resourceVersion: '3496',
+    selfLink: '/apis/monitoring.coreos.com/v1/prometheuses',
+  },
+}
+
+export const getPrometheusInstances = (req, res) => {
+  const { clusterId } = req.params
+  const instances = PrometheusInstance.list({ context, config: { clusterId } })
+  const body = {
+    ...defaultBody,
+    items: instances,
+  }
+  return res.send(body)
+}

--- a/src/server/api/qbert/prometheus.js
+++ b/src/server/api/qbert/prometheus.js
@@ -14,10 +14,23 @@ const defaultBody = {
 
 export const getPrometheusInstances = (req, res) => {
   const { clusterId } = req.params
-  const instances = PrometheusInstance.list({ context, config: { clusterId } })
+  const instances = PrometheusInstance.list({ context, clusterId })
   const body = {
     ...defaultBody,
     items: instances,
   }
   return res.send(body)
+}
+
+export const patchPrometheusInstance = (req, res) => {
+  const { clusterId, name, namespace } = req.params
+  const jsonPatches = req.body
+  PrometheusInstance.update({ clusterId, name, namespace, data: jsonPatches })
+  res.status(200).send({})
+}
+
+export const deletePrometheusInstance = (req, res) => {
+  const { clusterId, name, namespace } = req.params
+  PrometheusInstance.delete({ clusterId, name, namespace })
+  res.status(200).send({})
 }

--- a/src/server/context/simulator.js
+++ b/src/server/context/simulator.js
@@ -65,6 +65,10 @@ class Context {
     this.charts = []
     this.releases = []
     this.repositories = []
+    this.prometheusInstances = []
+    this.prometheusRules = []
+    this.prometheusServiceMonitors = []
+    this.prometheusAlertManagers = []
   }
 
   createSimUser = () => {

--- a/src/server/models/openstack/Catalog.js
+++ b/src/server/models/openstack/Catalog.js
@@ -4,206 +4,36 @@ const config = require('../../../../config')
 
 const fakeTenantId = uuid.v4()
 
+const createService = ({ name, type, url }) => {
+  const createEndpoint = _interface => ({
+    id: uuid.v4(),
+    interface: _interface,
+    region: config.region,
+    region_id: config.region,
+    url,
+  })
+
+  return {
+    endpoints: ['admin', 'internal', 'public'].map(createEndpoint),
+    id: uuid.v4(),
+    name,
+    type,
+  }
+}
+
 const Catalog = {
   getCatalog: () => {
-    return [
-      {
-        endpoints: [
-          {
-            id: uuid.v4(),
-            interface: 'admin',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/neutron`,
-          },
-          {
-            id: uuid.v4(),
-            interface: 'internal',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/neutron`,
-          },
-          {
-            id: uuid.v4(),
-            interface: 'public',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/neutron`,
-          },
-        ],
-        id: uuid.v4(),
-        name: 'neutron',
-        type: 'network',
-      },
-      {
-        endpoints: [
-          {
-            id: uuid.v4(),
-            interface: 'admin',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/nova/v2.1/${fakeTenantId}`,
-          },
-          {
-            id: uuid.v4(),
-            interface: 'internal',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/nova/v2.1/${fakeTenantId}`,
-          },
-          {
-            id: uuid.v4(),
-            interface: 'public',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/nova/v2.1/${fakeTenantId}`,
-          },
-        ],
-        id: uuid.v4(),
-        name: 'nova',
-        type: 'compute',
-      },
-      {
-        endpoints: [
-          {
-            id: uuid.v4(),
-            interface: 'admin',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/cinder/v3/${fakeTenantId}`,
-          },
-          {
-            id: uuid.v4(),
-            interface: 'internal',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/cinder/v3/${fakeTenantId}`,
-          },
-          {
-            id: uuid.v4(),
-            interface: 'public',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/cinder/v3/${fakeTenantId}`,
-          },
-        ],
-        id: uuid.v4(),
-        name: 'cinderv3',
-        type: 'volumev3',
-      },
-      {
-        endpoints: [
-          {
-            id: uuid.v4(),
-            interface: 'admin',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/glance`,
-          },
-          {
-            id: uuid.v4(),
-            interface: 'internal',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/glance`,
-          },
-          {
-            id: uuid.v4(),
-            interface: 'public',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/glance`,
-          },
-        ],
-        id: uuid.v4(),
-        name: 'glance',
-        type: 'image',
-      },
-      {
-        endpoints: [
-          {
-            id: uuid.v4(),
-            interface: 'admin',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/qbert/v1`,
-          },
-          {
-            id: uuid.v4(),
-            interface: 'internal',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/qbert/v1`,
-          },
-          {
-            id: uuid.v4(),
-            interface: 'public',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/qbert/v1`,
-          },
-        ],
-        id: uuid.v4(),
-        name: 'qbert',
-        type: 'qbert',
-      },
-      {
-        'endpoints': [
-          {
-            id: uuid.v4(),
-            url: `${config.apiHost}/monocular/v1`,
-            interface: 'admin',
-            region: config.region,
-            region_id: config.region,
-          },
-          {
-            id: uuid.v4(),
-            url: `${config.apiHost}/monocular/v1`,
-            interface: 'internal',
-            region: config.region,
-            region_id: config.region,
-          },
-          {
-            id: uuid.v4(),
-            url: `${config.apiHost}/monocular/v1`,
-            interface: 'public',
-            region: config.region,
-            region_id: config.region,
-          },
-        ],
-        id: uuid.v4(),
-        type: 'monocular',
-        name: 'monocular',
-      },
-      {
-        endpoints: [
-          {
-            id: uuid.v4(),
-            interface: 'admin',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/resmgr`,
-          },
-          {
-            id: uuid.v4(),
-            interface: 'internal',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/resmgr`,
-          },
-          {
-            id: uuid.v4(),
-            interface: 'public',
-            region: config.region,
-            region_id: config.region,
-            url: `${config.apiHost}/resmgr`,
-          },
-        ],
-        id: uuid.v4(),
-        name: 'resmgr',
-        type: 'resmgr',
-      },
+    const services = [
+      { name: 'neutron', type: 'network', url: `${config.apiHost}/neutron` },
+      { name: 'nova', type: 'compute', url: `${config.apiHost}/nova/v2.1/${fakeTenantId}` },
+      { name: 'cinderv3', type: 'volumev3', url: `${config.apiHost}/cinder/v3/${fakeTenantId}` },
+      { name: 'glance', type: 'image', url: `${config.apiHost}/glance` },
+      { name: 'qbert', type: 'qbert', url: `${config.apiHost}/qbert/v1` },
+      { name: 'monocular', type: 'monocular', url: `${config.apiHost}/monocular/v1` },
+      { name: 'resmgr', type: 'resmgr', url: `${config.apiHost}/resmgr` },
+      { name: 'appbert', type: 'Kubernetes App Management', url: `${config.apiHost}/appbert/v1` },
     ]
+    return services.map(createService)
   },
 }
 

--- a/src/server/models/prometheus/PrometheusInstance.js
+++ b/src/server/models/prometheus/PrometheusInstance.js
@@ -1,0 +1,82 @@
+import faker from 'faker'
+import uuid from 'uuid'
+import { propEq } from 'ramda'
+
+const create = (params) => {
+  if (!params.clusterId) {
+    console.error(`In create call for PrometheusInstance, clusterId is a required param.`)
+  }
+  const defaults = {
+    cpu: '500m',
+    name: faker.address.streetName(),
+    namespace: 'default',
+    memory: '512Mi',
+    retention: '15d',
+    uid: uuid.v4(),
+  }
+  const {
+    clusterId, // required
+    cpu,
+    memory,
+    name,
+    namespace,
+    retention,
+    uid,
+  } = { ...defaults, ...params }
+
+  const service = `${name}-service-xyz`
+
+  return {
+    clusterId, // This should be stripped from actual responses
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'Prometheus',
+    metadata: {
+      annotations: {
+        service,
+        service_path: `/api/v1/namespaces/default/services/${service}:web/proxy`
+      },
+      creationTimestamp: '2019-06-21T21:26:02Z',
+      generation: 1,
+      name,
+      namespace,
+      resourceVersion: '2342',
+      selfLink: `/apis/monitoring.coreos.com/v1/namespaces/${namespace}/prometheuses/${name}`,
+      uid,
+    },
+    spec: {
+      replicas: 1,
+      resources: {
+        requests: {
+          cpu,
+          memory,
+        }
+      },
+      retention,
+      ruleSelector: {
+        matchLabels: {
+          prometheus: name,
+          role: 'alert-rules'
+        }
+      },
+      rules: {
+        alert: {}
+      },
+      serviceAccountName: 'default',
+      serviceMonitorSelector: {
+        matchLabels: {
+          prometheus: name,
+          role: 'service-monitor'
+        }
+      }
+    }
+  }
+}
+
+const PrometheusInstance = {
+  list: ({ context, clusterId }) => {
+    return context.prometheusInstances.filter(propEq('clusterId', clusterId))
+  },
+  create,
+}
+
+export default PrometheusInstance

--- a/src/server/models/prometheus/PrometheusInstance.js
+++ b/src/server/models/prometheus/PrometheusInstance.js
@@ -1,6 +1,8 @@
+import context from '../../context'
 import faker from 'faker'
 import uuid from 'uuid'
 import { propEq } from 'ramda'
+import { applyJsonPatch, updateInArray } from '../../../app/utils/fp'
 
 const create = (params) => {
   if (!params.clusterId) {
@@ -8,7 +10,7 @@ const create = (params) => {
   }
   const defaults = {
     cpu: '500m',
-    name: faker.address.streetName(),
+    name: faker.address.streetName().replace(/ /g, ''),
     namespace: 'default',
     memory: '512Mi',
     retention: '15d',
@@ -26,7 +28,7 @@ const create = (params) => {
 
   const service = `${name}-service-xyz`
 
-  return {
+  const instance = {
     clusterId, // This should be stripped from actual responses
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'Prometheus',
@@ -70,13 +72,33 @@ const create = (params) => {
       }
     }
   }
+
+  context.prometheusInstances.push(instance)
 }
 
 const PrometheusInstance = {
-  list: ({ context, clusterId }) => {
+  list: ({ clusterId }) => {
     return context.prometheusInstances.filter(propEq('clusterId', clusterId))
   },
+
   create,
+
+  // `data` contains an array of JSON patches (https://tools.ietf.org/html/rfc6902)
+  update: ({ clusterId, name, data }) => {
+    const findInstance = obj => obj.clusterId === clusterId && obj.metadata.name === name
+    const updateFn = original => data.reduce(
+      (accum, patch) => applyJsonPatch(patch, accum),
+      original
+    )
+    context.prometheusInstances = updateInArray(findInstance, updateFn, context.prometheusInstances)
+    return context.prometheusInstances.find(findInstance)
+  },
+
+  delete: ({ clusterId, name }) => {
+    const findInstance = obj => obj.clusterId === clusterId && obj.metadata.name === name
+    const instances = context.prometheusInstances.filter(cluster => !findInstance(cluster))
+    context.prometheusInstances = instances
+  }
 }
 
 export default PrometheusInstance

--- a/src/server/presets/dev.js
+++ b/src/server/presets/dev.js
@@ -154,6 +154,7 @@ function loadPreset () {
 
   // Add Prometheus Instances to 'cluster'
   PrometheusInstance.create({ clusterId: cluster.uuid })
+  PrometheusInstance.create({ clusterId: cluster.uuid })
 
   // Namespaces
   const defaultNamespace = Namespace.create({ data: { name: 'default' }, context, config: { clusterId: cluster.uuid }, raw: true })

--- a/src/server/presets/dev.js
+++ b/src/server/presets/dev.js
@@ -26,6 +26,7 @@ import Chart from '../models/monocular/Chart'
 import Release from '../models/monocular/Release'
 import Repository from '../models/monocular/Repository'
 import StorageClass from '../models/qbert/StorageClass'
+import PrometheusInstance from '../models/prometheus/PrometheusInstance'
 import { attachNodeToCluster } from '../models/qbert/Operations'
 // import Token from '../models/openstack/Token'
 import { range } from '../util'
@@ -128,7 +129,7 @@ function loadPreset () {
   CloudProvider.create({ data: { name: 'mockLocalProvider', type: 'local' }, context })
 
   // Clusters
-  const cluster = Cluster.create({ data: { name: 'fakeCluster1', sshKey: 'someKey' }, context, raw: true })
+  const cluster = Cluster.create({ data: { name: 'fakeCluster1', sshKey: 'someKey', tags: { 'pf9-system:monitoring': 'true' } }, context, raw: true })
   const cluster2 = Cluster.create({ data: { name: 'fakeCluster2', sshKey: 'someKey' }, context, raw: true })
   Cluster.create({ data: { name: 'fakeCluster3' }, context })
   Cluster.create({ data: { name: 'mockAwsCluster', cloudProviderType: 'aws' }, context })
@@ -150,6 +151,9 @@ function loadPreset () {
 
   attachNodeToCluster(node, cluster)
   attachNodeToCluster(node2, cluster2)
+
+  // Add Prometheus Instances to 'cluster'
+  PrometheusInstance.create({ clusterId: cluster.uuid })
 
   // Namespaces
   const defaultNamespace = Namespace.create({ data: { name: 'default' }, context, config: { clusterId: cluster.uuid }, raw: true })

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -5,15 +5,16 @@ import cors from 'cors'
 
 import { requestLogger, enableAllCors, injectClientInfo } from './middleware'
 
-import keystone from './api/keystone'
-import nova from './api/nova'
-import neutron from './api/neutron'
+import admin from './api/admin'
+import appbert from './api/appbert'
 import cinder from './api/cinder'
 import glance from './api/glance'
-import qbert from './api/qbert'
+import keystone from './api/keystone'
 import monocular from './api/monocular'
+import neutron from './api/neutron'
+import nova from './api/nova'
+import qbert from './api/qbert'
 import resmgr from './api/resmgr'
-import admin from './api/admin'
 
 const defaultConfig = {
   port: 4444,
@@ -39,16 +40,16 @@ export function startServer (config = defaultConfig) {
   }
   app.use(injectClientInfo)
 
-  app.use('/keystone', keystone)
-  app.use('/nova', nova)
-  app.use('/neutron', neutron)
+  app.use('/admin', admin)
+  app.use('/appbert', appbert)
   app.use('/cinder', cinder)
   app.use('/glance', glance)
-  app.use('/qbert', qbert)
+  app.use('/keystone', keystone)
   app.use('/monocular', monocular)
+  app.use('/neutron', neutron)
+  app.use('/nova', nova)
+  app.use('/qbert', qbert)
   app.use('/resmgr', resmgr)
-  app.use('/resmgr', resmgr)
-  app.use('/admin', admin)
   app.use(cors())
 
   console.log(`Simulator server currently listening on port ${config.port}`)


### PR DESCRIPTION
This adds Managed Prometheus backend services to the simulator.

This PR only adds `PrometheusInstance`s.  Other endpoints will be added in a different PR.

Also did a slight refactor to the service catalog in the simulator since there was a ton of very verbose duplication.