### PR TITLE
decco container for next gen UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ coverage/*
 .vscode
 cypress/screenshots/*
 cypress/videos/*
+
+build-container/
+node-v*-linux-x64.tar.gz
+node/
+

--- a/decco-container/Dockerfile
+++ b/decco-container/Dockerfile
@@ -1,0 +1,35 @@
+FROM nginx
+MAINTAINER leb@platform9.com
+
+RUN apt -y update
+RUN apt -y install openssl ca-certificates
+
+# Copy all the RPM files into the container
+RUN mkdir -p /usr/share/nginx/html
+COPY publicfiles /usr/share/nginx/html/
+
+# configure nginx and confd
+COPY conf/nginx /etc/nginx/
+COPY conf/confd /etc/confd/
+
+WORKDIR /root
+COPY init-region .
+COPY start.sh .
+RUN chmod 755 init-region
+COPY consul /bin
+COPY confd /bin
+
+CMD /root/start.sh
+
+EXPOSE 8080
+
+LABEL com.platform9.image-type=du
+ARG VERSION
+LABEL com.platform9.pf9_version=${VERSION}
+ARG BUILD_ID
+LABEL com.platform9.build=${BUILD_ID}
+LABEL com.platform9.version="${VERSION}-${BUILD_ID}"
+ARG BRANCH
+LABEL com.platform9.branch=${BRANCH}
+ARG APP_METADATA
+LABEL com.platform9.app_metadata=${APP_METADATA}

--- a/decco-container/Makefile
+++ b/decco-container/Makefile
@@ -1,0 +1,76 @@
+# Copyright (C) 2019 Platform 9 Systems, Inc.
+
+.SUFFIXES:
+.PHONY: clean push image stage
+
+SRCROOT = $(abspath $(dir $(CURDIR)/../$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))))
+CONTAINER_ROOT=$(SRCROOT)/decco-container
+BUILD_DIR = $(SRCROOT)/build
+CONTAINER_BUILD_DIR = $(SRCROOT)/build-container
+STAGE = $(CONTAINER_BUILD_DIR)/stage
+CONTAINER_TAG = $(CONTAINER_BUILD_DIR)/container-tag
+EXTRACTED_RPM_DIR = $(CONTAINER_BUILD_DIR)/rpm
+PUBLIC_FILES =  $(STAGE)/publicfiles
+METADATA_FILE =  $(STAGE)/app_metadata.json
+UI_DIR =  $(PUBLIC_FILES)/ui
+PF9_VERSION ?= 1.0.0
+BUILD_NUMBER ?= 0
+BUILD_ID := $(BUILD_NUMBER)
+IMAGE_REPO ?= 514845858982.dkr.ecr.us-west-1.amazonaws.com/pf9-serenity
+IMAGE_TAG ?= $(or $(PF9_VERSION), $(PF9_VERSION), "latest")-$(BUILD_ID)
+BRANCH_NAME ?= $(or $(TEAMCITY_BUILD_BRANCH), $(TEAMCITY_BUILD_BRANCH), $(shell git symbolic-ref --short HEAD))
+RPM ?= $(shell find $(BUILD_DIR)/rpmbuild -name 'pf9-ui-plugin-*.rpm')
+CONSUL_URL ?= https://releases.hashicorp.com/consul/1.0.6/consul_1.0.6_linux_amd64.zip
+CONFD_URL ?= https://github.com/kelseyhightower/confd/releases/download/v0.15.0/confd-0.15.0-linux-amd64
+
+$(shell mkdir -p $(STAGE))
+$(shell mkdir -p $(PUBLIC_FILES))
+
+$(EXTRACTED_RPM_DIR): $(RPM)
+	mkdir -p $@
+	cd $@ && rpm2cpio $(RPM) | cpio -idmv
+
+# Enable this rule (and comment out the one below) to use
+# single optimized & minified JS file
+$(UI_DIR): $(EXTRACTED_RPM_DIR)
+	mv $(EXTRACTED_RPM_DIR)/opt/pf9/www/public/ui $(PUBLIC_FILES)
+
+# Enable this rule (and comment out the one above) to use
+# unoptimized development build (separate JS files)
+#$(UI_DIR): $(BUILD_DIR)
+#	mkdir -p $@
+#	cp -a $(BUILD_DIR)/* $@/
+
+$(METADATA_FILE): $(UI_DIR)
+	echo "Downloading consul"
+	cd $(STAGE) && wget -q $(CONSUL_URL) && unzip consul_*.zip
+	cd $(STAGE) && wget -q -O confd $(CONFD_URL) && chmod +x confd
+	cp -f $(CONTAINER_ROOT)/Dockerfile $(STAGE)
+	cp -r $(CONTAINER_ROOT)/conf $(STAGE)
+	cp -f $(CONTAINER_ROOT)/{init-region,start.sh} $(STAGE)
+	python $(CONTAINER_ROOT)/y2j.py $(CONTAINER_ROOT)/app_metadata.yaml > $@
+
+stage: $(METADATA_FILE)
+
+$(CONTAINER_TAG):
+	echo -ne "$(IMAGE_TAG)" >$@
+
+image: stage $(CONTAINER_TAG)
+	echo "Building Image"
+	docker build --rm -t $(IMAGE_REPO):$(IMAGE_TAG) \
+		--build-arg BUILD_ID=$(BUILD_ID) \
+		--build-arg VERSION=$(PF9_VERSION) \
+		--build-arg BRANCH=$(BRANCH_NAME) \
+		--build-arg APP_METADATA=`cat $(METADATA_FILE)` \
+		$(STAGE)
+	echo -ne "$(IMAGE_TAG)" >$(CONTAINER_BUILD_DIR)/container-tag
+
+# This assumes that credentials for the aws tool are configured, either in
+# ~/.aws/config or in AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+push: image
+	docker push $(IMAGE_REPO):$(IMAGE_TAG) || \
+	(aws ecr get-login --region=us-west-1 --no-include-email |sh && \
+	 docker push $(IMAGE_REPO):$(IMAGE_TAG))
+
+clean:
+	rm -rf $(CONTAINER_BUILD_DIR)

--- a/decco-container/app_metadata.yaml
+++ b/decco-container/app_metadata.yaml
@@ -1,0 +1,10 @@
+---
+- name: serenity
+  endpoints:
+  - name: ui
+    port: 8080
+    httpPath: "/ui"
+  egresses: []
+  logfiles:
+  - path: "/var/log/nginx/access.log"
+  - path: "/var/log/nginx/error.log"

--- a/decco-container/conf/confd/conf.d/cors-conf.toml
+++ b/decco-container/conf/confd/conf.d/cors-conf.toml
@@ -1,0 +1,8 @@
+[template]
+src = 'cors.conf'
+dest = '/etc/nginx/conf.d/pf9/cors.conf'
+owner = 'root'
+mode = '0644'
+keys = [
+    '/fqdn'
+]

--- a/decco-container/conf/confd/templates/cors.conf
+++ b/decco-container/conf/confd/templates/cors.conf
@@ -1,0 +1,24 @@
+# CORS config for nginx. Add this configuration to a location spec on a
+#    'slave' DU in nginx to provide an OPTIONS response that allows X-Auth-Tokens
+#    from a 'master' origin
+# NOTE - this works, but it's a little dicey - see
+#     https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
+
+set $master_origin '{{getv "/fqdn"}}';
+
+# This is needed in the response for all requests
+add_header 'Access-Control-Allow-Origin' $master_origin always;
+add_header 'Access-Control-Allow-Credentials' 'true' always;
+
+# Provide a response to http OPTIONS requests that allows requests from our UI
+# origin.
+if ($request_method = 'OPTIONS') {
+    add_header 'Access-Control-Allow-Origin' $master_origin;
+    add_header 'Access-Control-Allow-Credentials' 'true';
+    add_header 'Access-Control-Allow-Methods' 'HEAD, GET, POST, OPTIONS, PUT, DELETE, PATCH';
+    add_header 'Access-Control-Allow-Headers' 'X-Auth-Token, X-Configuration-Session, Content-Type, Authorization';
+    add_header 'Access-Control-Max-Age' 600;
+    add_header 'Content-Type' 'text/plain charset=UTF-8';
+    add_header 'Content-Length' 0;
+    return 204;
+}

--- a/decco-container/conf/nginx/conf.d/pf9.conf
+++ b/decco-container/conf/nginx/conf.d/pf9.conf
@@ -1,0 +1,43 @@
+server {
+    listen 80;
+    rewrite (.*) https://$http_host$1 permanent;
+}
+
+server {
+    root   /usr/share/nginx/html;
+    proxy_read_timeout 120s;
+
+    # x-auth-token header can exceed default size of 8k
+    large_client_header_buffers 4 64k;
+
+    # Response headers can exceed the default size of 4k
+    proxy_buffer_size 128k;
+    proxy_buffers    8 64k;
+    proxy_busy_buffers_size   128k;
+    fastcgi_buffers 8 128k;
+    fastcgi_buffer_size 128k;
+
+    listen 8080;
+
+    # frontend
+    location / {
+        rewrite (.*) https://$http_host/ui/index.html;
+    }
+
+    # status page
+    location /nginx_status {
+        stub_status on;
+        access_log off;
+        allow 127.0.0.1;
+        deny all;
+    }
+
+    location /ui {
+        try_files $uri /ui/index.html;
+        include /etc/nginx/conf.d/pf9/cors.conf;
+        index index.html;
+        autoindex off;
+        # caching can create problems when we change templates
+        expires 1h;
+    }
+}

--- a/decco-container/init-region
+++ b/decco-container/init-region
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -ex
+mkdir -p /var/log/nginx
+

--- a/decco-container/start.sh
+++ b/decco-container/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+confd -onetime -backend consul -node ${CONFIG_HOST_AND_PORT} -scheme ${CONFIG_SCHEME} -auth-token ${CONSUL_HTTP_TOKEN} -prefix /customers/${CUSTOMER_ID}/regions/${REGION_ID}
+nginx -g "daemon off;"

--- a/decco-container/y2j.py
+++ b/decco-container/y2j.py
@@ -1,0 +1,9 @@
+import yaml
+import json
+import sys
+
+fname = sys.argv[1]
+with open(fname, 'r') as f:
+    data = yaml.load(f)
+    out = json.dumps(data, separators=(',', ':'))
+    print out


### PR DESCRIPTION
- app name is pf9-serenity
- complies with decco/axon standard by supply an init-region script (which does nothing presently) and an app_metadata image annotation
- uses confd to set /etc/nginx/conf.d/pf9/cors.conf dynamically from Consul
- in order to build and push image, first run "make rpm" from support/ directory, then cd to decco-container/ and run "make push"
- required change in pf9-qbert repo: must add "admin_url" endpoint to Keystone at init-region time, the new UI needs it, whereas the old one uses "internal_url"
- testing: teamcity build: http://teamcity.platform9.horse:8111/viewLog.html?buildId=1034415&buildTypeId=Pf9project_ContainerBuilds_SerenityContainer&tab=buildResultsDiv, live UI: see https://du-test-kplane-leb-2568.platform9.horse/ui/