### PR TITLE
Remove service monitor selector field from table view

### DIFF
--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import { prometheusServiceMonitorsCacheKey } from './actions'
 
@@ -5,12 +6,28 @@ const renderKeyValues = obj => Object.entries(obj)
   .map(([key, value]) => `${key}: ${value}`)
   .join(', ')
 
+const renderExpressions = obj => Object.entries(obj)
+  .map(([k, v]) => `${v.key} '${v.operator}' ${v.values.join(', ')}`)
+  .join('; ')
+
+const renderSelector = obj => (
+  <div>
+    <div>
+      {(obj.matchExpressions && renderExpressions(obj.matchExpressions))}
+    </div>
+    <div>
+      {(obj.matchLabels && renderKeyValues(obj.matchLabels))}
+    </div>
+  </div>
+)
 export const columns = [
   { id: 'name', label: 'Name' },
   { id: 'clusterName', label: 'Cluster' },
   { id: 'namespace', label: 'Namespace' },
   { id: 'labels', label: 'Labels', render: renderKeyValues },
   { id: 'port', label: 'Endpoints' },
+  { id: 'namespaceSelector', label: 'Namespace Selector' },
+  { id: 'selector', label: 'Application Selector', render: renderSelector }
 ]
 
 export const options = {

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusServiceMonitors.js
@@ -10,8 +10,7 @@ export const columns = [
   { id: 'clusterName', label: 'Cluster' },
   { id: 'namespace', label: 'Namespace' },
   { id: 'labels', label: 'Labels', render: renderKeyValues },
-  { id: 'port', label: 'Port' },
-  { id: 'selector', label: 'Selector', render: renderKeyValues },
+  { id: 'port', label: 'Endpoints' },
 ]
 
 export const options = {

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -164,6 +164,8 @@ export const prometheusServiceMonitorActions = createCRUDActions(prometheusServi
       namespace: metadata.namespace,
       labels: metadata.labels,
       port: spec.endpoints.map(prop('port')).join(', '),
+      namespaceSelector: (spec.namespaceSelector && spec.namespaceSelector.matchNames && spec.namespaceSelector.matchNames.join(', ')) || '-',
+      selector: spec.selector,
     }))(items)
   },
   uniqueIdentifier,

--- a/src/app/plugins/kubernetes/components/prometheus/actions.js
+++ b/src/app/plugins/kubernetes/components/prometheus/actions.js
@@ -133,7 +133,6 @@ export const prometheusRuleActions = createCRUDActions(prometheusRulesCacheKey, 
 })
 
 /* Service Monitors */
-
 export const prometheusServiceMonitorsCacheKey = 'prometheusServiceMonitors'
 export const prometheusServiceMonitorActions = createCRUDActions(prometheusServiceMonitorsCacheKey, {
   listFn: async (params, loadFromContext) => {
@@ -165,7 +164,6 @@ export const prometheusServiceMonitorActions = createCRUDActions(prometheusServi
       namespace: metadata.namespace,
       labels: metadata.labels,
       port: spec.endpoints.map(prop('port')).join(', '),
-      selector: spec.selector.matchLabels,
     }))(items)
   },
   uniqueIdentifier,


### PR DESCRIPTION
This change removes the service monitor selector field from table view.
The selector field is of kubernetes API type: metav1.LabelSelector (https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitorspec)
which in itself can be of type MatchLabels or MatchExpressions (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#labelselector-v1-meta)

MatchLabels is simple key value array (which was handled)
MatchExpressions has operator format, which is more complex to display.

I believe for simplicity, we can omit this field from table view altogether.