### PR TITLE
New Logging and Edit Logging empty pages

### DIFF
--- a/src/app/core/components/buttons/CreateButton.js
+++ b/src/app/core/components/buttons/CreateButton.js
@@ -8,7 +8,6 @@ const styles = theme => ({
     borderRadius: 2,
     textTransform: 'none',
     height: 40,
-    boxShadow: '0 3px 1px -2px rgba(0, 0, 0, 0.11), 0 2px 2px 0 rgba(0, 0, 0, 0.11), 0 1px 5px 0 rgba(0, 0, 0, 0.2)',
   }
 })
 

--- a/src/app/core/components/buttons/CreateButton.js
+++ b/src/app/core/components/buttons/CreateButton.js
@@ -7,6 +7,8 @@ const styles = theme => ({
     margin: theme.spacing(1),
     borderRadius: 2,
     textTransform: 'none',
+    height: 40,
+    boxShadow: '0 3px 1px -2px rgba(0, 0, 0, 0.11), 0 2px 2px 0 rgba(0, 0, 0, 0.11), 0 1px 5px 0 rgba(0, 0, 0, 0.2)',
   }
 })
 

--- a/src/app/plugins/kubernetes/components/logging/LoggingAddPage.js
+++ b/src/app/plugins/kubernetes/components/logging/LoggingAddPage.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const LoggingAddPage = () => <h1>Add New Logging</h1>
+
+export default LoggingAddPage

--- a/src/app/plugins/kubernetes/components/logging/LoggingEditPage.js
+++ b/src/app/plugins/kubernetes/components/logging/LoggingEditPage.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const LoggingEditPage = () => <h1>Edit Logging</h1>
+
+export default LoggingEditPage

--- a/src/app/plugins/kubernetes/components/logging/LoggingListPage.js
+++ b/src/app/plugins/kubernetes/components/logging/LoggingListPage.js
@@ -46,8 +46,8 @@ const useStyles = makeStyles(theme => createStyles({
   },
 }))
 
-const EDIT_URL = '/ui/kubernetes/logging/edit'
-const ADD_URL = '/ui/kubernetes/logging/add'
+const addUrl = '/ui/kubernetes/logging/add'
+const editUrl = '/ui/kubernetes/logging/edit'
 
 const status = {
   ENABLED: 'enabled',
@@ -181,7 +181,7 @@ const LoggingListPage = withRouter(({ history }) => {
     <Fragment>
       <Box className={classes.titleAndCreateButton}>
         <h2>Logging</h2>
-        <CreateButton onClick={() => history.push(ADD_URL)}>New Logging</CreateButton>
+        <CreateButton onClick={() => history.push(addUrl)}>New Logging</CreateButton>
       </Box>
       <ListTable columns={columns} data={data} batchActions={actions} />
     </Fragment>
@@ -263,7 +263,7 @@ const getActions = (classes, history) => [
   {
     icon: <ActionIcon classes={classes} icon='edit' label='Edit' />,
     label: 'Edit',
-    action: (clusters) => history.push(`${EDIT_URL}/${clusters[0].cluster}`),
+    action: (clusters) => history.push(`${editUrl}/${clusters[0].cluster}`),
     cond: (clusters) => clusters.length === 1
   },
   {

--- a/src/app/plugins/kubernetes/components/logging/LoggingListPage.js
+++ b/src/app/plugins/kubernetes/components/logging/LoggingListPage.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react'
-import { withRouter } from 'react-router-dom'
+import useReactRouter from 'use-react-router'
 import { makeStyles, createStyles } from '@material-ui/styles'
 import Box from '@material-ui/core/Box'
 import ListTable from 'core/components/listTable/ListTable'
@@ -172,8 +172,9 @@ const data = [
   },
 ]
 
-const LoggingListPage = withRouter(({ history }) => {
+const LoggingListPage = () => {
   const classes = useStyles()
+  const { history } = useReactRouter()
   const columns = getColumns(classes)
   const actions = getActions(classes, history)
 
@@ -186,7 +187,7 @@ const LoggingListPage = withRouter(({ history }) => {
       <ListTable columns={columns} data={data} batchActions={actions} />
     </Fragment>
   )
-})
+}
 
 const renderStatus = (classes, value) => {
   let icon

--- a/src/app/plugins/kubernetes/components/logging/LoggingListPage.js
+++ b/src/app/plugins/kubernetes/components/logging/LoggingListPage.js
@@ -1,10 +1,16 @@
 import React, { Fragment } from 'react'
+import { withRouter } from 'react-router-dom'
 import { makeStyles, createStyles } from '@material-ui/styles'
 import Box from '@material-ui/core/Box'
 import ListTable from 'core/components/listTable/ListTable'
 import FontAwesomeIcon from 'core/components/FontAwesomeIcon'
+import CreateButton from 'core/components/buttons/CreateButton'
 
 const useStyles = makeStyles(theme => createStyles({
+  titleAndCreateButton: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
   actionIconWrapper: {
     display: 'flex',
     flexDirection: 'column',
@@ -39,6 +45,9 @@ const useStyles = makeStyles(theme => createStyles({
     color: '#e44c34',
   },
 }))
+
+const EDIT_URL = '/ui/kubernetes/logging/edit'
+const ADD_URL = '/ui/kubernetes/logging/add'
 
 const status = {
   ENABLED: 'enabled',
@@ -163,18 +172,21 @@ const data = [
   },
 ]
 
-const LoggingPage = () => {
+const LoggingListPage = withRouter(({ history }) => {
   const classes = useStyles()
   const columns = getColumns(classes)
-  const actions = getActions(classes)
+  const actions = getActions(classes, history)
 
   return (
     <Fragment>
-      <h2>Logging</h2>
+      <Box className={classes.titleAndCreateButton}>
+        <h2>Logging</h2>
+        <CreateButton onClick={() => history.push(ADD_URL)}>New Logging</CreateButton>
+      </Box>
       <ListTable columns={columns} data={data} batchActions={actions} />
     </Fragment>
   )
-}
+})
 
 const renderStatus = (classes, value) => {
   let icon
@@ -235,7 +247,7 @@ const ActionIcon = ({ classes, icon, label }) =>
     {label}
   </Box>
 
-const getActions = (classes) => [
+const getActions = (classes, history) => [
   {
     icon: <ActionIcon classes={classes} icon='check' label='Enable' />,
     label: 'Enable',
@@ -251,7 +263,7 @@ const getActions = (classes) => [
   {
     icon: <ActionIcon classes={classes} icon='edit' label='Edit' />,
     label: 'Edit',
-    action: () => {},
+    action: (clusters) => history.push(`${EDIT_URL}/${clusters[0].cluster}`),
     cond: (clusters) => clusters.length === 1
   },
   {
@@ -261,4 +273,4 @@ const getActions = (classes) => [
   },
 ]
 
-export default LoggingPage
+export default LoggingListPage

--- a/src/app/plugins/kubernetes/index.js
+++ b/src/app/plugins/kubernetes/index.js
@@ -24,7 +24,9 @@ import UpdatePrometheusRulePage from './components/prometheus/UpdatePrometheusRu
 import UpdatePrometheusServiceMonitorPage from './components/prometheus/UpdateServiceMonitorPage'
 import UpdatePrometheusAlertManagerPage
   from './components/prometheus/UpdatePrometheusAlertManagerPage'
-import LoggingPage from './components/logging/LoggingPage'
+import LoggingListPage from './components/logging/LoggingListPage'
+import LoggingAddPage from './components/logging/LoggingAddPage'
+import LoggingEditPage from './components/logging/LoggingEditPage'
 import config from '../../../../config'
 import DashboardPage from 'k8s/components/DashboardPage'
 
@@ -128,7 +130,17 @@ Kubernetes.registerPlugin = pluginManager => {
       {
         name: 'Logging (beta)',
         link: { path: '/logging', exact: true },
-        component: LoggingPage,
+        component: LoggingListPage,
+      },
+      {
+        name: 'Add Logging',
+        link: { path: '/logging/add', exact: true },
+        component: LoggingAddPage,
+      },
+      {
+        name: 'Edit Logging',
+        link: { path: '/logging/edit/:id', exact: true },
+        component: LoggingEditPage,
       },
       {
         name: 'Add Namespace',


### PR DESCRIPTION
This PR implements:
- Clicking on `+ New Logging` => Redirects to New Logging Page
- Clicking on `Edit` => Redirects to Edit Logging Page

<img width="200" alt="Screen Shot 2019-09-24 at 20 46 45" src="https://user-images.githubusercontent.com/1504544/65558284-778f6a80-df0c-11e9-9c88-c257b408d7e0.png">
<img width="56" alt="Screen Shot 2019-09-24 at 20 46 50" src="https://user-images.githubusercontent.com/1504544/65558285-778f6a80-df0c-11e9-86fa-075436d3c29f.png">
