### PR TITLE
Added loadFromContext in create/update functions and loadOnDemand option in useDataLoader hook

### DIFF
--- a/src/app/core/helpers/createContextUpdater.js
+++ b/src/app/core/helpers/createContextUpdater.js
@@ -139,8 +139,12 @@ function createContextUpdater (cacheKey, dataUpdaterFn, options = {}) {
       additionalOptions,
       dumpCache: true,
     })
+    const loadFromContext = (key, params = emptyObj, refetch) => {
+      const loaderFn = getContextLoader(key)
+      return loaderFn({ getContext, setContext, params, refetch, additionalOptions })
+    }
     try {
-      const output = await dataUpdaterFn(params, prevItems)
+      const output = await dataUpdaterFn(params, prevItems, loadFromContext)
       const operationSwitchCase = switchCase(
         // If no operation is chosen (ie "any" or a custom operation), just replace the whole array with the new output
         isNil(output) ? identity : always(output),

--- a/src/app/core/hooks/useDataLoader.js
+++ b/src/app/core/hooks/useDataLoader.js
@@ -23,7 +23,7 @@ const onErrorHandler = moize((loaderFn, showToast) => (errorMessage, catchedErr,
  */
 const useDataLoader = (loaderFn, params = emptyObj, options = emptyObj) => {
   const {
-    loadOnDemand = true,
+    loadOnDemand = false,
     invalidateCache = false,
   } = options
 


### PR DESCRIPTION
As a good practice, most of the data loading calls should be made in the `createFn`/`updateFn` of the createCRUDActions or `createContextUpdate` helpers.
To further encourage this, I added an additional parameter called `loadFromContext` so that we can cache-load any additional required data there:

![image](https://user-images.githubusercontent.com/339539/67928214-0c147900-fbed-11e9-940c-ddacf673c590.png)

Also please keep in mind that you can define any custom operations (besides create and update) with the already previously existing `customOperations` option:
![image](https://user-images.githubusercontent.com/339539/67928443-9fe64500-fbed-11e9-820c-0f1459827bd6.png)
These custom operations will also receive a third `loadFromContext` parameter from now on.


Moreover, I added the possibility of using `loadOnDemand` option in the `useDataLoader` hook which will allow us decide when to load the data instead of loading it when the component renders or on param updates. 
By doing so, we will be able to load on demand at any time using the third argument (reload) returned by the `useDataLoader` hook `[data, loading, reload]`.
Example:
```
const params = {}
const exampleComponent () => {
	// In this case, we don't need the first returned argument, as we won't use the data for the rendering
	const [, loading, load] = useContextLoader(clustersLoader, params, { loadOnDemand: true })
	const handleSubmit = async () => {
		// Use the data returned from the promise directly, instead of waiting for the setState react cycle
		const data = await load()
		... do something with the data
	}
	return <FormWrapper loading={loading}>
		<ValidatedForm onSubmit={handleSubmit}>
		....
		</ValidatedForm>
	</FormWrapper>

}
```
In any case, I strongly discourage this in order to prevent the view from becoming too cluttered and having too much responsibility (also side effects are much trickier to handle there), so please avoid doing so whenever possible and make any side data calls within the action functions.

