### PR TITLE
Auto select first region if stored region doesn't exist

### DIFF
--- a/src/api-client/ResMgr.js
+++ b/src/api-client/ResMgr.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { __, contains, partition, uniq } from 'ramda'
+import { __, partition, uniq, includes } from 'ramda'
 
 const roleNames = {
   'pf9-ostackhost-neutron': 'Hypervisor',
@@ -29,7 +29,7 @@ const neutronComponents = [
 export const localizeRole = role => roleNames[role] || role
 
 export const localizeRoles = (roles = []) => {
-  const isNeutronRole = contains(__, neutronComponents)
+  const isNeutronRole = includes(__, neutronComponents)
   const [neutronRoles, normalRoles] = partition(isNeutronRole, roles)
   const hasAllNetworkRoles = neutronRoles.length === neutronComponents.length
   return uniq([

--- a/src/app/plugins/openstack/components/regions/RegionChooser.js
+++ b/src/app/plugins/openstack/components/regions/RegionChooser.js
@@ -1,38 +1,38 @@
 import React, { useState, useCallback, useMemo } from 'react'
-import ApiClient from 'api-client/ApiClient'
 import Selector from 'core/components/Selector'
-import { pluck, propEq, prop } from 'ramda'
+import { pluck, propEq, find, pipe, head, prop } from 'ramda'
 import { useScopedPreferences } from 'core/providers/PreferencesProvider'
 import { Tooltip } from '@material-ui/core'
 import useDataLoader from 'core/hooks/useDataLoader'
 import { regionActions } from 'k8s/components/infrastructure/common/actions'
 import { appUrlRoot } from 'app/constants'
 
-const apiClient = ApiClient.getInstance()
-
 const RegionChooser = props => {
   const [tooltipOpen, setTooltipOpen] = useState(false)
-  const { prefs, updatePrefs } = useScopedPreferences('RegionChooser')
-  const { lastRegion } = prefs
+  const { prefs: { lastRegion }, updatePrefs } = useScopedPreferences('RegionChooser')
   const [loading, setLoading] = useState(false)
-  const [curRegion, setRegion] = useState(apiClient.activeRegion || prop('id', lastRegion))
   const [regionSearch, setSearchText] = useState('')
-  // const { setContext } = useContext(AppContext)
-
   const [regions, loadingRegions] = useDataLoader(regionActions.list)
-
+  const [selectedRegion, setRegion] = useState()
+  const curRegion = useMemo(() => {
+    if (selectedRegion) {
+      return selectedRegion
+    }
+    if (lastRegion && find(propEq('id', lastRegion.id), regions)) {
+      return lastRegion.id
+    }
+    return pipe(head, prop('id'))(regions) || 'Current Region'
+  }, [regions, lastRegion, selectedRegion])
   const handleRegionSelect = useCallback(async region => {
     setLoading(true)
     setRegion(region)
-    // Future Todo: Update the Selector component or create a variant of the component
-    // that can take a list of objects
-    const fullRegionObj = regions.find(propEq('id', region))
-    await updatePrefs({ lastRegion: fullRegionObj })
+    const lastRegion = regions.find(propEq('id', region))
+    await updatePrefs({ lastRegion })
 
     // Initial loading of the app is tightly coupled to knowing the region to use.
     // Reloading the app when the region changes is the simplest and most robust solution.
     // FIXME this can probably be avoided using the commented code below
-    window.location = appUrlRoot
+    window.location.href = appUrlRoot
     // await setContext(pipe(
     //   // Reset all the data cache
     //   assoc(dataCacheKey, emptyArr),
@@ -61,7 +61,7 @@ const RegionChooser = props => {
         onMouseLeave={handleTooltipClose}
         onClick={handleTooltipClose}
         className={props.className}
-        name={!curRegion || curRegion.length === 0 ? 'Current Region' : curRegion}
+        name={curRegion}
         list={regionNames}
         onChoose={handleRegionSelect}
         onSearchChange={setSearchText}


### PR DESCRIPTION
This fixes the confusing issue that happens when switching between servers, which tried to use the previously selected Region even if that region no longer existed.
However, it is not yet a perfect solution, as it is now, errors are still shown if a region is chosen without some required services (such as `qbert`)
I will address this other issue in another PR, after further discussing the possible solutions.