### PR TITLE
Change prometheus labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10610,7 +10610,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10628,11 +10629,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10645,15 +10648,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10756,7 +10762,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10766,6 +10773,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10778,17 +10786,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10805,6 +10816,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10877,7 +10889,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10887,6 +10900,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10962,7 +10976,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10992,6 +11007,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11009,6 +11025,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11047,11 +11064,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
@@ -20,13 +20,12 @@ export const columns = [
   { id: 'clusterName', label: 'Cluster' },
   { id: 'namespace', label: 'Namespace' },
   // { id: 'dashboard', label: 'Dashboard', render: renderDashboardLink },
-  { id: 'serviceMonitorSelector', label: 'Service Monitor', render: renderKeyValues },
+  { id: 'serviceMonitorSelector', label: 'Service Monitor Selectors', render: renderKeyValues },
   { id: 'alertManagersSelector', label: 'Alert Managers' },
   { id: 'cpu', label: 'CPU' },
   { id: 'storage', label: 'Storage', display: false },
   { id: 'memory', label: 'Memory' },
   { id: 'retention', label: 'Retention' },
-  { id: 'version', label: 'Version' },
   { id: 'replicas', label: 'Replicas' },
 ]
 

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -37,7 +37,6 @@ export const mapPrometheusInstance = curry((clusters, { clusterId, metadata, spe
   cpu: pathStrOrNull('resources.requests.cpu', spec),
   storage: pathStrOrNull('resources.requests.storage', spec),
   memory: pathStrOrNull('resources.requests.memory', spec),
-  version: metadata.resourceVersion,
   retention: spec.retention,
   replicas: spec.replicas,
   dashboard: pathOr('', ['annotations', 'service_path'], metadata),

--- a/src/app/plugins/kubernetes/index.js
+++ b/src/app/plugins/kubernetes/index.js
@@ -155,7 +155,7 @@ Kubernetes.registerPlugin = pluginManager => {
         component: NamespacesListPage,
       },
       {
-        name: 'Prometheus Monitoring (BETA)',
+        name: 'Monitoring (beta)',
         link: { path: '/prometheus', exact: true },
         component: PrometheusMonitoringPage,
       },
@@ -369,7 +369,7 @@ Kubernetes.registerPlugin = pluginManager => {
     },
     { name: 'Storage Classes', icon: 'hdd', link: { path: '/storage_classes' } },
     { name: 'Namespaces', icon: 'object-group', link: { path: '/namespaces' } },
-    { name: 'Prometheus Monitoring (BETA)', icon: 'chart-area', link: { path: '/prometheus' } },
+    { name: 'Monitoring (beta)', icon: 'chart-area', link: { path: '/prometheus' } },
     { name: 'Logging (beta)', icon: 'clipboard-list', link: { path: '/logging' } },
     { name: 'RBAC', icon: 'user-shield', link: { path: '/rbac' } },
     { name: 'API Access', icon: 'key', link: { path: '/api_access' } },


### PR DESCRIPTION
This change fixes a few lables related to monitoring
* Prometheus Monitoring (beta) ==> Monitoring (beta). To make it consistent with logging tab
* Service Monitors ==> Service Monitor Selectors. To reflect correct type for data shown in the table. (Prometheus CR spec has a field called "Service Monitor Selector" which is what is shown here)