### PR TITLE
[PMK-2186] Created smaller alert component for login failure alert

### DIFF
--- a/src/app/core/components/Alert.js
+++ b/src/app/core/components/Alert.js
@@ -27,6 +27,14 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
     border: 0,
   },
+  rootSmall: {
+    maxWidth: 800,
+    padding: theme.spacing(1, 1),
+    margin: theme.spacing(2, 0),
+    width: '100%',
+    border: 0,
+    display: 'flex',
+  },
   success: { color: green[600] },
   error: { color: theme.palette.error.dark },
   info: { color: theme.palette.primary.dark },
@@ -37,12 +45,23 @@ const useStyles = makeStyles(theme => ({
     top: theme.spacing(1),
     fontSize: 28,
   },
+  iconSmall: {
+    fontSize: 28,
+    flexGrow: 0,
+    alignSelf: 'center',
+  },
   close: {
     position: 'absolute',
     right: theme.spacing(2),
     top: theme.spacing(1),
     padding: theme.spacing(1),
     margin: theme.spacing(-1),
+  },
+  closeSmall: {
+    flexGrow: 0,
+    padding: theme.spacing(1),
+    margin: theme.spacing(-1),
+    alignSelf: 'center',
   },
   iconVariant: {
     opacity: 0.9,
@@ -52,24 +71,28 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     alignItems: 'center',
   },
+  messageSmall: {
+    alignSelf: 'center',
+    flexGrow: 1
+  },
 }))
 
-const Alert = ({ children, message, variant }) => {
+const Alert = ({ children, message, variant, small }) => {
   const classes = useStyles()
   const [open, setOpen] = useState(true)
   if (!open) { return null }
   const Icon = variantIcon[variant]
 
   return (
-    <Paper className={classes.root}>
-      <Icon className={clsx(classes.icon, classes.iconVariant, classes[variant])} />
-      {message && <Typography variant="body1" color="inherit">{message}</Typography>}
+    <Paper className={small ? classes.rootSmall : classes.root}>
+      <Icon className={clsx(small ? classes.iconSmall : classes.icon, classes.iconVariant, classes[variant])} />
+      {message && <Typography variant="body1" color="inherit" className={small ? classes.messageSmall : ''}>{message}</Typography>}
       {children}
       <IconButton
         key='close'
         aria-label='Close'
         color='inherit'
-        className={classes.close}
+        className={small ? classes.closeSmall : classes.close}
         onClick={() => setOpen(false)}
       >
         <CloseIcon />

--- a/src/app/core/components/Alert.js
+++ b/src/app/core/components/Alert.js
@@ -21,78 +21,59 @@ const variantIcon = {
 const useStyles = makeStyles(theme => ({
   root: {
     maxWidth: 800,
-    position: 'relative',
-    padding: theme.spacing(1, 8),
+    position: ({ small }) => small ? 'initial' : 'relative',
+    padding: ({ small }) => small ? theme.spacing(1, 1) : theme.spacing(1, 8),
     margin: theme.spacing(2, 0),
-    width: '100%',
     border: 0,
-  },
-  rootSmall: {
-    maxWidth: 800,
-    padding: theme.spacing(1, 1),
-    margin: theme.spacing(2, 0),
-    width: '100%',
-    border: 0,
-    display: 'flex',
+    display: ({ small }) => small ? 'flex' : 'block'
   },
   success: { color: green[600] },
   error: { color: theme.palette.error.dark },
   info: { color: theme.palette.primary.dark },
   warning: { color: amber[700] },
   icon: {
-    position: 'absolute',
-    left: theme.spacing(2),
-    top: theme.spacing(1),
+    position: ({ small }) => small ? 'initial' : 'absolute',
+    left: ({ small }) => small ? 'initial' : theme.spacing(2),
+    top: ({ small }) => small ? 'initial' : theme.spacing(1),
     fontSize: 28,
-  },
-  iconSmall: {
-    fontSize: 28,
-    flexGrow: 0,
-    alignSelf: 'center',
+    flexGrow: ({ small }) => small ? 0 : 'initial',
+    alignSelf: ({ small }) => small ? 'center' : 'initial',
   },
   close: {
-    position: 'absolute',
-    right: theme.spacing(2),
-    top: theme.spacing(1),
+    position: ({ small }) => small ? 'initial' : 'absolute',
+    right: ({ small }) => small ? 'initial' : theme.spacing(2),
+    top: ({ small }) => small ? 'initial' : theme.spacing(1),
     padding: theme.spacing(1),
     margin: theme.spacing(-1),
-  },
-  closeSmall: {
-    flexGrow: 0,
-    padding: theme.spacing(1),
-    margin: theme.spacing(-1),
-    alignSelf: 'center',
+    flexGrow: ({ small }) => small ? 0 : 'initial',
+    alignSelf: ({ small }) => small ? 'center' : 'initial',
   },
   iconVariant: {
     opacity: 0.9,
     marginRight: theme.spacing(1),
   },
   message: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  messageSmall: {
-    alignSelf: 'center',
-    flexGrow: 1
+    alignSelf: ({ small }) => small ? 'center' : 'initial',
+    flexGrow: ({ small }) => small ? 1 : 'initial',
   },
 }))
 
 const Alert = ({ children, message, variant, small }) => {
-  const classes = useStyles()
+  const classes = useStyles({ small })
   const [open, setOpen] = useState(true)
   if (!open) { return null }
   const Icon = variantIcon[variant]
 
   return (
-    <Paper className={small ? classes.rootSmall : classes.root}>
-      <Icon className={clsx(small ? classes.iconSmall : classes.icon, classes.iconVariant, classes[variant])} />
-      {message && <Typography variant="body1" color="inherit" className={small ? classes.messageSmall : ''}>{message}</Typography>}
+    <Paper className={classes.root}>
+      <Icon className={clsx(classes.icon, classes.iconVariant, classes[variant])} />
+      {message && <Typography variant="body1" color="inherit" className={classes.message}>{message}</Typography>}
       {children}
       <IconButton
         key='close'
         aria-label='Close'
         color='inherit'
-        className={small ? classes.closeSmall : classes.close}
+        className={classes.close}
         onClick={() => setOpen(false)}
       >
         <CloseIcon />

--- a/src/app/core/public/LoginPage.js
+++ b/src/app/core/public/LoginPage.js
@@ -10,14 +10,11 @@ import { withAppContext } from 'core/providers/AppProvider'
 import Alert from 'core/components/Alert'
 import { withRouter } from 'react-router'
 import SimpleLink from 'core/components/SimpleLink'
-<<<<<<< HEAD:src/app/core/public/LoginPage.js
 import ExternalLink from 'core/components/ExternalLink'
 import { forgotPasswordUrl } from 'app/constants.js'
 import { pathJoin } from 'utils/misc'
 import { imageUrlRoot, dashboardUrl } from 'app/constants'
-=======
 import moment from 'moment'
->>>>>>> Updated current copyright year to use moment:src/app/plugins/openstack/components/LoginPage.js
 
 const styles = theme => ({
   root: {

--- a/src/app/core/public/LoginPage.js
+++ b/src/app/core/public/LoginPage.js
@@ -161,7 +161,7 @@ export class LoginPage extends React.PureComponent {
         of Service</ExternalLink>.
       </Typography>
       <Typography className={classes.paragraph} variant="caption" color="textSecondary">
-        © 2014-2018 Platform9 Systems, Inc.
+        © 2014-2019 Platform9 Systems, Inc.
       </Typography>
     </Fragment>
   }
@@ -183,9 +183,7 @@ export class LoginPage extends React.PureComponent {
                 {this.renderMFACheckbox()}
                 {this.state.MFAcheckbox && this.renderMFAInput()}
                 {loginFailed && (
-                  <div className={classes.errorContainer}>
-                    <Alert variant="error" message="Login failed" />
-                  </div>
+                  <Alert small variant="error" message="Login failed" />
                 )}
                 <Button type="submit" disabled={loading} className={classes.signinButton} variant="contained" color="primary">
                   {loading ? 'Attempting login...' : 'Sign In'}

--- a/src/app/core/public/LoginPage.js
+++ b/src/app/core/public/LoginPage.js
@@ -10,10 +10,14 @@ import { withAppContext } from 'core/providers/AppProvider'
 import Alert from 'core/components/Alert'
 import { withRouter } from 'react-router'
 import SimpleLink from 'core/components/SimpleLink'
+<<<<<<< HEAD:src/app/core/public/LoginPage.js
 import ExternalLink from 'core/components/ExternalLink'
 import { forgotPasswordUrl } from 'app/constants.js'
 import { pathJoin } from 'utils/misc'
 import { imageUrlRoot, dashboardUrl } from 'app/constants'
+=======
+import moment from 'moment'
+>>>>>>> Updated current copyright year to use moment:src/app/plugins/openstack/components/LoginPage.js
 
 const styles = theme => ({
   root: {
@@ -161,7 +165,7 @@ export class LoginPage extends React.PureComponent {
         of Service</ExternalLink>.
       </Typography>
       <Typography className={classes.paragraph} variant="caption" color="textSecondary">
-        © 2014-2019 Platform9 Systems, Inc.
+        © 2014-{moment().year()} Platform9 Systems, Inc.
       </Typography>
     </Fragment>
   }


### PR DESCRIPTION
Debating whether or not to keep a separate component for smaller alerts? For this first pass, copied the entire Alert component and changed the styling. Could possibly add a prop that determines the size, but it could be possible these large and small alerts will diverge more in the future. Thoughts?

<img width="478" alt="Screen Shot 2019-11-11 at 1 53 09 AM" src="https://user-images.githubusercontent.com/6668478/68549158-b24f5280-0427-11ea-9ac8-c3593a82fc71.png">
