### PR TITLE
Fix CRUDListContainer items adding and removal

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -69,27 +69,27 @@ class App extends React.Component {
     return (
       <Router>
         <HotKeysProvider>
-          <ToastProvider>
-            <AppContext initialContext={{ apiClient, initialized: false, sessionLoaded: false }}>
-              <PreferencesProvider>
-                <ThemeManager>
+          <AppContext initialContext={{ apiClient, initialized: false, sessionLoaded: false }}>
+            <PreferencesProvider>
+              <ThemeManager>
+                <ToastProvider>
                   <div id="_main-container">
                     <SessionManager>
                       <AppContainer
                         sections={plugins.map(([id, plugin]) => ({
                           id,
                           name: plugin.name,
-                          links: plugin.getNavItems()
+                          links: plugin.getNavItems(),
                         }))}>
                         {plugins.map(apply(this.renderPluginRoutes))}
                         {devEnabled && <DeveloperToolsEmbed />}
                       </AppContainer>
                     </SessionManager>
                   </div>
-                </ThemeManager>
-              </PreferencesProvider>
-            </AppContext>
-          </ToastProvider>
+                </ToastProvider>
+              </ThemeManager>
+            </PreferencesProvider>
+          </AppContext>
         </HotKeysProvider>
       </Router>
     )
@@ -97,7 +97,7 @@ class App extends React.Component {
 }
 
 App.propTypes = {
-  pluginManager: PropTypes.object
+  pluginManager: PropTypes.object,
 }
 
 export default App

--- a/src/app/core/AppContext.js
+++ b/src/app/core/AppContext.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { path, assocPath, flatten, omit } from 'ramda'
-import { ensureArray } from 'utils/fp'
+import { assocPath, flatten, omit } from 'ramda'
 
 export const Context = React.createContext({})
 export const Consumer = Context.Consumer
@@ -36,7 +35,7 @@ class AppContext extends React.Component {
     },
 
     // Get an updated version of the current context values (not methods)
-    getContext: contextPath => {
+    getContext: getterFn => {
       const contextValues = omit([
         'initSession',
         'updateSession',
@@ -46,7 +45,7 @@ class AppContext extends React.Component {
       ], this.state)
 
       // Return all values if no path is specified
-      return contextPath ? path(ensureArray(contextPath), contextValues) : contextValues
+      return getterFn ? getterFn(contextValues) : contextValues
     },
 
     setContext: (...args) => {

--- a/src/app/core/AppContext.js
+++ b/src/app/core/AppContext.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { path, assocPath, flatten, omit } from 'ramda'
 import { ensureArray } from 'utils/fp'
-import { withToast } from 'core/providers/ToastProvider'
 
 export const Context = React.createContext({})
 export const Consumer = Context.Consumer
@@ -11,7 +10,6 @@ export const Provider = Context.Provider
 class AppContext extends React.Component {
   state = {
     ...this.props.initialContext,
-    showToast: this.props.showToast,
 
     session: {},
 
@@ -106,4 +104,4 @@ export const withAppContext = Component => props =>
     }
   </Consumer>
 
-export default withToast(AppContext)
+export default AppContext

--- a/src/app/core/helpers/clusterContextUpdater.js
+++ b/src/app/core/helpers/clusterContextUpdater.js
@@ -21,7 +21,7 @@ const clusterContextUpdater = (key, updaterFn, returnLast = false) =>
           '__all__': updatedData,
         }, ctx)
       })
-    } else if (getContext([...keyPath, '__all__'])) {
+    } else if (getContext(path([...keyPath, '__all__']))) {
       // update "__all__" key (if __all__ exists)
       await setContext(ctx =>
         assocPath(

--- a/src/app/core/helpers/contextLoader.js
+++ b/src/app/core/helpers/contextLoader.js
@@ -30,13 +30,14 @@ const contextLoader = (contextPath, loaderFn, options) => {
       if (!output && defaultValue) {
         await setContext(ctx => contextSetter(ctx, defaultValue, props))
       }
+      const context = getContext()
       const args = {
         params: {},
         ...props,
-        context: getContext(),
+        context,
         getContext,
         setContext,
-        apiClient: getContext('apiClient'),
+        apiClient: context.apiClient,
         reload: reload && cascade,
         cascade,
         loadFromContext: (contextPath, customArgs) =>

--- a/src/app/core/helpers/contextUpdater.js
+++ b/src/app/core/helpers/contextUpdater.js
@@ -19,7 +19,6 @@ const contextUpdater = (contextPath, updaterFn, returnLast = false) => {
     const context = getContext()
     const output = await updaterFn({
       ...args,
-      showToast: context.showToast,
       apiClient: context.apiClient,
       currentItems,
       loadFromContext: (contextPath, customArgs) =>

--- a/src/app/core/helpers/createAddComponents.js
+++ b/src/app/core/helpers/createAddComponents.js
@@ -6,6 +6,7 @@ import FormWrapper from 'core/components/FormWrapper'
 import createCRUDActions from 'core/helpers/createCRUDActions'
 import createFormComponent from 'core/helpers/createFormComponent'
 import requiresAuthentication from 'openstack/util/requiresAuthentication'
+import { withToast } from 'core/providers/ToastProvider'
 
 const createAddComponents = options => {
   const defaults = {}
@@ -13,7 +14,6 @@ const createAddComponents = options => {
     FormComponent,
     actions,
     createFn,
-    dataKey,
     formSpec,
     initFn,
     listUrl,
@@ -31,16 +31,15 @@ const createAddComponents = options => {
 
   class AddPageBase extends React.Component {
     handleAdd = async data => {
-      const { setContext, getContext, context, history } = this.props
+      const { history } = this.props
       try {
-        const existing = await (loaderFn || crudActions.list)({ setContext, getContext, context })
+        await (loaderFn || crudActions.list)(this.props)
         if (initFn) {
           // Sometimes a component needs more than just a single GET API call.
           // This function allows for any amount of arbitrary initialization.
           await initFn(this.props)
         }
-        const created = await (createFn || crudActions.create)({ data, getContext, context, setContext })
-        await setContext({ [dataKey]: [...existing, created] })
+        await (createFn || crudActions.create)({ data, ...this.props })
         history.push(listUrl)
       } catch (err) {
         console.error(err)
@@ -57,6 +56,7 @@ const createAddComponents = options => {
   }
 
   const AddPage = compose(
+    withToast,
     withAppContext,
     withRouter,
     requiresAuthentication,

--- a/src/app/core/helpers/createCRUDComponents.js
+++ b/src/app/core/helpers/createCRUDComponents.js
@@ -12,6 +12,7 @@ import TopExtraContent from 'core/components/TopExtraContent'
 import withDataLoader from 'core/hocs/withDataLoader'
 import withDataMapper from 'core/hocs/withDataMapper'
 import { pathOr, prop } from 'ramda'
+import { withToast } from 'core/providers/ToastProvider'
 
 /**
  * This helper removes a lot of boilerplate from standard CRUD operations.
@@ -88,9 +89,8 @@ const createCRUDComponents = options => {
 
   // ListContainer
   class ContainerBase extends React.Component {
-    handleRemove = id => {
-      const { context, getContext, setContext } = this.props
-      return (deleteFn || crudActions.delete)({ id, context, getContext, setContext })
+    handleRemove = async id => {
+      return (deleteFn || crudActions.delete)({ id, ...this.props })
     }
 
     redirectToAdd = () => {
@@ -124,6 +124,7 @@ const createCRUDComponents = options => {
   }
 
   const ListContainer = compose(
+    withToast,
     withAppContext,
     withRouter,
   )(ContainerBase)

--- a/src/app/plugins/openstack/components/volumes/AddVolumePage.js
+++ b/src/app/plugins/openstack/components/volumes/AddVolumePage.js
@@ -24,7 +24,7 @@ class AddVolumePage extends React.Component {
       const volumesToCreate = constructBatch(numVolumes, volumeNamePrefix, rest)
       const existing = await loadVolumes({ setContext, getContext })
       const createdVolumes = await asyncMap(volumesToCreate, data =>
-        getContext('apiClient').cinder.createVolume(data)
+        getContext().apiClient.cinder.createVolume(data)
       )
       setContext({ volumes: [ ...existing, ...createdVolumes ] })
       history.push('/ui/openstack/storage#volumes')

--- a/src/app/plugins/openstack/components/volumes/AddVolumeTypePage.js
+++ b/src/app/plugins/openstack/components/volumes/AddVolumeTypePage.js
@@ -15,7 +15,7 @@ class AddVolumeTypePage extends React.Component {
         name: data.name,
         extra_specs: keyValueArrToObj(data.metadata),
       }
-      const createdVolumeType = await getContext('apiClient').cinder.createVolumeType(volumeType)
+      const createdVolumeType = await getContext().apiClient.cinder.createVolumeType(volumeType)
       const existingVolumeTypes = await loadVolumeTypes({ setContext, getContext })
       setContext({ volumeTypes: [ ...existingVolumeTypes, createdVolumeType ] })
       history.push('/ui/openstack/storage#volumeTypes')

--- a/src/app/plugins/openstack/components/volumes/CreateSnapshotPage.js
+++ b/src/app/plugins/openstack/components/volumes/CreateSnapshotPage.js
@@ -19,7 +19,7 @@ class CreateSnapshotPage extends React.Component {
         description: snapshotData.description,
       }
       const existingSnapshots = await loadVolumeSnapshots({ setContext, getContext })
-      const createdSnapshot = await getContext('apiClient').cinder.snapshotVolume(params)
+      const createdSnapshot = await getContext().apiClient.cinder.snapshotVolume(params)
       setContext({ volumeSnapshots: [ ...existingSnapshots, createdSnapshot ] })
       history.push('/ui/openstack/storage#volumeSnapshots')
     } catch (err) {

--- a/src/app/plugins/openstack/components/volumes/VolumeSnapshotsListContainer.js
+++ b/src/app/plugins/openstack/components/volumes/VolumeSnapshotsListContainer.js
@@ -27,7 +27,7 @@ export const VolumeSnapshotsList = createListTableComponent({
 class VolumeSnapshotsListContainer extends React.Component {
   handleRemove = async id => {
     const { getContext, setContext } = this.props
-    await getContext('apiClient').cinder.deleteSnapshot(id)
+    await getContext().apiClient.cinder.deleteSnapshot(id)
     const newVolumeSnapshots = (await loadVolumeSnapshots({ getContext, setContext }))
       .filter(x => x.id !== id)
     setContext({ volumeSnapshots: newVolumeSnapshots })

--- a/src/app/plugins/openstack/components/volumes/VolumesListContainer.js
+++ b/src/app/plugins/openstack/components/volumes/VolumesListContainer.js
@@ -40,7 +40,7 @@ export const VolumesList = createListTableComponent({
 class VolumesListContainer extends React.Component {
   handleRemove = async id => {
     const { getContext, setContext } = this.props
-    await getContext('apiClient').cinder.deleteVolume(id)
+    await getContext().apiClient.cinder.deleteVolume(id)
     const newVolumes = (await getVolumes({ getContext, setContext }))
       .filter(x => x.id !== id)
     setContext({ volumes: newVolumes })


### PR DESCRIPTION
This fixes an error that was causing the app to crash when displaying a toast notification, due to `ToastProvider` requiring the app theme but `ThemeManager` was being declared afterwards it so it was unable to access it.

Also fixed the deletion of list items as the context data was temporary emptied so it was misleading from the user perspective. Furthermore I added an overlayed loading spinner while a deletion is in progress so that the user will have a better feedback and he'll be unable to interact with the list until it has finished.