### PR TITLE
Use helper methods to create Logging pages: list, add and edit

### DIFF
--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -2,6 +2,7 @@ import { assoc, propOr } from 'ramda'
 import { keyValueArrToObj } from 'utils/fp'
 import { pathJoin } from 'utils/misc'
 import { normalizeResponse } from 'api-client/helpers'
+import LoggingStub from 'k8s/components/logging/LoggingStub'
 
 const normalizeClusterizedResponse = (clusterId, response) => propOr([], 'items', response).map(
   x => ({ ...x, clusterId }))
@@ -507,6 +508,9 @@ class Qbert {
 
   getPrometheusDashboardLink =
     instance => `${this.cachedEndpoint}/clusters/${instance.clusterUuid}/k8sapi${instance.dashboard}`
+
+  /* Logging */
+  getLoggings = () => LoggingStub.getLoggings()
 }
 
 export default Qbert

--- a/src/app/core/components/listTable/ListTableBatchActions.js
+++ b/src/app/core/components/listTable/ListTableBatchActions.js
@@ -1,17 +1,21 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { IconButton, Tooltip } from '@material-ui/core'
+import { Tooltip } from '@material-ui/core'
+import FontAwesomeIcon from 'core/components/FontAwesomeIcon'
 import { withAppContext } from 'core/AppProvider'
 
 // FIXME this should not be accessing the context
-const ListTableBatchActions = ({ actionClassName, context, batchActions, selected = [] }) => {
+const ListTableBatchActions = ({ actionClassName, actionIconClassName, context, batchActions, selected = [] }) => {
   const filtered = (batchActions || []).filter(action =>
     action.cond === undefined || action.cond(selected, context)
   )
   if (selected.length === 0 || filtered.length === 0) { return null }
   return filtered.map(action => (
     <Tooltip key={action.label} title={action.label}>
-      <IconButton className={actionClassName} onClick={() => action.action(selected, context)}>{action.icon}</IconButton>
+      <div className={actionClassName} onClick={() => action.action(selected, context)}>
+        <FontAwesomeIcon className={actionIconClassName}>{action.icon}</FontAwesomeIcon>
+        {action.label}
+      </div>
     </Tooltip>
   ))
 }
@@ -25,7 +29,7 @@ ListTableBatchActions.propTypes = {
     PropTypes.shape({
       label: PropTypes.string.isRequired,
       action: PropTypes.func,
-      icon: PropTypes.node,
+      icon: PropTypes.string,
       cond: PropTypes.func,
     })
   ),

--- a/src/app/core/components/listTable/ListTableToolbar.js
+++ b/src/app/core/components/listTable/ListTableToolbar.js
@@ -109,11 +109,11 @@ const ListTableToolbar = ({
         [classes.highlight]: numSelected > 0,
       })}
     >
-      <ListTableBatchActions actionClassName={classes.action} batchActions={batchActions} selected={selected} />
+      <ListTableBatchActions actionClassName={classes.action} actionIconClassName={classes.actionIcon} batchActions={batchActions} selected={selected} />
       {numSelected === 1 && onEdit && (
         <Tooltip title="Edit">
           <div className={classes.action} onClick={onEdit}>
-            <FontAwesomeIcon className={classes.actionIcon}>{'pencil-alt'}</FontAwesomeIcon>
+            <FontAwesomeIcon className={classes.actionIcon}>edit</FontAwesomeIcon>
             Edit
           </div>
         </Tooltip>
@@ -121,7 +121,7 @@ const ListTableToolbar = ({
       {numSelected > 0 && onDelete && (
         <Tooltip title="Delete">
           <div className={classes.action} onClick={onDelete}>
-            <FontAwesomeIcon className={classes.actionIcon}>{'trash-alt'}</FontAwesomeIcon>
+            <FontAwesomeIcon className={classes.actionIcon}>trash-alt</FontAwesomeIcon>
             Delete
           </div>
         </Tooltip>

--- a/src/app/core/components/listTable/TitleAndAddButton.js
+++ b/src/app/core/components/listTable/TitleAndAddButton.js
@@ -1,0 +1,56 @@
+import React, { Fragment, useState, useCallback, useMemo } from 'react'
+import PropTypes from 'prop-types'
+import useReactRouter from 'use-react-router'
+import { makeStyles, createStyles } from '@material-ui/styles'
+import Box from '@material-ui/core/Box'
+import CreateButton from 'core/components/buttons/CreateButton'
+
+const useStyles = makeStyles(theme => createStyles({
+  container: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+}))
+
+const TitleAndAddButton = ({ title, addUrl, addText, renderAddDialog, reload }) => {
+  const { history } = useReactRouter()
+  const classes = useStyles()
+  const [addDialogOpen, setAddDialogOpen] = useState(false)
+
+  const handleAddDialogClose = useCallback(() => {
+    setAddDialogOpen(false)
+    reload()
+  }, [reload])
+
+  const addButton = useMemo(() => (
+    <CreateButton onClick={() => renderAddDialog ? setAddDialogOpen(true) : history.push(addUrl)}>
+      {addText}
+    </CreateButton>
+  ), [history])
+
+  const isTitleOrButtonVisible = addUrl || title || !!renderAddDialog
+  const isAddDialogOpen = !!renderAddDialog && addDialogOpen
+
+  return (
+    <Fragment>
+      {isTitleOrButtonVisible &&
+        <Box className={classes.container}>
+          <h2>{title}</h2>
+          {!!addUrl && addButton}
+        </Box>
+      }
+      {isAddDialogOpen && renderAddDialog(handleAddDialogClose)}
+    </Fragment>
+  )
+}
+
+TitleAndAddButton.propTypes = {
+  title: PropTypes.string,
+  addUrl: PropTypes.string,
+  addText: PropTypes.string,
+  renderAddDialog: PropTypes.func,
+  reload: PropTypes.func,
+}
+
+export default TitleAndAddButton

--- a/src/app/core/helpers/createCRUDComponents.js
+++ b/src/app/core/helpers/createCRUDComponents.js
@@ -1,8 +1,7 @@
-import React, { useMemo, useCallback, useState } from 'react'
-import CreateButton from 'core/components/buttons/CreateButton'
+import React, { useCallback } from 'react'
 import CRUDListContainer from 'core/components/CRUDListContainer'
 import ListTable from 'core/components/listTable/ListTable'
-import TopExtraContent from 'core/components/TopExtraContent'
+import TitleAndAddButton from 'core/components/listTable/TitleAndAddButton'
 import requiresAuthentication from 'openstack/util/requiresAuthentication'
 import useDataLoader from 'core/hooks/useDataLoader'
 import useDataUpdater from 'core/hooks/useDataUpdater'
@@ -41,7 +40,9 @@ const createCRUDComponents = options => {
     deleteFn = cacheKey ? getContextUpdater(cacheKey, 'delete') : null,
     defaultParams = {},
     columns = [],
+    batchActions = [],
     rowActions = [],
+    innerTitle,
     uniqueIdentifier = 'id',
     addText = 'Add',
     addUrl,
@@ -53,7 +54,7 @@ const createCRUDComponents = options => {
 
   // List
   const List = ({
-    onAdd, onDelete, onEdit, rowActions, data, onRefresh, onActionComplete, loading,
+    onAdd, onDelete, onEdit, batchActions, rowActions, data, onRefresh, onActionComplete, loading,
     visibleColumns, columnsOrder, rowsPerPage, orderBy, orderDirection,
     getParamsUpdater, filters,
   }) => {
@@ -75,6 +76,7 @@ const createCRUDComponents = options => {
         onAdd={onAdd}
         onDelete={onDelete}
         onEdit={onEdit}
+        batchActions={batchActions}
         rowActions={rowActions}
         searchTarget="name"
         uniqueIdentifier={uniqueIdentifier}
@@ -94,16 +96,6 @@ const createCRUDComponents = options => {
   // ListContainer
   const ListContainer = withRouter(({ history, data, loading, reload, ...restProps }) => {
     const [handleRemove, deleting] = deleteFn ? useDataUpdater(deleteFn, reload) : emptyArr
-    const [addDialogOpen, setAddDialogOpen] = useState(false)
-    const handleAddDialogClose = useCallback(() => {
-      setAddDialogOpen(false)
-      reload()
-    }, [reload])
-    const addButton = useMemo(
-      () => <CreateButton onClick={
-        () => renderAddDialog ? setAddDialogOpen(true) : history.push(addUrl)
-      }>{addText}</CreateButton>,
-      [history])
     const refetch = useCallback(() => reload(true))
     return (
       <CRUDListContainer
@@ -113,11 +105,17 @@ const createCRUDComponents = options => {
         uniqueIdentifier={uniqueIdentifier}
       >
         {handlers => <>
-          {(addUrl || renderAddDialog) && <TopExtraContent>{addButton}</TopExtraContent>}
-          {renderAddDialog && addDialogOpen && renderAddDialog(handleAddDialogClose)}
+          <TitleAndAddButton
+            title={innerTitle}
+            addUrl={addUrl}
+            addText={addText}
+            renderAddDialog={renderAddDialog}
+            reload={reload}
+          />
           <List
             loading={loading || deleting}
             data={data}
+            batchActions={batchActions}
             rowActions={rowActions}
             onRefresh={refetch}
             onActionComplete={reload}

--- a/src/app/plugins/kubernetes/components/logging/LoggingAddPage.js
+++ b/src/app/plugins/kubernetes/components/logging/LoggingAddPage.js
@@ -1,5 +1,5 @@
 import React from 'react'
 
-const LoggingAddPage = () => <h1>Add New Logging</h1>
+const LoggingAddPage = () => <h1>Add New Logging Configuration</h1>
 
 export default LoggingAddPage

--- a/src/app/plugins/kubernetes/components/logging/LoggingAddPage.js
+++ b/src/app/plugins/kubernetes/components/logging/LoggingAddPage.js
@@ -1,5 +1,14 @@
-import React from 'react'
+import createAddComponents from 'core/helpers/createAddComponents'
+import LoggingForm from './LoggingForm'
 
-const LoggingAddPage = () => <h1>Add New Logging Configuration</h1>
+const options = {
+  createFn: () => {},
+  FormComponent: LoggingForm,
+  listUrl: '/ui/kubernetes/logging',
+  name: 'AddLogging',
+  title: 'Add New Logging Configuration',
+}
+
+const { AddPage: LoggingAddPage } = createAddComponents(options)
 
 export default LoggingAddPage

--- a/src/app/plugins/kubernetes/components/logging/LoggingEditPage.js
+++ b/src/app/plugins/kubernetes/components/logging/LoggingEditPage.js
@@ -1,5 +1,19 @@
-import React from 'react'
+import createUpdateComponents from 'core/helpers/createUpdateComponents'
+import LoggingForm from './LoggingForm'
+import ApiClient from 'api-client/ApiClient'
 
-const LoggingEditPage = () => <h1>Edit Logging Configuration</h1>
+const { qbert } = ApiClient.getInstance()
+
+const options = {
+  FormComponent: LoggingForm,
+  updateFn: () => {},
+  loaderFn: qbert.getLoggings,
+  listUrl: '/ui/kubernetes/logging',
+  name: 'EditLogging',
+  title: 'Edit Logging Configuration',
+  uniqueIdentifier: 'cluster',
+}
+
+const { UpdatePage: LoggingEditPage } = createUpdateComponents(options)
 
 export default LoggingEditPage

--- a/src/app/plugins/kubernetes/components/logging/LoggingEditPage.js
+++ b/src/app/plugins/kubernetes/components/logging/LoggingEditPage.js
@@ -1,5 +1,5 @@
 import React from 'react'
 
-const LoggingEditPage = () => <h1>Edit Logging</h1>
+const LoggingEditPage = () => <h1>Edit Logging Configuration</h1>
 
 export default LoggingEditPage

--- a/src/app/plugins/kubernetes/components/logging/LoggingForm.js
+++ b/src/app/plugins/kubernetes/components/logging/LoggingForm.js
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const LoggingForm = ({ initialValues }) => {
+  const isEdit = !!initialValues
+
+  return (
+    <div>
+      <h3>Logging Form</h3>
+      {isEdit && <p>{JSON.stringify(initialValues)}</p>}
+    </div>
+  )
+}
+
+export default LoggingForm

--- a/src/app/plugins/kubernetes/components/logging/LoggingListPage.js
+++ b/src/app/plugins/kubernetes/components/logging/LoggingListPage.js
@@ -1,28 +1,16 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import useReactRouter from 'use-react-router'
 import { makeStyles, createStyles } from '@material-ui/styles'
-import Box from '@material-ui/core/Box'
-import ListTable from 'core/components/listTable/ListTable'
 import FontAwesomeIcon from 'core/components/FontAwesomeIcon'
-import CreateButton from 'core/components/buttons/CreateButton'
+import ApiClient from 'api-client/ApiClient'
+import createCRUDComponents from 'core/helpers/createCRUDComponents'
+
+const { qbert } = ApiClient.getInstance()
 
 const useStyles = makeStyles(theme => createStyles({
   titleAndCreateButton: {
     display: 'flex',
     justifyContent: 'space-between',
-  },
-  actionIconWrapper: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 40,
-    height: 40,
-  },
-  actionIcon: {
-    fontSize: 18,
-    fontWeight: 300,
-    color: '#606060',
   },
   enabledIcon: {
     fontSize: 13,
@@ -56,137 +44,27 @@ const status = {
   FAILED: 'failed',
 }
 
-const storageType = {
-  S3: 'AWS-S3',
-  ELASTIC_SEARCH: 'ElasticSearch',
-}
-
-const data = [
-  {
-    cluster: 'cluster-id-01',
-    status: status.ENABLED,
-    logStorage: [
-      storageType.S3,
-      storageType.ELASTIC_SEARCH
-    ],
-    logDestination: [
-      'bucket123/regionnameABC',
-      'http://mybucket.s3.johnsmith',
-    ],
-  },
-  {
-    cluster: 'cluster-id-02',
-    status: status.DISABLED,
-    logStorage: [
-      storageType.S3,
-    ],
-    logDestination: [
-      'bucket123/regionnameABC',
-    ],
-  },
-  {
-    cluster: 'cluster-id-03',
-    status: status.ENABLED,
-    logStorage: [
-      storageType.ELASTIC_SEARCH
-    ],
-    logDestination: [
-      'http://mybucket.s3.johnsmith',
-    ],
-  },
-  {
-    cluster: 'cluster-id-04',
-    status: status.ENABLED,
-    logStorage: [
-      storageType.S3,
-      storageType.ELASTIC_SEARCH
-    ],
-    logDestination: [
-      'bucket123/regionnameABC',
-      'http://mybucket.s3.johnsmith',
-    ],
-  },
-  {
-    cluster: 'cluster-id-05',
-    status: status.CONFIGURING,
-    logStorage: [
-      storageType.ELASTIC_SEARCH
-    ],
-    logDestination: [
-      'http://mybucket.s3.johnsmith',
-    ],
-  },
-  {
-    cluster: 'cluster-id-06',
-    status: status.FAILED,
-    logStorage: [
-      storageType.S3,
-      storageType.ELASTIC_SEARCH
-    ],
-    logDestination: [
-      'bucket123/regionnameABC',
-      'http://mybucket.s3.johnsmith',
-    ],
-  },
-  {
-    cluster: 'cluster-id-07',
-    status: status.DISABLED,
-    logStorage: [
-      storageType.S3,
-    ],
-    logDestination: [
-      'bucket123/regionnameABC',
-    ],
-  },
-  {
-    cluster: 'cluster-id-08',
-    status: status.ENABLED,
-    logStorage: [
-      storageType.ELASTIC_SEARCH
-    ],
-    logDestination: [
-      'http://mybucket.s3.johnsmith',
-    ],
-  },
-  {
-    cluster: 'cluster-id-09',
-    status: status.ENABLED,
-    logStorage: [
-      storageType.S3,
-      storageType.ELASTIC_SEARCH
-    ],
-    logDestination: [
-      'bucket123/regionnameABC',
-      'http://mybucket.s3.johnsmith',
-    ],
-  },
-  {
-    cluster: 'cluster-id-10',
-    status: status.ENABLED,
-    logStorage: [
-      storageType.ELASTIC_SEARCH
-    ],
-    logDestination: [
-      'http://mybucket.s3.johnsmith',
-    ],
-  },
-]
-
 const LoggingListPage = () => {
   const classes = useStyles()
   const { history } = useReactRouter()
   const columns = getColumns(classes)
-  const actions = getActions(classes, history)
+  const batchActions = getActions(classes, history)
 
-  return (
-    <Fragment>
-      <Box className={classes.titleAndCreateButton}>
-        <h2>Logging</h2>
-        <CreateButton onClick={() => history.push(addUrl)}>New Logging</CreateButton>
-      </Box>
-      <ListTable columns={columns} data={data} batchActions={actions} />
-    </Fragment>
-  )
+  const options = {
+    innerTitle: 'Logging',
+    addText: 'New Logging',
+    uniqueIdentifier: 'cluster',
+    loaderFn: qbert.getLoggings,
+    onEdit: () => {},
+    onDelete: () => {},
+    addUrl,
+    editUrl,
+    columns,
+    batchActions,
+  }
+  const { ListPage } = createCRUDComponents(options)
+
+  return <ListPage />
 }
 
 const renderStatus = (classes, value) => {
@@ -242,35 +120,18 @@ const getColumns = (classes) => [
   { id: 'logDestination', label: 'Log Destination', render: renderList },
 ]
 
-const ActionIcon = ({ classes, icon, label }) =>
-  <Box className={classes.actionIconWrapper}>
-    <FontAwesomeIcon className={classes.actionIcon}>{icon}</FontAwesomeIcon>
-    {label}
-  </Box>
-
 const getActions = (classes, history) => [
   {
-    icon: <ActionIcon classes={classes} icon='check' label='Enable' />,
+    icon: 'check',
     label: 'Enable',
     action: () => {},
     cond: (clusters) => clusters.every(cluster => cluster.status === status.DISABLED)
   },
   {
-    icon: <ActionIcon classes={classes} icon='times' label='Disable' />,
+    icon: 'times',
     label: 'Disable',
     action: () => {},
     cond: (clusters) => clusters.every(cluster => cluster.status === status.ENABLED)
-  },
-  {
-    icon: <ActionIcon classes={classes} icon='edit' label='Edit' />,
-    label: 'Edit',
-    action: (clusters) => history.push(`${editUrl}/${clusters[0].cluster}`),
-    cond: (clusters) => clusters.length === 1
-  },
-  {
-    icon: <ActionIcon classes={classes} icon='trash-alt' label='Delete' />,
-    label: 'Delete',
-    action: () => {},
   },
 ]
 

--- a/src/app/plugins/kubernetes/components/logging/LoggingStub.js
+++ b/src/app/plugins/kubernetes/components/logging/LoggingStub.js
@@ -1,0 +1,130 @@
+/* Stub data while not fetching from real API */
+
+const status = {
+  ENABLED: 'enabled',
+  DISABLED: 'disabled',
+  CONFIGURING: 'configuring',
+  FAILED: 'failed',
+}
+
+const storageType = {
+  S3: 'AWS-S3',
+  ELASTIC_SEARCH: 'ElasticSearch',
+}
+
+const getLoggings = () => [
+  {
+    cluster: 'cluster-id-01',
+    status: status.ENABLED,
+    logStorage: [
+      storageType.S3,
+      storageType.ELASTIC_SEARCH
+    ],
+    logDestination: [
+      'bucket123/regionnameABC',
+      'http://mybucket.s3.johnsmith',
+    ],
+  },
+  {
+    cluster: 'cluster-id-02',
+    status: status.DISABLED,
+    logStorage: [
+      storageType.S3,
+    ],
+    logDestination: [
+      'bucket123/regionnameABC',
+    ],
+  },
+  {
+    cluster: 'cluster-id-03',
+    status: status.ENABLED,
+    logStorage: [
+      storageType.ELASTIC_SEARCH
+    ],
+    logDestination: [
+      'http://mybucket.s3.johnsmith',
+    ],
+  },
+  {
+    cluster: 'cluster-id-04',
+    status: status.ENABLED,
+    logStorage: [
+      storageType.S3,
+      storageType.ELASTIC_SEARCH
+    ],
+    logDestination: [
+      'bucket123/regionnameABC',
+      'http://mybucket.s3.johnsmith',
+    ],
+  },
+  {
+    cluster: 'cluster-id-05',
+    status: status.CONFIGURING,
+    logStorage: [
+      storageType.ELASTIC_SEARCH
+    ],
+    logDestination: [
+      'http://mybucket.s3.johnsmith',
+    ],
+  },
+  {
+    cluster: 'cluster-id-06',
+    status: status.FAILED,
+    logStorage: [
+      storageType.S3,
+      storageType.ELASTIC_SEARCH
+    ],
+    logDestination: [
+      'bucket123/regionnameABC',
+      'http://mybucket.s3.johnsmith',
+    ],
+  },
+  {
+    cluster: 'cluster-id-07',
+    status: status.DISABLED,
+    logStorage: [
+      storageType.S3,
+    ],
+    logDestination: [
+      'bucket123/regionnameABC',
+    ],
+  },
+  {
+    cluster: 'cluster-id-08',
+    status: status.ENABLED,
+    logStorage: [
+      storageType.ELASTIC_SEARCH
+    ],
+    logDestination: [
+      'http://mybucket.s3.johnsmith',
+    ],
+  },
+  {
+    cluster: 'cluster-id-09',
+    status: status.ENABLED,
+    logStorage: [
+      storageType.S3,
+      storageType.ELASTIC_SEARCH
+    ],
+    logDestination: [
+      'bucket123/regionnameABC',
+      'http://mybucket.s3.johnsmith',
+    ],
+  },
+  {
+    cluster: 'cluster-id-10',
+    status: status.ENABLED,
+    logStorage: [
+      storageType.ELASTIC_SEARCH
+    ],
+    logDestination: [
+      'http://mybucket.s3.johnsmith',
+    ],
+  },
+]
+
+const LoggingStub = {
+  getLoggings,
+}
+
+export default LoggingStub


### PR DESCRIPTION
The main point in this PR is to refactor `Logging` to use helper methods and be prepared for the next step, that would be fetching and caching real data. More specifically, this PR:
- Creates `LoggingStub` to be used by `Qbert` while fetching real data is not implemented
- Refactor `LoggingListPage` to use helper method `createCRUDComponents`
- Refactor `LoggingAddPage` to use helper method `createAddComponents`
- Refactor `LoggingEditPage` to use helper method `createUpdateComponents`
- Creates `LoggingForm` to be used by `LoggingAddPage` and `LoggingEditPage`
- Refactor `createCRUDComponents` to support `batchActions`
- Refactor `ListTableBatchActions` to standardize custom batchActions buttons