### PR TITLE
Allow having composite unique identifiers when creating context loaders/updaters

### DIFF
--- a/src/app/core/components/FormWrapper.js
+++ b/src/app/core/components/FormWrapper.js
@@ -51,11 +51,11 @@ const FormWrapper = ({
           }
         </Grid>
         <Divider className={classes.divider} />
-        <div className={className}>
-          <Progress {...progressProps}>
+        <Progress {...progressProps}>
+          <div className={className}>
             {children}
-          </Progress>
-        </div>
+          </div>
+        </Progress>
       </Grid>
     </Grid>
   )

--- a/src/app/plugins/kubernetes/components/apps/AppDetailsPage.js
+++ b/src/app/plugins/kubernetes/components/apps/AppDetailsPage.js
@@ -48,7 +48,7 @@ const AppDetailsPage = () => {
   const { match: { params: routeParams } } = useReactRouter()
   const { params, getParamsUpdater } = useParams({
     clusterId: routeParams.clusterId,
-    appId: routeParams.id,
+    id: routeParams.id,
     release: routeParams.release,
   })
   const [showingDeployDialog, setShowingDeployDialog] = useState(false)
@@ -119,7 +119,7 @@ const AppDetailsPage = () => {
         <Grid item xs={9} lg={10} zeroMinWidth>
           <AppVersionPicklist
             label="Application Version"
-            appId={params.appId}
+            appId={params.id}
             clusterId={params.clusterId}
             release={params.release}
             value={params.version}

--- a/src/app/plugins/kubernetes/components/apps/actions.js
+++ b/src/app/plugins/kubernetes/components/apps/actions.js
@@ -26,15 +26,15 @@ export const releaseDetailCacheKey = 'deployment'
 export const repositoriesWithClustersCacheKey = 'repositoriesWithClusters'
 export const repositoriesCacheKey = 'repositories'
 
-export const appDetailLoader = createContextLoader(singleAppCacheKey, async ({ clusterId, appId, release, version }) => {
-  const chart = await qbert.getChart(clusterId, appId, release, version)
+export const appDetailLoader = createContextLoader(singleAppCacheKey, async ({ clusterId, id, release, version }) => {
+  const chart = await qbert.getChart(clusterId, id, release, version)
   return {
     ...chart,
     readmeMarkdown: await qbert.getChartReadmeContents(clusterId, chart.attributes.readme),
   }
 }, {
-  uniqueIdentifier,
-  indexBy: ['clusterId', 'appId', 'release', 'version'],
+  uniqueIdentifier: ['id', 'clusterId'],
+  indexBy: ['clusterId', 'id', 'release', 'version'],
   dataMapper: async (items, { clusterId }) => {
     const monocularUrl = await qbert.clusterMonocularBaseUrl(clusterId, null)
     return map(({ id, ...item }) => {
@@ -114,7 +114,7 @@ export const appActions = createCRUDActions(appsCacheKey, {
     deploy: `Successfully deployed App ${name}`,
   })(operation),
   entityName: 'App Catalog',
-  uniqueIdentifier,
+  uniqueIdentifier: ['id', 'clusterId'],
   indexBy: 'clusterId',
   dataMapper: async (items, { clusterId, repositoryId }) => {
     const monocularUrl = await qbert.clusterMonocularBaseUrl(clusterId, null)

--- a/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/actions.js
@@ -98,12 +98,10 @@ export const loadCloudProviderDetails = createContextLoader(
 export const loadCloudProviderRegionDetails = createContextLoader(
   'cloudProviderRegionDetails',
   async ({ cloudProviderId, cloudProviderRegionId }) => {
-    const response = await qbert.getCloudProviderRegionDetails(cloudProviderId, cloudProviderRegionId)
-    // We create an artificial `id` parameter in the response so that createContextLoader has a
-    // uniqueIdentifier to key off of.  Failure to do this results in inproperly cached values.
-    return { id: `${cloudProviderId}-${cloudProviderRegionId}`, ...response }
+    return qbert.getCloudProviderRegionDetails(cloudProviderId, cloudProviderRegionId)
   },
   {
+    uniqueIdentifier: ['cloudProviderId', 'cloudProviderRegionId'],
     indexBy: ['cloudProviderId', 'cloudProviderRegionId'],
   },
 )


### PR DESCRIPTION
This will allow us to define composite unique identifiers such as
![image](https://user-images.githubusercontent.com/339539/68158506-5ba6cc00-ff82-11e9-898f-6480b53117ea.png)
...instead of having to create a custom ID with the combined fields.

