### PR TITLE
Return strings instead of booleans

### DIFF
--- a/src/app/plugins/kubernetes/components/storage/StorageClassesAddPage.js
+++ b/src/app/plugins/kubernetes/components/storage/StorageClassesAddPage.js
@@ -108,10 +108,10 @@ const getInitialStorageClassYaml = (wizardContext) => {
     metadata: {
       name: wizardContext.name,
       annotations: {
-        'storageclass.kubernetes.io/is-default-class': wizardContext.isDefault,
+        'storageclass.kubernetes.io/is-default-class': wizardContext.isDefault.toString(),
       },
       labels: {
-        'kubernetes.io/cluster-service': true,
+        'kubernetes.io/cluster-service': true.toString(),
       },
     },
     provisioner: 'kubernetes.io/aws-ebs',


### PR DESCRIPTION
The backend expects strings for `true` and `false` instead of booleans in the Storage Class YAML. This PR fixes the front-end to meet this requirement.