### PR TITLE
[WIP] Style MultiSelect

### DIFF
--- a/src/app/core/components/MultiSelect.js
+++ b/src/app/core/components/MultiSelect.js
@@ -7,6 +7,8 @@ import InputAdornment from '@material-ui/core/InputAdornment'
 import OutlinedInput from '@material-ui/core/OutlinedInput'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Checkbox from '@material-ui/core/Checkbox'
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank'
+import CheckBoxIcon from '@material-ui/icons/CheckBox'
 import SearchIcon from '@material-ui/icons/Search'
 import * as Fuse from 'fuse.js'
 
@@ -18,26 +20,61 @@ const useStyles = makeStyles(theme => createStyles({
   container: {
     display: 'inline-flex',
     flexDirection: 'column',
-    padding: 10,
+    padding: 8,
     border: '1px solid #000',
   },
-  option: {
-
+  searchInputWrapper: {
+    marginBottom: 4,
+  },
+  notchedOutline: {
+    borderRadius: 0,
+  },
+  input: {
+    boxSizing: 'border-box',
+    height: 30,
+    padding: 6,
+    fontSize: 13,
+  },
+  adornedStart: {
+    paddingLeft: 8,
+  },
+  searchIcon: {
+    color: '#bababa',
+  },
+  positionStart: {
+    marginRight: 0,
+  },
+  formControlLabelRoot: {
+    marginLeft: -6,
+    margin: '2px 0',
+  },
+  checkbox: {
+    padding: 4,
+  },
+  checkboxSize: {
+    fontSize: 16,
+  },
+  options: {
+    overflowY: 'auto',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  optionLabel: {
+    fontSize: 13,
   },
 }))
 
 const MultiSelect = ({ label, options, values, onChange, maxOptions, sortSelectedFirst }) => {
   const classes = useStyles()
 
-  const adjustOptions = (options) => {
+  const sortOptions = (options) => {
     const sortBySelected = (a, b) => values.includes(b.value) - values.includes(a.value)
     const sortedOptions = sortSelectedFirst ? options.sort(sortBySelected) : options
-    const limitedOptions = maxOptions ? sortedOptions.slice(0, maxOptions) : sortedOptions
 
-    return limitedOptions
+    return sortedOptions
   }
 
-  const [visibleOptions, setVisibleOptions] = useState(adjustOptions(options))
+  const [visibleOptions, setVisibleOptions] = useState(sortOptions(options))
   const [fuse, setFuse] = useState(null)
 
   useEffect(() => setFuse(new Fuse(options, FUSE_OPTIONS)), [options])
@@ -52,10 +89,10 @@ const MultiSelect = ({ label, options, values, onChange, maxOptions, sortSelecte
 
   const onSearchChange = (term) => {
     if (!term) {
-      setVisibleOptions(adjustOptions(options))
+      setVisibleOptions(sortOptions(options))
     } else if (fuse) {
       const searchResults = fuse.search(term)
-      setVisibleOptions(adjustOptions(searchResults))
+      setVisibleOptions(sortOptions(searchResults))
     }
   }
 
@@ -67,22 +104,27 @@ const MultiSelect = ({ label, options, values, onChange, maxOptions, sortSelecte
 
   return (
     <Box className={classes.container}>
-      <SearchField onSearchChange={onSearchChange} onHitEnter={onHitEnter} />
-      {visibleOptions.map((option) => (
-        <Option
-          classes={classes}
-          key={option.value}
-          label={option.label}
-          value={option.value}
-          checked={values.includes(option.value)}
-          onChange={() => toggleOption(option.value)}
-        />
-      ))}
+      <SearchField classes={classes} onSearchChange={onSearchChange} onHitEnter={onHitEnter} />
+      <Box
+        className={classes.options}
+        style={{ height: maxOptions ? getOptionsHeight(maxOptions) : 'initial' }}
+      >
+        {visibleOptions.map((option) => (
+          <Option
+            classes={classes}
+            key={option.value}
+            label={option.label}
+            value={option.value}
+            checked={values.includes(option.value)}
+            onChange={() => toggleOption(option.value)}
+          />
+        ))}
+      </Box>
     </Box>
   )
 }
 
-const SearchField = ({ onSearchChange, onHitEnter }) => {
+const SearchField = ({ classes, onSearchChange, onHitEnter }) => {
   const [term, setTerm] = useState('')
 
   useEffect(() => onSearchChange(term), [term])
@@ -96,12 +138,21 @@ const SearchField = ({ onSearchChange, onHitEnter }) => {
   }
 
   return (
-    <FormControl>
+    <FormControl className={classes.searchInputWrapper}>
       <OutlinedInput
         value={term}
         onChange={(e) => setTerm(e.target.value)}
         onKeyDown={handleKeyDown}
-        startAdornment={<InputAdornment position="start"><SearchIcon /></InputAdornment>}
+        startAdornment={
+          <InputAdornment position="start" classes={{ positionStart: classes.positionStart }}>
+            <SearchIcon className={classes.searchIcon} />
+          </InputAdornment>
+        }
+        classes={{
+          notchedOutline: classes.notchedOutline,
+          input: classes.input,
+          adornedStart: classes.adornedStart,
+        }}
       />
     </FormControl>
   )
@@ -109,10 +160,20 @@ const SearchField = ({ onSearchChange, onHitEnter }) => {
 
 const Option = ({ classes, label, ...checkboxProps }) =>
   <FormControlLabel
-    className={classes.options}
     label={label}
-    control={<Checkbox {...checkboxProps} />}
+    control={
+      <Checkbox
+        color="primary"
+        className={classes.checkbox}
+        icon={<CheckBoxOutlineBlankIcon className={classes.checkboxSize} />}
+        checkedIcon={<CheckBoxIcon className={classes.checkboxSize} />}
+        {...checkboxProps}
+      />
+    }
+    classes={{ root: classes.formControlLabelRoot, label: classes.optionLabel }}
   />
+
+const getOptionsHeight = (maxOptions) => maxOptions * 28
 
 const optionPropType = PropTypes.shape({
   value: PropTypes.string,

--- a/src/app/core/components/MultiSelect.js
+++ b/src/app/core/components/MultiSelect.js
@@ -21,7 +21,7 @@ const useStyles = makeStyles(theme => createStyles({
     display: 'inline-flex',
     flexDirection: 'column',
     padding: 8,
-    border: '1px solid #000',
+    border: `1px solid ${theme.palette.common.black}`,
   },
   searchInputWrapper: {
     marginBottom: 4,


### PR DESCRIPTION
This PR:
- Apply styling to MultiSelect to make it look the old UI
- Changes `maxOptions` to no limit the number of options, but instead, it limits the component's height, but all the options could be viewed by scrolling.

TODO:
- Move some styling to `defaultTheme.js`

<img width="207" alt="Screen Shot 2019-09-20 at 14 25 27" src="https://user-images.githubusercontent.com/1504544/65346216-8c899800-dbb2-11e9-9b73-0819a77aafa0.png">
Storybook image