### PR TITLE
Fixed the SSH key field validation in AWS cluster creation wizard.

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/AwsClusterSshKeyPicklist.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/AwsClusterSshKeyPicklist.js
@@ -7,7 +7,7 @@ import Picklist from 'core/components/Picklist'
 import { loadCloudProviderRegionDetails } from 'k8s/components/infrastructure/cloudProviders/actions'
 
 const AwsClusterSshKeyPicklist = forwardRef(({
-  cloudProviderId, cloudProviderRegionId, hasError, errorMessage, ...rest
+  cloudProviderId, cloudProviderRegionId, ...rest
 }, ref) => {
   const [details, loading] = useDataLoader(loadCloudProviderRegionDetails, { cloudProviderId, cloudProviderRegionId })
 
@@ -20,8 +20,6 @@ const AwsClusterSshKeyPicklist = forwardRef(({
       ref={ref}
       loading={loading}
       options={options}
-      error={hasError}
-      helperText={errorMessage}
     />
   )
 })


### PR DESCRIPTION
Passing the correct props to component.
[](url)
![sshKeyValidation](https://user-images.githubusercontent.com/8025925/68104307-97994d00-ff00-11e9-8a79-90734156cf80.gif)
