### PR TITLE
Fix metrics port label

### DIFF
--- a/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
+++ b/src/app/plugins/kubernetes/components/prometheus/AddPrometheusInstancePage.js
@@ -96,7 +96,7 @@ const AddPrometheusInstanceForm = ({ onComplete }) => {
                 {enableStorage &&
                 <CheckboxField id="enablePersistentStorage" label="Enable persistent storage" />}
                 <TextField id="retention" label="Storage Retention (days)" info="Defaults to 15 days if nothing is set" />
-                <TextField id="port" label="Service Monitor Port" info="Port for the service monitor" />
+                <TextField id="port" label="Metrics Exporter Port" info="Name of Prometheus Exporter Port for fetching application merices" />
                 <KeyValuesField id="appLabels" label="App Labels" info="Key/value pairs for app that Prometheus will monitor" />
               </ValidatedForm>
             </WizardStep>


### PR DESCRIPTION
The field name for specifying prometheus port and help message needs correction. The UI form hides ServiceMonitor object completely from the user. The user just
* specifies config for prometheus pod
* application labels and port from where metrics can be fetched

This change updates the field labels to reflect this design 