### PR TITLE
Bugfix/fetching all clusters

### DIFF
--- a/src/api-client/Keystone.js
+++ b/src/api-client/Keystone.js
@@ -64,6 +64,7 @@ class Keystone {
   get tenantsUrl () { return `${this.adminV3}/PF9-KSADM/all_tenants_all_users` }
   get tokensUrl () { return `${this.v3}/auth/tokens?nocatalog` }
   get usersUrl () { return `${this.v3}/users` }
+  get credentialsUrl () { return `${this.v3}/credentials` }
   get groupsUrl () { return `${this.v3}/groups` }
   get groupMappingsUrl () { return `${this.v3}/OS-FEDERATION/mappings` }
   get rolesUrl () { return `${this.v3}/roles` }
@@ -230,6 +231,11 @@ class Keystone {
       this.client.activeRegion = this.client.serviceCatalog[0].endpoints[0].region
     }
     return servicesByRegion[this.client.activeRegion]
+  }
+
+  getCredentials = async () => {
+    const response = await axios.get(this.credentialsUrl, this.client.getAuthHeaders())
+    return response.data.credentials
   }
 
   getUser = async (id) => {

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -8,6 +8,7 @@ export const dashboardUrl = `${appUrlRoot}/kubernetes/`
 export const allKey = '__all__'
 export const noneKey = '__none__'
 export const listTablePrefs = ['visibleColumns', 'columnsOrder', 'rowsPerPage', 'orderBy', 'orderDirection']
+export const uuidRegex = new RegExp(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/, 'i')
 
 export const k8sPrefix = `${appUrlRoot}/kubernetes`
 
@@ -24,7 +25,7 @@ export const clarityDashboardUrl = `${clarityUrlRoot}/dashboard`
 export const imageUrls = Object.freeze({
   logo: `${imageUrlRoot}/logo.png`,
   loading: `${imageUrlRoot}/loading.gif`,
-  kubernetes: `${imageUrlRoot}/logo-kubernetes-h.png`
+  kubernetes: `${imageUrlRoot}/logo-kubernetes-h.png`,
 })
 
 // k8s
@@ -37,5 +38,5 @@ export const codeMirrorOptions = Object.freeze({
  * @type {object}
  */
 export const defaultAxiosConfig = Object.freeze({
-  timeout: 120000
+  timeout: 120000,
 })

--- a/src/app/core/components/ExternalLink.js
+++ b/src/app/core/components/ExternalLink.js
@@ -4,7 +4,7 @@ import SimpleLink from 'core/components/SimpleLink'
 
 const ExternalLink = ({ url, children, newWindow }) => {
   const moreProps = newWindow ? { target: '_blank', rel: 'noopener' } : {}
-  return (<SimpleLink src={url} {...moreProps}>{children}</SimpleLink>)
+  return (<SimpleLink src={url} {...moreProps}>{children || url}</SimpleLink>)
 }
 
 ExternalLink.propTypes = {
@@ -15,7 +15,7 @@ ExternalLink.propTypes = {
   newWindow: PropTypes.bool,
 
   // The link contents.  Usually just simple text but can be any node.
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 }
 
 ExternalLink.defaultProps = {

--- a/src/app/core/components/InfoTooltip.js
+++ b/src/app/core/components/InfoTooltip.js
@@ -9,14 +9,13 @@ const styles = theme => ({
   infoTooltip: {
     background: theme.palette.common.white,
     color: theme.palette.text.primary,
-    borderRadius: 0,
     border: 0,
     maxWidth: 300,
     fontSize: 14,
     display: 'flex',
     flexFlow: 'row nowrap',
-    paddingTop: 0,
-    marginTop: 0,
+    borderRadius: 3,
+    marginTop: -7,
   },
   infoIcon: {
     fontSize: theme.spacing(2.4),

--- a/src/app/core/components/pageContainer/PageContainer.js
+++ b/src/app/core/components/pageContainer/PageContainer.js
@@ -39,6 +39,7 @@ const useStyles = makeStyles(theme => ({
   },
   content: {
     zIndex: 0,
+    minHeight: 400,
   },
 }))
 

--- a/src/app/core/components/validatedForm/ValidatedForm.js
+++ b/src/app/core/components/validatedForm/ValidatedForm.js
@@ -17,7 +17,7 @@ const styles = theme => ({
   root: {
     display: 'flex',
     flexFlow: 'column wrap',
-    width: '100%',
+    width: '50%',
     maxWidth: 400,
     minWidth: 300,
     '& .MuiFormControl-root': {

--- a/src/app/core/helpers/createCRUDComponents.js
+++ b/src/app/core/helpers/createCRUDComponents.js
@@ -51,6 +51,7 @@ const createCRUDComponents = options => {
     editDisabledInfo,
     debug,
     name,
+    searchTarget = 'name',
     multiSelection = true,
   } = options
 
@@ -86,7 +87,7 @@ const createCRUDComponents = options => {
         onEdit={onEdit}
         batchActions={batchActions}
         rowActions={rowActions}
-        searchTarget="name"
+        searchTarget={searchTarget}
         uniqueIdentifier={uniqueIdentifier}
         visibleColumns={visibleColumns}
         columnsOrder={columnsOrder}

--- a/src/app/plugins/kubernetes/components/apps/AppCard.js
+++ b/src/app/plugins/kubernetes/components/apps/AppCard.js
@@ -14,7 +14,6 @@ const useStyles = makeStyles(theme => ({
     display: 'inline-block',
     marginTop: theme.spacing(1),
     marginRight: theme.spacing(0.5),
-    maxWidth: 100,
     textOverflow: 'clip',
     whiteSpace: 'pre-wrap',
     overflow: 'hidden',
@@ -41,7 +40,6 @@ const useStyles = makeStyles(theme => ({
     flexBasis: 'auto',
     flexShrink: 1,
     flexGrow: 1,
-    overflow: 'hidden',
   },
   icon: {
     width: '100%',
@@ -57,37 +55,18 @@ const useStyles = makeStyles(theme => ({
     marginTop: theme.spacing(1),
     marginBottom: theme.spacing(1),
   },
-  info: {
-    overflow: 'hidden',
-    position: 'relative',
-    /* use this value to count block height */
-    lineHeight: '1.5em',
-    /* max-height = line-height (1.2) * lines max number (3) */
-    maxHeight: '4.5em',
-    textAligh: 'justify',
-    marginRight: '-1em',
-    paddingRight: '1em',
-    '&:before': {
-      content: '\'...\'',
-      position: 'absolute',
-      right: theme.spacing(1),
-      bottom: 0,
-    },
-    '&:after': {
-      content: '\'\'',
-      position: 'absolute',
-      right: 0,
-      width: '2em',
-      height: '1em',
-      marginTop: '0.2em',
-      background: 'white',
-    },
-  },
   content: {
     flex: '1 0 auto',
-    height: 140,
+    minHeight: 156,
+    maxHeight: 156,
+    transition: 'max-height 0.3s cubic-bezier(0, 1, 0, 1)',
+    '&:hover': {
+      maxHeight: 312,
+      transition: 'max-height 0.6s ease-in-out',
+    },
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+    padding: theme.spacing(1, 2, 0),
   },
   actions: {
     display: 'flex',

--- a/src/app/plugins/kubernetes/components/apps/AppDetailsPage.js
+++ b/src/app/plugins/kubernetes/components/apps/AppDetailsPage.js
@@ -12,6 +12,7 @@ import { emptyObj, emptyArr } from 'utils/fp'
 import SimpleLink from 'core/components/SimpleLink'
 import AppDeployDialog from 'k8s/components/apps/AppDeployDialog'
 import PageContainer from 'core/components/pageContainer/PageContainer'
+import ExternalLink from 'core/components/ExternalLink'
 
 const useStyles = makeStyles(theme => ({
   backLink: {
@@ -64,7 +65,7 @@ const AppDetailsPage = () => {
       onClose={() => setShowingDeployDialog(false)} />}
     <Progress loading={loadingApp} overlay renderContentOnMount>
       <Grid container justify="center" spacing={3}>
-        <Grid item xs={3}>
+        <Grid item xs={3} lg={2}>
           {app.logoUrl && <Card className={classes.card}>
             <CardMedia className={classes.icon} image={app.logoUrl} title={app.name} />
             <Button
@@ -89,7 +90,7 @@ const AppDetailsPage = () => {
               Home
             </Typography>
             <Typography variant="body2" component="div">
-              {app.home && <SimpleLink target="_blank" src={app.home} />}
+              {app.home && <ExternalLink url={app.home} />}
             </Typography>
             <br />
             <Typography
@@ -99,7 +100,7 @@ const AppDetailsPage = () => {
             <Typography variant="body2" component="div">
               {(app.sources || emptyArr).map(source =>
                 <div key={source}>
-                  <SimpleLink target="_blank" src={source} />
+                  <ExternalLink url={source} />
                 </div>)}
             </Typography>
             <br />
@@ -110,12 +111,12 @@ const AppDetailsPage = () => {
             <Typography variant="body2" component="div">
               {(app.maintainers || emptyArr).map(maintainer =>
                 <div key={maintainer.email}>
-                  <SimpleLink target="_blank" src={`mailto: ${maintainer.email}`}>{maintainer.name}</SimpleLink>
+                  <ExternalLink url={`mailto: ${maintainer.email}`}>{maintainer.name}</ExternalLink>
                 </div>)}
             </Typography>
           </Paper>
         </Grid>
-        <Grid item xs={9} zeroMinWidth>
+        <Grid item xs={9} lg={10} zeroMinWidth>
           <AppVersionPicklist
             label="Application Version"
             appId={params.appId}

--- a/src/app/plugins/kubernetes/components/apps/DeployedAppDetailsPage.js
+++ b/src/app/plugins/kubernetes/components/apps/DeployedAppDetailsPage.js
@@ -42,7 +42,7 @@ const useStyles = makeStyles(theme => ({
     fontFamily: 'monospace, serif',
     border: '1px solid #ccc',
     padding: 11,
-    whiteSpace: 'pre-wrap',
+    overflowX: 'scroll',
     color: '#212121',
   },
 }))
@@ -80,7 +80,7 @@ const DeployedAppDetailsPage = () => {
     />
     <Progress loading={loading || removing} overlay renderContentOnMount>
       <Grid container justify="center" spacing={3}>
-        <Grid item xs={3}>
+        <Grid item xs={3} lg={2}>
           {release.logoUrl && <Card className={classes.card}>
             <CardMedia className={classes.icon} image={release.logoUrl} title={release.name} />
             <Button
@@ -125,7 +125,7 @@ const DeployedAppDetailsPage = () => {
             </Typography>
           </Paper>
         </Grid>
-        <Grid item xs={9} zeroMinWidth>
+        <Grid item xs={9} lg={10} zeroMinWidth>
           <Typography variant="h4" component="h4">
             {release.name}
           </Typography>

--- a/src/app/plugins/kubernetes/components/common/NamespacePicklist.js
+++ b/src/app/plugins/kubernetes/components/common/NamespacePicklist.js
@@ -3,7 +3,7 @@ import Picklist from 'core/components/Picklist'
 import { projectAs } from 'utils/fp'
 import useDataLoader from 'core/hooks/useDataLoader'
 import PropTypes from 'prop-types'
-import { isEmpty, propOr, head } from 'ramda'
+import { isEmpty, propOr, head, uniqBy, prop } from 'ramda'
 import { allKey } from 'app/constants'
 import namespaceActions from 'k8s/components/namespaces/actions'
 
@@ -12,9 +12,8 @@ const NamespacePicklist = forwardRef(
   ({ clusterId, loading, onChange, selectFirst, ...rest }, ref) => {
     const [namespaces, namespacesLoading] = useDataLoader(namespaceActions.list, { clusterId })
     const options = useMemo(() => projectAs(
-      { label: 'name', value: 'name' }, namespaces,
+      { label: 'name', value: 'name' }, uniqBy(prop('name'), namespaces),
     ), [namespaces])
-
     // Select the first item as soon as data is loaded
     useEffect(() => {
       if (!isEmpty(options) && selectFirst) {

--- a/src/app/plugins/kubernetes/components/dashboard/DashboardPage.js
+++ b/src/app/plugins/kubernetes/components/dashboard/DashboardPage.js
@@ -1,26 +1,28 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { compose } from 'app/utils/fp'
 import { makeStyles, createStyles } from '@material-ui/styles'
 import { Typography } from '@material-ui/core'
 import requiresAuthentication from 'openstack/util/requiresAuthentication'
+import { AppContext } from 'core/AppProvider'
 
 const useStyles = makeStyles(theme => createStyles({
   welcome: {
     fontSize: '24px',
-    marginBottom: '20px'
-  }
+    marginBottom: '20px',
+  },
 }))
 
 const Dashboard = () => {
   const classes = useStyles()
+  const { session: { username } } = useContext(AppContext)
 
   return (
     <div>
-      <Typography className={classes.welcome}>Welcome (username)</Typography>
+      <Typography className={classes.welcome}>Welcome {username}</Typography>
     </div>
   )
 }
 
 export default compose(
-  requiresAuthentication
+  requiresAuthentication,
 )(Dashboard)

--- a/src/app/plugins/kubernetes/components/namespaces/actions.js
+++ b/src/app/plugins/kubernetes/components/namespaces/actions.js
@@ -1,10 +1,10 @@
-import { pluck } from 'ramda'
+import { pluck, flatten } from 'ramda'
 import { allKey } from 'app/constants'
 import ApiClient from 'api-client/ApiClient'
 import { clustersCacheKey } from 'k8s/components/infrastructure/common/actions'
 import createCRUDActions from 'core/helpers/createCRUDActions'
-import { flatMapAsync } from 'utils/async'
 import { parseClusterParams } from 'k8s/components/infrastructure/clusters/actions'
+import { someAsync } from 'utils/async'
 
 const { qbert } = ApiClient.getInstance()
 
@@ -26,7 +26,7 @@ const namespaceActions = createCRUDActions(namespacesCacheKey, {
   listFn: async (params, loadFromContext) => {
     const [ clusterId, clusters ] = await parseClusterParams(params, loadFromContext)
     if (clusterId === allKey) {
-      return flatMapAsync(qbert.getClusterNamespaces, pluck('uuid', clusters))
+      return someAsync(pluck('uuid', clusters).map(qbert.getClusterNamespaces)).then(flatten)
     }
     return qbert.getClusterNamespaces(clusterId)
   },

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -1,10 +1,10 @@
 import { pathStrOrNull, objSwitchCase } from 'utils/fp'
-import { map, pathEq, find, pluck, curry, pipe, last, pathOr, prop, propEq } from 'ramda'
+import { map, pathEq, find, pluck, curry, pipe, last, pathOr, prop, propEq, flatten } from 'ramda'
 import ApiClient from 'api-client/ApiClient'
 import { clustersCacheKey } from '../infrastructure/common/actions'
 import { notFoundErr } from 'app/constants'
 import createCRUDActions from 'core/helpers/createCRUDActions'
-import { flatMapAsync } from 'utils/async'
+import { someAsync } from 'utils/async'
 
 const { appbert, qbert } = ApiClient.getInstance()
 const uniqueIdentifier = 'metadata.uid'
@@ -49,7 +49,7 @@ export const prometheusInstanceActions = createCRUDActions(prometheusInstancesCa
   listFn: async (params, loadFromContext) => {
     const clusterTags = await loadFromContext(clusterTagsCacheKey)
     const clusterUuids = pluck('uuid', clusterTags.filter(hasMonitoring))
-    return flatMapAsync(qbert.getPrometheusInstances, clusterUuids)
+    return someAsync(clusterUuids.map(qbert.getPrometheusInstances)).then(flatten)
   },
   createFn: async data => {
     return qbert.createPrometheusInstance(data.cluster, data)
@@ -101,7 +101,7 @@ export const prometheusRuleActions = createCRUDActions(prometheusRulesCacheKey, 
   listFn: async (params, loadFromContext) => {
     const clusterTags = await loadFromContext(clusterTagsCacheKey)
     const clusterUuids = pluck('uuid', clusterTags.filter(hasMonitoring))
-    return flatMapAsync(qbert.getPrometheusRules, clusterUuids)
+    return someAsync(clusterUuids.map(qbert.getPrometheusRules)).then(flatten)
   },
   updateFn: async data => {
     return qbert.updatePrometheusRules(data)
@@ -139,7 +139,7 @@ export const prometheusServiceMonitorActions = createCRUDActions(prometheusServi
   listFn: async (params, loadFromContext) => {
     const clusterTags = await loadFromContext(clusterTagsCacheKey)
     const clusterUuids = pluck('uuid', clusterTags.filter(hasMonitoring))
-    return flatMapAsync(qbert.getPrometheusServiceMonitors, clusterUuids)
+    return someAsync(clusterUuids.map(qbert.getPrometheusServiceMonitors)).then(flatten)
   },
   updateFn: async data => {
     return qbert.updatePrometheusServiceMonitor(data)
@@ -178,7 +178,7 @@ export const prometheusAlertManagerActions = createCRUDActions(prometheusAlertMa
   listFn: async (params, loadFromContext) => {
     const clusterTags = await loadFromContext(clusterTagsCacheKey)
     const clusterUuids = pluck('uuid', clusterTags.filter(hasMonitoring))
-    return flatMapAsync(qbert.getPrometheusAlertManagers, clusterUuids)
+    return someAsync(clusterUuids.map(qbert.getPrometheusAlertManagers)).then(flatten)
   },
   updateFn: async data => {
     return qbert.updatePrometheusAlertManager(data)

--- a/src/app/plugins/kubernetes/components/storage/actions.js
+++ b/src/app/plugins/kubernetes/components/storage/actions.js
@@ -1,9 +1,9 @@
 import ApiClient from 'api-client/ApiClient'
-import { propEq, pluck, pipe, find, prop, map } from 'ramda'
+import { propEq, pluck, pipe, find, prop, map, flatten } from 'ramda'
 import yaml from 'js-yaml'
 import { clustersCacheKey } from 'k8s/components/infrastructure/common/actions'
 import createCRUDActions from 'core/helpers/createCRUDActions'
-import { flatMapAsync } from 'utils/async'
+import { someAsync } from 'utils/async'
 import { parseClusterParams } from 'k8s/components/infrastructure/clusters/actions'
 import { allKey, notFoundErr } from 'app/constants'
 import { pathStr } from 'utils/fp'
@@ -16,7 +16,7 @@ const storageClassActions = createCRUDActions(storageClassesCacheKey, {
   listFn: async (params, loadFromContext) => {
     const [clusterId, clusters] = await parseClusterParams(params, loadFromContext)
     if (clusterId === allKey) {
-      return flatMapAsync(qbert.getClusterStorageClasses, pluck('uuid', clusters))
+      return someAsync(pluck('uuid', clusters).map(qbert.getClusterStorageClasses)).then(flatten)
     }
     return qbert.getClusterStorageClasses(clusterId)
   },

--- a/src/app/plugins/kubernetes/components/userManagement/UsersListPage.js
+++ b/src/app/plugins/kubernetes/components/userManagement/UsersListPage.js
@@ -6,7 +6,7 @@ export const options = {
     { id: 'id', label: 'OpenStack ID', display: false },
     { id: 'username', label: 'Username' },
     { id: 'displayname', label: 'Display Name' },
-    { id: 'two_factor', label: 'Two-Factor Authentication' },
+    { id: 'twoFactor', label: 'Two-Factor Authentication' },
     { id: 'tenants', label: 'Tenants' },
   ],
   cacheKey: mngmUsersCacheKey,
@@ -14,6 +14,7 @@ export const options = {
   name: 'Users',
   title: 'Users',
   uniqueIdentifier: 'id',
+  searchTarget: 'username',
 }
 
 const { ListPage: UsersListPage } = createCRUDComponents(options)

--- a/src/app/utils/async.js
+++ b/src/app/utils/async.js
@@ -1,4 +1,4 @@
-import { curry, flatten, mapObjIndexed, fromPairs } from 'ramda'
+import { curry, flatten, mapObjIndexed, fromPairs, head } from 'ramda'
 import { ensureArray } from 'utils/fp'
 
 export const pluckAsync = curry((key, promise) => promise.then(obj => obj[key]))
@@ -49,4 +49,25 @@ export const propsAsync = async objPromises => {
   const results = await Promise.all(promises)
 
   return fromPairs(results)
+}
+
+/**
+ * Like Promise.all but it won't reject if any (or all) of the promises are rejected
+ * and it will always fullfill by returning an array with the successful results
+ * An error handler function can be provided to deal with promise rejections individually
+ * @param promises
+ * @param [errorHandler] Function that can be used to handle the rejected promises
+ * @returns {Promise<[*,...]>}
+ */
+export const someAsync = async (promises, errorHandler = err => console.warn(err)) => {
+  const results = await Promise.all(promises.map(async promise => {
+    try {
+      return [await promise]
+    } catch (err) {
+      errorHandler(err)
+      return null
+    }
+  }))
+  // Just return the successful results
+  return results.filter(Array.isArray).map(head)
 }


### PR DESCRIPTION
This fixes an issue when trying to fetch resources by "All" clusters, as if one of the clusters was returning error, the `Promise.all` failed so we were not displaying the items for the other clusters.

To do so, I added a function called `someAsync` to allow resolving an array of promises in parallel ignoring individual promise rejections.

Also solved some other minor warnings and issues