### PR TITLE
Add buttons and misc design changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "build-storybook": "build-storybook",
     "dev": "cross-env NODE_ENV=development npm start",
     "lint": "./node_modules/.bin/eslint src",
-    "start": "webpack-dev-server --progress --colors --hot --inline --env.development",
+    "start": "webpack-dev-server --progress --colors --hot --inline --env.development --host 0.0.0.0",
     "server": "./node_modules/.bin/babel-node --inspect --presets @babel/preset-env src/server/main.js",
     "all": "concurrently --kill-others \"npm run server\" \"npm start\"",
     "docker:build": " docker build -t ui-dev .",

--- a/src/app/core/components/Toolbar.js
+++ b/src/app/core/components/Toolbar.js
@@ -59,7 +59,7 @@ const styles = theme => ({
     position: 'absolute',
     color: theme.palette.text.primary,
     right: theme.spacing.unit * 3,
-    bottom: -(theme.spacing.unit * 8),
+    bottom: -(theme.spacing.unit * 9.5),
   },
 })
 

--- a/src/app/core/components/buttons/CancelButton.js
+++ b/src/app/core/components/buttons/CancelButton.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import Button from '@material-ui/core/Button'
+import { withStyles } from '@material-ui/styles'
+
+const styles = theme => ({
+  baseButton: {
+    margin: theme.spacing.unit * 1,
+    borderRadius: 2,
+  }
+})
+
+const CancelButton = ({ children, classes, disabled, ...rest }) => {
+  const params = {
+    className: classes.baseButton,
+    color: disabled ? 'secondary' : 'primary',
+    variant: 'outlined',
+    disabled,
+    ...rest,
+  }
+
+  return <Button {...params}>{children || 'Cancel'}</Button>
+}
+
+export default withStyles(styles)(CancelButton)

--- a/src/app/core/components/buttons/CreateButton.js
+++ b/src/app/core/components/buttons/CreateButton.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import Button from '@material-ui/core/Button'
+import { withStyles } from '@material-ui/styles'
+
+const styles = theme => ({
+  baseButton: {
+    margin: theme.spacing.unit * 1,
+    borderRadius: 2,
+  }
+})
+
+const CreateButton = ({ children, classes, ...rest }) => (
+  <Button
+    className={classes.baseButton}
+    variant="contained"
+    size="large"
+    color="primary"
+    {...rest}
+  >
+    + {children}
+  </Button>
+)
+
+export default withStyles(styles)(CreateButton)

--- a/src/app/core/components/buttons/NewEntryButton.js
+++ b/src/app/core/components/buttons/NewEntryButton.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import Button from '@material-ui/core/Button'
+import { withStyles } from '@material-ui/styles'
+
+const styles = theme => ({
+  baseButton: {
+    margin: theme.spacing.unit * 1,
+    borderRadius: 2,
+  },
+})
+
+const NewEntryButton = ({ children, classes, disabled, ...rest }) => {
+  const params = {
+    className: classes.baseButton,
+    color: disabled ? 'primary' : 'primary',
+    variant: 'text',
+    disabled,
+    ...rest,
+  }
+
+  return (
+    <Button {...params}>
+      + {children}
+    </Button>
+  )
+}
+
+export default withStyles(styles)(NewEntryButton)

--- a/src/app/core/components/buttons/NextButton.js
+++ b/src/app/core/components/buttons/NextButton.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import Button from '@material-ui/core/Button'
+import Icon from '@material-ui/core/Icon'
+import { withStyles } from '@material-ui/styles'
+
+const styles = theme => ({
+  baseButton: {
+    margin: theme.spacing.unit * 1,
+    borderRadius: 2,
+  },
+  rightIcon: {
+    marginLeft: theme.spacing.unit * 1
+  },
+})
+
+const NextButton = ({ children, classes, disabled, ...rest }) => {
+  const params = {
+    className: classes.baseButton,
+    color: disabled ? 'primary' : 'primary',
+    variant: 'contained',
+    disabled,
+    ...rest,
+  }
+
+  return (
+    <Button {...params}>
+      <Icon className={classes.rightIcon}>arrow_forward</Icon>
+      {children || 'Next'}
+    </Button>
+  )
+}
+
+export default withStyles(styles)(NextButton)

--- a/src/app/core/components/buttons/PrevButton.js
+++ b/src/app/core/components/buttons/PrevButton.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import Button from '@material-ui/core/Button'
+import Icon from '@material-ui/core/Icon'
+import { withStyles } from '@material-ui/styles'
+
+const styles = theme => ({
+  baseButton: {
+    margin: theme.spacing.unit * 1,
+    borderRadius: 2,
+  },
+  leftIcon: {
+    marginRight: theme.spacing.unit * 1
+  },
+})
+
+const PrevButton = ({ children, classes, disabled, ...rest }) => {
+  const params = {
+    className: classes.baseButton,
+    color: disabled ? 'primary' : 'primary',
+    variant: 'outlined',
+    disabled,
+    ...rest,
+  }
+
+  return (
+    <Button {...params}>
+      <Icon className={classes.leftIcon}>arrow_back</Icon>
+      {children || 'Back'}
+    </Button>
+  )
+}
+
+export default withStyles(styles)(PrevButton)

--- a/src/app/core/components/buttons/SubmitButton.js
+++ b/src/app/core/components/buttons/SubmitButton.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import Button from '@material-ui/core/Button'
+import { withStyles } from '@material-ui/styles'
+
+const styles = theme => ({
+  baseButton: {
+    margin: theme.spacing.unit * 1,
+    borderRadius: 2,
+  }
+})
+
+const SubmitButton = ({ children, classes, disabled, ...rest }) => {
+  const params = {
+    className: classes.baseButton,
+    color: disabled ? 'secondary' : 'primary',
+    variant: 'contained',
+    disabled,
+    ...rest,
+  }
+
+  return <Button {...params}>{children || 'Submit'}</Button>
+}
+
+export default withStyles(styles)(SubmitButton)

--- a/src/app/core/components/listTable/ListTable.js
+++ b/src/app/core/components/listTable/ListTable.js
@@ -359,7 +359,6 @@ class ListTable extends React.Component {
       data,
       paginate,
       showCheckboxes,
-      title,
       canDragColumns,
       filters,
       inlineFilters,
@@ -390,7 +389,6 @@ class ListTable extends React.Component {
           <Paper className={classes.root}>
             <ListTableToolbar
               selected={selected}
-              title={title}
               onAdd={this.props.onAdd && this.handleAdd}
               onDelete={this.props.onDelete && this.handleDelete}
               onEdit={this.props.onEdit && this.handleEdit}
@@ -418,7 +416,6 @@ class ListTable extends React.Component {
                   onSelectAllClick={this.handleSelectAllClick}
                   onRequestSort={this.handleRequestSort}
                   checked={selectedAll}
-                  title={title}
                   rowCount={data.length}
                   showCheckboxes={showCheckboxes}
                 />
@@ -456,7 +453,6 @@ ListTable.propTypes = {
   })).isRequired,
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
   options: PropTypes.object,
-  title: PropTypes.string.isRequired,
   onAdd: PropTypes.func,
   onDelete: PropTypes.func,
   onEdit: PropTypes.func,

--- a/src/app/core/components/listTable/ListTable.js
+++ b/src/app/core/components/listTable/ListTable.js
@@ -371,6 +371,7 @@ class ListTable extends React.Component {
       selected,
       visibleColumns,
       filterValues,
+      rowsPerPage,
     } = this.state
 
     if (!data) {
@@ -403,6 +404,9 @@ class ListTable extends React.Component {
               onFilterUpdate={this.handleFilterUpdate}
               onFiltersReset={this.handleFiltersReset}
               batchActions={batchActions}
+              rowsPerPage={rowsPerPage}
+              onChangeRowsPerPage={this.handleChangeRowsPerPage}
+              rowsPerPageOptions={[5, 10, 25, 50, 100]}
             />
             <div className={classes.tableWrapper}>
               <Table className={classes.table}>

--- a/src/app/core/components/listTable/ListTableToolbar.js
+++ b/src/app/core/components/listTable/ListTableToolbar.js
@@ -28,11 +28,6 @@ const toolbarStyles = theme => ({
   toolbar: {
     justifyContent: 'flex-end',
   },
-  title: {
-    flex: '0 0 auto',
-    marginRight: theme.spacing.unit * 2,
-    color: theme.palette.primary.contrastText,
-  },
   rowActions: {
     color: 'inherit',
   },
@@ -56,7 +51,7 @@ const ListTableToolbar = ({
   classes, columns, context, filterValues, filters, inlineFilters,
   onAdd, onColumnToggle, onDelete, onEdit, onFilterUpdate,
   onFiltersReset, onSearchChange,
-  rowActions, searchTerm, selected, title, visibleColumns,
+  rowActions, searchTerm, selected, visibleColumns,
 }) => {
   const numSelected = (selected || []).length
   return (
@@ -65,9 +60,6 @@ const ListTableToolbar = ({
         [classes.highlight]: numSelected > 0,
       })}
     >
-      <div className={classes.title}>
-        <Typography variant="h6">{title}</Typography>
-      </div>
       <ListTableRowActions actionClassName={classes.action} rowActions={rowActions} selected={selected} />
       {numSelected === 1 && onEdit && (
         <Tooltip title="Edit">
@@ -127,7 +119,6 @@ const ListTableToolbar = ({
 }
 
 ListTableToolbar.propTypes = {
-  title: PropTypes.string,
   classes: PropTypes.object.isRequired,
   columns: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string,

--- a/src/app/core/components/listTable/ListTableToolbar.js
+++ b/src/app/core/components/listTable/ListTableToolbar.js
@@ -4,10 +4,11 @@ import AddIcon from '@material-ui/icons/Add'
 import ListTableColumnButton from 'core/components/listTable/ListTableColumnSelector'
 import ListTableFilters from 'core/components/listTable/ListTableFilters'
 import ListTableRowActions from './ListTableRowActions'
+import PerPageControl from './PerPageControl'
 import SearchBar from 'core/components/SearchBar'
 import classnames from 'classnames'
 import { compose } from 'ramda'
-import { Button, Toolbar, Tooltip, Typography } from '@material-ui/core'
+import { Button, Toolbar, Tooltip } from '@material-ui/core'
 import { withStyles } from '@material-ui/styles'
 import ListTableFiltersButton from 'core/components/listTable/ListTableFiltersButton'
 import FontAwesomeIcon from 'core/components/FontAwesomeIcon'
@@ -52,6 +53,7 @@ const ListTableToolbar = ({
   onAdd, onColumnToggle, onDelete, onEdit, onFilterUpdate,
   onFiltersReset, onSearchChange,
   rowActions, searchTerm, selected, visibleColumns,
+  rowsPerPage, onChangeRowsPerPage, rowsPerPageOptions,
 }) => {
   const numSelected = (selected || []).length
   return (
@@ -112,6 +114,11 @@ const ListTableToolbar = ({
               </Button>
             </Tooltip>
           )}
+          <PerPageControl
+            value={rowsPerPage}
+            onChangeRowsPerPage={onChangeRowsPerPage}
+            rowsPerPageOptions={rowsPerPageOptions}
+          />
         </Toolbar>
       </div>
     </Toolbar>
@@ -146,6 +153,9 @@ ListTableToolbar.propTypes = {
   selected: PropTypes.array,
   visibleColumns: PropTypes.array,
   onColumnToggle: PropTypes.func,
+  rowsPerPage: PropTypes.number.isRequired,
+  onChangeRowsPerPage: PropTypes.func.isRequired,
+  rowsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
 }
 
 export default compose(

--- a/src/app/core/components/listTable/PerPageControl.js
+++ b/src/app/core/components/listTable/PerPageControl.js
@@ -1,0 +1,65 @@
+import React from 'react'
+import { FormControl, InputBase, MenuItem, Select, Tooltip } from '@material-ui/core'
+import { withStyles } from '@material-ui/styles'
+
+// This code was derived from the "Customized Selects" example from
+// https://material-ui.com/components/selects/
+
+const BootstrapInput = withStyles(theme => ({
+  root: {
+    'label + &': {
+      marginTop: theme.spacing.unit * 3,
+    },
+  },
+  input: {
+    borderRadius: 4,
+    position: 'relative',
+    backgroundColor: theme.palette.background.paper,
+    border: '1px solid #ced4da',
+    fontSize: 16,
+    padding: '10px 26px 10px 12px',
+    transition: theme.transitions.create(['border-color', 'box-shadow']),
+    // Use the system font instead of the default Roboto font.
+    fontFamily: [
+      '-apple-system',
+      'BlinkMacSystemFont',
+      '"Segoe UI"',
+      'Roboto',
+      '"Helvetica Neue"',
+      'Arial',
+      'sans-serif',
+      '"Apple Color Emoji"',
+      '"Segoe UI Emoji"',
+      '"Segoe UI Symbol"',
+    ].join(','),
+    '&:focus': {
+      borderRadius: 4,
+      borderColor: '#80bdff',
+      boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
+    },
+  },
+}))(InputBase)
+
+const styles = theme => ({
+  margin: {
+    margin: theme.spacing.unit * 1,
+  },
+})
+
+const PerPageControl = ({ classes, value, onChangeRowsPerPage, rowsPerPageOptions }) => {
+  return (
+    <FormControl className={classes.margin}>
+      <Tooltip title="Per Page" placement="top">
+        <Select
+          value={value}
+          onChange={onChangeRowsPerPage}
+          input={<BootstrapInput />}
+        >
+          {rowsPerPageOptions.map(pp => <MenuItem value={pp} key={pp}>{pp}</MenuItem>)}
+        </Select>
+      </Tooltip>
+    </FormControl>
+  )
+}
+
+export default withStyles(styles)(PerPageControl)

--- a/src/app/core/helpers/createCRUDComponents.js
+++ b/src/app/core/helpers/createCRUDComponents.js
@@ -1,17 +1,17 @@
 import React from 'react'
-import { compose } from 'app/utils/fp'
-import { withAppContext } from 'core/AppContext'
+import CreateButton from 'core/components/buttons/CreateButton'
 import CRUDListContainer from 'core/components/CRUDListContainer'
 import ListTable from 'core/components/listTable/ListTable'
-import createCRUDActions from 'core/helpers/createCRUDActions'
-import { withScopedPreferences } from 'core/providers/PreferencesProvider'
-import requiresAuthentication from 'openstack/util/requiresAuthentication'
-import { withRouter } from 'react-router-dom'
-import { Button } from '@material-ui/core'
 import TopExtraContent from 'core/components/TopExtraContent'
+import createCRUDActions from 'core/helpers/createCRUDActions'
+import requiresAuthentication from 'openstack/util/requiresAuthentication'
 import withDataLoader from 'core/hocs/withDataLoader'
 import withDataMapper from 'core/hocs/withDataMapper'
+import { compose } from 'app/utils/fp'
 import { pathOr, prop } from 'ramda'
+import { withAppContext } from 'core/AppContext'
+import { withRouter } from 'react-router-dom'
+import { withScopedPreferences } from 'core/providers/PreferencesProvider'
 import { withToast } from 'core/providers/ToastProvider'
 
 /**
@@ -50,7 +50,6 @@ const createCRUDComponents = options => {
     editUrl,
     debug,
     name,
-    title,
   } = options
 
   // List
@@ -68,7 +67,6 @@ const createCRUDComponents = options => {
     // }
     return (
       <ListTable
-        title={title}
         columns={columns}
         data={data}
         onAdd={onAdd}
@@ -97,9 +95,7 @@ const createCRUDComponents = options => {
       this.props.history.push(addUrl)
     }
 
-    renderAddButton = () => {
-      return <Button variant="contained" size="small" color="primary" onClick={this.redirectToAdd}>+ {addText}</Button>
-    }
+    renderAddButton = () => <CreateButton onClick={this.redirectToAdd}>{addText}</CreateButton>
 
     render () {
       let moreProps = {}

--- a/src/app/plugins/developer/components/DeveloperToolsEmbed.js
+++ b/src/app/plugins/developer/components/DeveloperToolsEmbed.js
@@ -1,13 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import ApiHelper from 'developer/components/ApiHelper'
+import ContextViewer from 'developer/components/ContextViewer'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+import SimpleLink from 'core/components/SimpleLink'
+import { compose } from 'app/utils/fp'
+import { withStyles } from '@material-ui/styles'
 import {
   Button, ExpansionPanel, ExpansionPanelDetails, ExpansionPanelSummary, Typography,
 } from '@material-ui/core'
-import { withStyles } from '@material-ui/styles'
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
-import { compose } from 'app/utils/fp'
-import ApiHelper from 'developer/components/ApiHelper'
-import ContextViewer from 'developer/components/ContextViewer'
 
 const styles = theme => ({
   root: {
@@ -60,6 +61,7 @@ class DeveloperToolsEmbed extends React.Component {
     // This is currently UI developers only so leaving always expanded
     return (
       <div className={classes.root}>
+
         {false && <Button onClick={this.collapse}>collapse devtools</Button>}
         <Typography variant="subtitle1">Developer Tools</Typography>
         <Panel title="Context Viewer">
@@ -68,6 +70,7 @@ class DeveloperToolsEmbed extends React.Component {
         <Panel title="API helper">
           <ApiHelper />
         </Panel>
+        <SimpleLink src="/ui/themes/configure">Theme Manager</SimpleLink>
       </div>
     )
   }

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
@@ -44,7 +44,6 @@ export const options = {
   editUrl: '/ui/kubernetes/prometheus/instances/edit',
   loaderFn: loadPrometheusInstances,
   name: 'PrometheusInstances',
-  title: 'Prometheus Instances',
   uniqueIdentifier: 'uid',
 }
 

--- a/src/app/plugins/theme/components/examples/ButtonsExample.js
+++ b/src/app/plugins/theme/components/examples/ButtonsExample.js
@@ -1,4 +1,10 @@
 import React from 'react'
+import CancelButton from 'core/components/buttons/CancelButton'
+import CreateButton from 'core/components/buttons/CreateButton'
+import NextButton from 'core/components/buttons/NextButton'
+import NewEntryButton from 'core/components/buttons/NewEntryButton'
+import PrevButton from 'core/components/buttons/PrevButton'
+import SubmitButton from 'core/components/buttons/SubmitButton'
 import Panel from '../Panel'
 import ExternalLink from 'core/components/ExternalLink'
 import CustomizeExpander from '../CustomizeExpander'
@@ -7,6 +13,29 @@ import { Button } from '@material-ui/core'
 
 const ButtonsExample = ({ expanded = false }) => (
   <Panel title="Buttons" defaultExpanded={expanded}>
+    <CreateButton>Add Cluster</CreateButton>
+
+    <br />
+
+    <CancelButton />
+    <CancelButton disabled />
+
+    <br />
+
+    <SubmitButton />
+    <SubmitButton disabled />
+
+    <br />
+
+    <PrevButton />
+    <NextButton />
+
+    <br />
+
+    <NewEntryButton>New Key / Value Entry</NewEntryButton>
+
+    <hr />
+
     <Button variant="contained">Default</Button>
     <Button variant="contained" color="primary">Primary</Button>
     <Button variant="contained" color="secondary">Secondary</Button>

--- a/src/stories/common/buttons/CreateButton.stories.js
+++ b/src/stories/common/buttons/CreateButton.stories.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { addStoriesFromModule } from '../../helpers'
+
+import CreateButton from 'core/components/buttons/CreateButton'
+
+const addStories = addStoriesFromModule(module)
+
+addStories('Common Components/Buttons', {
+  'Create Button': () => (
+    <CreateButton>Add Cluster</CreateButton>
+  ),
+})


### PR DESCRIPTION
This PR makes the following changes:
* Created a set of buttons based on design feedback.  They are now added to the theme editor.  I tried adding them to Storybook as well but there are lots of issues with reloading and errors that I am leaning towards abandoning Storybook and just using the theme editor for showcasing components.
* Removed the title from the `ListTable`.  It has been decided not to have the title in the table itself.  Instead, any page that has a table will also have tabs—even when there is just 1 tab.
* Swapped out the "Create" button to the new design and added it to `createCRUDComponents`.
* Added the Rows Per Page control in the top right of the table.
* Made dev server listen on all address (needed for demo env since by default it is only `localhost`).

![Screen Shot 2019-07-17 at 2 55 32 PM](https://user-images.githubusercontent.com/289156/61414563-1eb7ac00-a8a3-11e9-996f-f560ac061cfa.png)


![Screen Shot 2019-07-17 at 2 51 50 PM](https://user-images.githubusercontent.com/289156/61414560-1d867f00-a8a3-11e9-9797-b17987b9393b.png)


![Screen Shot 2019-07-17 at 3 53 38 PM](https://user-images.githubusercontent.com/289156/61417291-8b36a900-a8ab-11e9-9119-0b679738910b.png)
