### PR TITLE
Load theme.json on app startup

### DIFF
--- a/src/app/core/AppContext.js
+++ b/src/app/core/AppContext.js
@@ -4,7 +4,7 @@ import { path, assocPath, flatten, omit } from 'ramda'
 import { ensureArray } from 'utils/fp'
 import { withToast } from 'core/providers/ToastProvider'
 
-const Context = React.createContext({})
+export const Context = React.createContext({})
 export const Consumer = Context.Consumer
 export const Provider = Context.Provider
 

--- a/src/app/plugins/theme/components/ColorsPanel.js
+++ b/src/app/plugins/theme/components/ColorsPanel.js
@@ -38,6 +38,7 @@ const ColorsPanel = () => (
     <ColorPicker path="palette.text.secondary" />
     <ColorPicker path="palette.text.disabled" />
     <ColorPicker path="palette.text.hint" />
+
     <br />
   </Panel>
 )

--- a/src/app/plugins/theme/components/CustomizeExpander.js
+++ b/src/app/plugins/theme/components/CustomizeExpander.js
@@ -1,0 +1,34 @@
+import React, { useState } from 'react'
+import { Button } from '@material-ui/core'
+import { makeStyles } from '@material-ui/styles'
+
+const styles = theme => ({
+  root: {
+    marginTop: theme.spacing.unit * 4,
+  }
+})
+
+const CustomizeExpander = ({ children }) => {
+  const classes = makeStyles(styles)()
+  const [expanded, setExpanded] = useState(false)
+  const toggleExpanded = () => setExpanded(!expanded)
+
+  const customizeButton = (<Button onClick={toggleExpanded}>customize</Button>)
+
+  const expandedContent = (
+    <div>
+      <Button onClick={toggleExpanded}>collapse</Button>
+      <br />
+      {children}
+    </div>
+  )
+
+  return (
+    <div className={classes.root}>
+      <br />
+      {expanded ? expandedContent : customizeButton}
+    </div>
+  )
+}
+
+export default CustomizeExpander

--- a/src/app/plugins/theme/components/KitchenSink.js
+++ b/src/app/plugins/theme/components/KitchenSink.js
@@ -10,8 +10,8 @@ import { withAppContext } from 'core/AppContext'
 
 const KitchenSink = ({ context: { theme } }) => (
   <div>
-    <FormExample expanded />
-    <WizardExample expanded />
+    <FormExample />
+    <WizardExample />
     <ButtonsExample expanded />
     <TabsExample expanded />
     <TablesExample expanded />

--- a/src/app/plugins/theme/components/examples/ButtonsExample.js
+++ b/src/app/plugins/theme/components/examples/ButtonsExample.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import Panel from '../Panel'
 import ExternalLink from 'core/components/ExternalLink'
+import CustomizeExpander from '../CustomizeExpander'
 import ColorPicker from '../ColorPicker'
-import { Button, Typography } from '@material-ui/core'
+import { Button } from '@material-ui/core'
 
 const ButtonsExample = ({ expanded = false }) => (
   <Panel title="Buttons" defaultExpanded={expanded}>
@@ -10,22 +11,21 @@ const ButtonsExample = ({ expanded = false }) => (
     <Button variant="contained" color="primary">Primary</Button>
     <Button variant="contained" color="secondary">Secondary</Button>
 
-    <br />
-    <br />
+    <CustomizeExpander>
+      <ColorPicker path="palette.grey.300" />
+      <ColorPicker path="palette.primary.main" />
+      <ColorPicker path="palette.secondary.main" />
+      <ColorPicker path="palette.primary.contrastText" />
+      <ColorPicker path="palette.secondary.contrastText" />
 
+      <br />
+      <br />
 
-    <ColorPicker path="palette.grey.300" />
-    <ColorPicker path="palette.primary.main" />
-    <ColorPicker path="palette.secondary.main" />
-    <ColorPicker path="palette.primary.contrastText" />
-    <ColorPicker path="palette.secondary.contrastText" />
+      <ExternalLink url="https://material-ui.com/components/buttons/" newWindow>Material-UI Docs</ExternalLink>
+      <br />
+      <ExternalLink url="https://material-ui.com/api/button/" newWindow>Material-UI API</ExternalLink>
+    </CustomizeExpander>
 
-    <br />
-    <br />
-
-    <ExternalLink url="https://material-ui.com/components/buttons/" newWindow >Material-UI Docs</ExternalLink>
-    <br />
-    <ExternalLink url="https://material-ui.com/api/button/" newWindow >Material-UI API</ExternalLink>
   </Panel>
 )
 

--- a/src/app/plugins/theme/components/examples/ButtonsExample.js
+++ b/src/app/plugins/theme/components/examples/ButtonsExample.js
@@ -1,12 +1,31 @@
 import React from 'react'
 import Panel from '../Panel'
-import { Button } from '@material-ui/core'
+import ExternalLink from 'core/components/ExternalLink'
+import ColorPicker from '../ColorPicker'
+import { Button, Typography } from '@material-ui/core'
 
 const ButtonsExample = ({ expanded = false }) => (
   <Panel title="Buttons" defaultExpanded={expanded}>
     <Button variant="contained">Default</Button>
     <Button variant="contained" color="primary">Primary</Button>
     <Button variant="contained" color="secondary">Secondary</Button>
+
+    <br />
+    <br />
+
+
+    <ColorPicker path="palette.grey.300" />
+    <ColorPicker path="palette.primary.main" />
+    <ColorPicker path="palette.secondary.main" />
+    <ColorPicker path="palette.primary.contrastText" />
+    <ColorPicker path="palette.secondary.contrastText" />
+
+    <br />
+    <br />
+
+    <ExternalLink url="https://material-ui.com/components/buttons/" newWindow >Material-UI Docs</ExternalLink>
+    <br />
+    <ExternalLink url="https://material-ui.com/api/button/" newWindow >Material-UI API</ExternalLink>
   </Panel>
 )
 

--- a/src/app/static/theme.json
+++ b/src/app/static/theme.json
@@ -1,0 +1,377 @@
+{
+    "breakpoints": {
+        "keys": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+        ],
+        "values": {
+            "xs": 0,
+            "sm": 600,
+            "md": 960,
+            "lg": 1280,
+            "xl": 1920
+        }
+    },
+    "direction": "ltr",
+    "mixins": {
+        "toolbar": {
+            "minHeight": 56,
+            "@media (min-width:0px) and (orientation: landscape)": {
+                "minHeight": 48
+            },
+            "@media (min-width:600px)": {
+                "minHeight": 64
+            }
+        }
+    },
+    "overrides": {
+        "MuiOutlinedInput": {
+            "root": {
+                "marginBottom": "16px"
+            }
+        }
+    },
+    "palette": {
+        "common": {
+            "black": "#000",
+            "white": "#fff"
+        },
+        "type": "light",
+        "primary": {
+            "light": "#aee0ff",
+            "main": "#4aa3df",
+            "dark": "#1e699c",
+            "contrastText": "#fff"
+        },
+        "secondary": {
+            "50": "#fbe9e7",
+            "100": "#ffccbc",
+            "200": "#ffab91",
+            "300": "#ff8a65",
+            "400": "#ff7043",
+            "500": "#ff5722",
+            "600": "#f4511e",
+            "700": "#e64a19",
+            "800": "#d84315",
+            "900": "#bf360c",
+            "A100": "#ff9e80",
+            "A200": "#ff6e40",
+            "A400": "#ff3d00",
+            "A700": "#dd2c00",
+            "main": "#ff3d00",
+            "light": "#ff6e40",
+            "dark": "#dd2c00",
+            "contrastText": "#fff"
+        },
+        "error": {
+            "light": "#e57373",
+            "main": "#f44336",
+            "dark": "#d32f2f",
+            "contrastText": "#fff"
+        },
+        "grey": {
+            "50": "#fafafa",
+            "100": "#f5f5f5",
+            "200": "#eeeeee",
+            "300": "#e0e0e0",
+            "400": "#bdbdbd",
+            "500": "#9e9e9e",
+            "600": "#757575",
+            "700": "#616161",
+            "800": "#424242",
+            "900": "#212121",
+            "A100": "#d5d5d5",
+            "A200": "#aaaaaa",
+            "A400": "#303030",
+            "A700": "#616161"
+        },
+        "contrastThreshold": 3,
+        "tonalOffset": 0.2,
+        "text": {
+            "primary": "rgba(0, 0, 0, 0.87)",
+            "secondary": "rgba(0, 0, 0, 0.54)",
+            "disabled": "rgba(0, 0, 0, 0.38)",
+            "hint": "rgba(0, 0, 0, 0.38)"
+        },
+        "divider": "rgba(0, 0, 0, 0.12)",
+        "background": {
+            "paper": "#fff",
+            "default": "#fafafa"
+        },
+        "action": {
+            "active": "rgba(0, 0, 0, 0.54)",
+            "hover": "rgba(0, 0, 0, 0.08)",
+            "hoverOpacity": 0.08,
+            "selected": "rgba(0, 0, 0, 0.14)",
+            "disabled": "rgba(0, 0, 0, 0.26)",
+            "disabledBackground": "rgba(0, 0, 0, 0.12)"
+        },
+        "sidebar": {
+            "background": "#243748",
+            "text": "#aee0ff"
+        }
+    },
+    "props": {},
+    "shadows": [
+        "none",
+        "0px 1px 3px 0px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 2px 1px -1px rgba(0,0,0,0.12)",
+        "0px 1px 5px 0px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 3px 1px -2px rgba(0,0,0,0.12)",
+        "0px 1px 8px 0px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 3px 3px -2px rgba(0,0,0,0.12)",
+        "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+        "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+        "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+        "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+        "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+        "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+        "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+        "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+        "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+        "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+        "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+        "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+        "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+        "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+        "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+        "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+        "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+        "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+        "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+        "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+        "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)"
+    ],
+    "typography": {
+        "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+        "fontSize": 14,
+        "fontWeightLight": 300,
+        "fontWeightRegular": 400,
+        "fontWeightMedium": 500,
+        "display4": {
+            "fontSize": "7rem",
+            "fontWeight": 300,
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "letterSpacing": "-.04em",
+            "lineHeight": "1.14286em",
+            "marginLeft": "-.04em",
+            "color": "rgba(0, 0, 0, 0.54)"
+        },
+        "display3": {
+            "fontSize": "3.5rem",
+            "fontWeight": 400,
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "letterSpacing": "-.02em",
+            "lineHeight": "1.30357em",
+            "marginLeft": "-.02em",
+            "color": "rgba(0, 0, 0, 0.54)"
+        },
+        "display2": {
+            "fontSize": "2.8125rem",
+            "fontWeight": 400,
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "lineHeight": "1.13333em",
+            "marginLeft": "-.02em",
+            "color": "rgba(0, 0, 0, 0.54)"
+        },
+        "display1": {
+            "fontSize": "2.125rem",
+            "fontWeight": 400,
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "lineHeight": "1.20588em",
+            "color": "rgba(0, 0, 0, 0.54)"
+        },
+        "headline": {
+            "fontSize": "1.5rem",
+            "fontWeight": 400,
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "lineHeight": "1.35417em",
+            "color": "rgba(0, 0, 0, 0.87)"
+        },
+        "title": {
+            "fontSize": "1.3125rem",
+            "fontWeight": 500,
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "lineHeight": "1.16667em",
+            "color": "rgba(0, 0, 0, 0.87)"
+        },
+        "subheading": {
+            "fontSize": "1rem",
+            "fontWeight": 400,
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "lineHeight": "1.5em",
+            "color": "rgba(0, 0, 0, 0.87)"
+        },
+        "body2": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 400,
+            "fontSize": "0.875rem",
+            "lineHeight": 1.5,
+            "letterSpacing": "0.01071em"
+        },
+        "body1": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 400,
+            "fontSize": "1rem",
+            "lineHeight": 1.5,
+            "letterSpacing": "0.00938em"
+        },
+        "caption": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 400,
+            "fontSize": "0.75rem",
+            "lineHeight": 1.66,
+            "letterSpacing": "0.03333em"
+        },
+        "button": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 500,
+            "fontSize": "0.875rem",
+            "lineHeight": 1.75,
+            "letterSpacing": "0.02857em",
+            "textTransform": "uppercase"
+        },
+        "h1": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 300,
+            "fontSize": "6rem",
+            "lineHeight": 1,
+            "letterSpacing": "-0.01562em"
+        },
+        "h2": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 300,
+            "fontSize": "3.75rem",
+            "lineHeight": 1,
+            "letterSpacing": "-0.00833em"
+        },
+        "h3": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 400,
+            "fontSize": "3rem",
+            "lineHeight": 1.04,
+            "letterSpacing": "0em"
+        },
+        "h4": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 400,
+            "fontSize": "2.125rem",
+            "lineHeight": 1.17,
+            "letterSpacing": "0.00735em"
+        },
+        "h5": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 400,
+            "fontSize": "1.5rem",
+            "lineHeight": 1.33,
+            "letterSpacing": "0em"
+        },
+        "h6": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 500,
+            "fontSize": "1.25rem",
+            "lineHeight": 1.6,
+            "letterSpacing": "0.0075em"
+        },
+        "subtitle1": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 400,
+            "fontSize": "1rem",
+            "lineHeight": 1.75,
+            "letterSpacing": "0.00938em"
+        },
+        "subtitle2": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 500,
+            "fontSize": "0.875rem",
+            "lineHeight": 1.57,
+            "letterSpacing": "0.00714em"
+        },
+        "body1Next": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 400,
+            "fontSize": "1rem",
+            "lineHeight": 1.5,
+            "letterSpacing": "0.00938em"
+        },
+        "body2Next": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 400,
+            "fontSize": "0.875rem",
+            "lineHeight": 1.5,
+            "letterSpacing": "0.01071em"
+        },
+        "buttonNext": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 500,
+            "fontSize": "0.875rem",
+            "lineHeight": 1.75,
+            "letterSpacing": "0.02857em",
+            "textTransform": "uppercase"
+        },
+        "captionNext": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 400,
+            "fontSize": "0.75rem",
+            "lineHeight": 1.66,
+            "letterSpacing": "0.03333em"
+        },
+        "overline": {
+            "color": "rgba(0, 0, 0, 0.87)",
+            "fontFamily": "\"Roboto\", \"Helvetica\", \"Arial\", sans-serif",
+            "fontWeight": 400,
+            "fontSize": "0.75rem",
+            "lineHeight": 2.66,
+            "letterSpacing": "0.08333em",
+            "textTransform": "uppercase"
+        },
+        "useNextVariants": true
+    },
+    "shape": {
+        "borderRadius": 4
+    },
+    "spacing": {
+        "unit": 8
+    },
+    "transitions": {
+        "easing": {
+            "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+            "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+            "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+            "sharp": "cubic-bezier(0.4, 0, 0.6, 1)"
+        },
+        "duration": {
+            "shortest": 150,
+            "shorter": 200,
+            "short": 250,
+            "standard": 300,
+            "complex": 375,
+            "enteringScreen": 225,
+            "leavingScreen": 195
+        }
+    },
+    "zIndex": {
+        "mobileStepper": 1000,
+        "appBar": 1100,
+        "drawer": 1200,
+        "modal": 1300,
+        "snackbar": 1400,
+        "tooltip": 1500
+    }
+}


### PR DESCRIPTION
This adds a `theme.json` to our static files.  In the future we can override this file on the server to give different customers white-label theming capability.

I also sketched out an idea for providing the theme controls for the relevant section with the preview of it.  That way the person editing the theme isn't wondering what value needs to be changed to affect a given component.

![Screen Shot 2019-07-03 at 3 14 20 PM](https://user-images.githubusercontent.com/289156/60628221-50118180-9da5-11e9-9033-aa013854d369.png)
