### PR TITLE
Fix fetch loggings for invalid clusters

### DIFF
--- a/src/api-client/Qbert.js
+++ b/src/api-client/Qbert.js
@@ -512,9 +512,13 @@ class Qbert {
   getLoggingsBaseUrl = async (clusterUuid) => `${await this.baseUrl()}/clusters/${clusterUuid}/k8sapi/apis/logging.pf9.io/v1alpha1/outputs`
 
   getLoggings = async (clusterUuid) => {
-    const url = await this.getLoggingsBaseUrl(clusterUuid)
-    const response = await this.client.basicGet(url)
-    return response
+    try {
+      const url = await this.getLoggingsBaseUrl(clusterUuid)
+      const response = await this.client.basicGet(url)
+      return response
+    } catch (e) {
+      console.log(`Could not fetch loggings for cluster ${clusterUuid}`)
+    }
   }
 
   createLogging = async (clusterUuid, logging) => {

--- a/src/app/plugins/kubernetes/components/logging/actions.js
+++ b/src/app/plugins/kubernetes/components/logging/actions.js
@@ -33,13 +33,18 @@ const mapLoggings = (cluster, loggings) => {
 const loggingActions = createCRUDActions(loggingsCacheKey, {
   listFn: async (params, loadFromContext) => {
     const clusters = await loadFromContext(clustersCacheKey)
+    const loggings = []
 
-    const loggingsPromises = clusters.map(async cluster => {
-      const response = await qbert.getLoggings(cluster.uuid)
-      return mapLoggings(cluster, response[0])
-    })
-
-    const loggings = await Promise.all(loggingsPromises)
+    for (const cluster of clusters) {
+      try {
+        const response = await qbert.getLoggings(cluster.uuid)
+        const loggingsForCluster = mapLoggings(cluster, response)
+        loggings.push(loggingsForCluster)
+      } catch (e) {
+        console.log(`Could not fetch loggings for cluster ${cluster.uuid}`)
+        console.log(e)
+      }
+    }
 
     return loggings
   },

--- a/src/server/models/qbert/Logging.js
+++ b/src/server/models/qbert/Logging.js
@@ -3,6 +3,7 @@ import createModel from '../createModel'
 const options = {
   dataKey: 'loggings',
   uniqueIdentifier: 'cluster',
+  loaderFn: (list) => list[0],
 }
 
 const Logging = createModel(options)


### PR DESCRIPTION
This PR fixes the issue of trying to fetch loggings from an invalid cluster. It also adjusts the stubbed `getLoggings(clusterId)` to return an object instead of a list. 