### PR TITLE
Enable public dev variant of UI

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -29,6 +29,8 @@ const config = {
       password: OS_PASSWORD || 'secret',
     },
     region: OS_REGION,
+    // Show development version of the UI
+    developer: true,
   },
 
   test: {

--- a/src/app/plugins/kubernetes/index.js
+++ b/src/app/plugins/kubernetes/index.js
@@ -22,6 +22,7 @@ import UpdatePrometheusInstancePage from './components/prometheus/UpdatePromethe
 import UpdatePrometheusRulePage from './components/prometheus/UpdatePrometheusRulePage'
 import UpdatePrometheusServiceMonitorPage from './components/prometheus/UpdateServiceMonitorPage'
 import UpdatePrometheusAlertManagerPage from './components/prometheus/UpdatePrometheusAlertManagerPage'
+import config from '../../../../config'
 
 class Kubernetes extends React.Component {
   render () {
@@ -158,7 +159,7 @@ Kubernetes.registerPlugin = pluginManager => {
   const clarityLink = path => ({ link: { path: clarityBase(path), external: true } })
 
   // For development we can set this manually
-  const useClarityLinks = window.localStorage.disableClarityLinks !== 'true'
+  const useClarityLinks = !(window.localStorage.disableClarityLinks === 'true' || config.developer)
 
   // These nav items will redirect to the old "clarity" UI while the new UI is under development.
   const clarityNavItems = [


### PR DESCRIPTION
When deploying the UI for demo / staging environments we don't want people needing to use the JavaScript console to set the `localStorage` settings.  This exposes it in the `config.js`.

I wanted to include it in `features.json` but unfortunately we need this information very early in the bootstrapping process and it would take too much effort and slow down initial app loading if we tried that approach.