### PR TITLE
Monitoring addon button

### DIFF
--- a/src/api-client/Appbert.js
+++ b/src/api-client/Appbert.js
@@ -21,11 +21,10 @@ class Appbert {
   }
 
   toggleMonitoring = async (clusterUuid, pkgId, on) => {
-    if (on === true) {
+    if (on) {
       return this.client.basicPut(`${await this.baseUrl()}/clusters/${clusterUuid}/${pkgId}`)
-    } else {
-      return this.client.basicDelete(`${await this.baseUrl()}/clusters/${clusterUuid}/${pkgId}`)
     }
+    return this.client.basicDelete(`${await this.baseUrl()}/clusters/${clusterUuid}/${pkgId}`)
   }
 }
 

--- a/src/api-client/Appbert.js
+++ b/src/api-client/Appbert.js
@@ -15,6 +15,18 @@ class Appbert {
   getClusterTags = async () => {
     return this.client.basicGet(`${await this.baseUrl()}/clusters`)
   }
+
+  getPackages = async () => {
+    return this.client.basicGet(`${await this.baseUrl()}/packages`)
+  }
+
+  toggleMonitoring = async (clusterUuid, pkgId, on) => {
+    if (on === true) {
+      return this.client.basicPut(`${await this.baseUrl()}/clusters/${clusterUuid}/${pkgId}`)
+    } else {
+      return this.client.basicDelete(`${await this.baseUrl()}/clusters/${clusterUuid}/${pkgId}`)
+    }
+  }
 }
 
 export default Appbert

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -7,6 +7,7 @@ import AttachIcon from '@material-ui/icons/AddToQueue'
 import DetachIcon from '@material-ui/icons/RemoveFromQueue'
 import ScaleIcon from '@material-ui/icons/TrendingUp'
 import UpgradeIcon from '@material-ui/icons/PresentToAll'
+import InsertChartIcon from '@material-ui/icons/InsertChart'
 import { clustersCacheKey } from '../common/actions'
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import ClusterAttachNodeDialog from './ClusterAttachNodeDialog'
@@ -21,6 +22,7 @@ import DashboardLink from './DashboardLink'
 import CreateButton from 'core/components/buttons/CreateButton'
 import { AppContext } from 'core/providers/AppProvider'
 import { both, prop } from 'ramda'
+import PrometheusAddonDialog from 'k8s/components/prometheus/PrometheusAddonDialog'
 
 const getClusterPopoverContent = (healthyMasterNodes, masterNodes) =>
   `${healthyMasterNodes.length} of ${masterNodes.length} master nodes healthy (3 required)`
@@ -211,6 +213,12 @@ export const options = {
       label: 'Upgrade cluster',
       action: upgradeCluster,
       disabledInfo: 'Feature not yet implemented',
+    },
+    {
+      cond: isAdmin,
+      icon: <InsertChartIcon />,
+      label: 'Monitoring',
+      dialog: PrometheusAddonDialog,
     },
   ],
 }

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusAddonDialog.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusAddonDialog.js
@@ -46,7 +46,7 @@ const PrometheusAddonDialog = ({ rows: [cluster], onClose }) => {
       </DialogContent>
       <DialogActions>
         <Button color="primary" type="submit" variant="contained" onClick={toggleMonitoring}>
-          {enabled === true ? 'Disable' : 'Enable'}
+          {enabled ? 'Disable' : 'Enable'}
         </Button>
         <Button variant="contained" onClick={onClose}>
           Cancel

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusAddonDialog.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusAddonDialog.js
@@ -45,10 +45,10 @@ const PrometheusAddonDialog = ({ rows: [cluster], onClose }) => {
         </p>
       </DialogContent>
       <DialogActions>
-        <Button color='primary' type='submit' variant='contained' onClick={toggleMonitoring}>
+        <Button color="primary" type="submit" variant="contained" onClick={toggleMonitoring}>
           {enabled === true ? 'Disable' : 'Enable'}
         </Button>
-        <Button variant='contained' onClick={onClose}>
+        <Button variant="contained" onClick={onClose}>
           Cancel
         </Button>
       </DialogActions>

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusAddonDialog.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusAddonDialog.js
@@ -1,0 +1,27 @@
+
+import React from 'react'
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@material-ui/core'
+
+const PrometheusAddonDialog = ({ onClose }) => {
+  return (
+    <Dialog open onClose={onClose}>
+      <DialogTitle>Monitoring Add-On (Beta)</DialogTitle>
+      <DialogContent>
+        <p>
+          <b>Note</b> Monitoring is a Beta feature
+        </p>
+        <p>
+          After enabling monitoring add on, you will be able to access prometheus metrics for Kubernets and Grafana
+          dashboards. Cluster users will be able to spin up their own prometheus instances for application monitoring.
+        </p>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="contained" onClick={onClose}>
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default PrometheusAddonDialog

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusAddonDialog.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusAddonDialog.js
@@ -1,22 +1,54 @@
 
 import React from 'react'
+import { castFuzzyBool } from 'utils/misc'
+import { compose, path } from 'ramda'
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@material-ui/core'
+import ApiClient from 'api-client/ApiClient'
 
-const PrometheusAddonDialog = ({ onClose }) => {
+export const hasPrometheusEnabled = compose(castFuzzyBool, path(['tags', 'pf9-system:monitoring']))
+
+const { appbert } = ApiClient.getInstance()
+
+const PrometheusAddonDialog = ({ rows: [cluster], onClose }) => {
+  const enabled = hasPrometheusEnabled(cluster)
+  const toggleMonitoring = () => {
+    try {
+      appbert.getPackages().then(pkgs => {
+        const monPkg = (pkgs || []).filter(pkg => (
+          pkg.name === 'pf9-mon'
+        ))
+        if (monPkg === null || monPkg.length === 0) {
+          console.log('no monitoring package found')
+          onClose()
+          return
+        }
+        const monId = monPkg[0].ID
+        appbert.toggleMonitoring(cluster.uuid, monId, !enabled).then(() => {
+          onClose()
+        })
+      })
+    } catch (e) {
+      console.log(e)
+    }
+  }
+
   return (
     <Dialog open onClose={onClose}>
       <DialogTitle>Monitoring Add-On (Beta)</DialogTitle>
       <DialogContent>
         <p>
-          <b>Note</b> Monitoring is a Beta feature
+          <b>Note:</b> Monitoring is a Beta feature
         </p>
         <p>
-          After enabling monitoring add on, you will be able to access prometheus metrics for Kubernets and Grafana
-          dashboards. Cluster users will be able to spin up their own prometheus instances for application monitoring.
+          After enabling monitoring add on, you will be able to access prometheus metrics and Grafana
+          dashboards for Kubernetes. In addition, users will be able to spin up their own prometheus instances for application monitoring.
         </p>
       </DialogContent>
       <DialogActions>
-        <Button variant="contained" onClick={onClose}>
+        <Button color='primary' type='submit' variant='contained' onClick={toggleMonitoring}>
+          {enabled === true ? 'Disable' : 'Enable'}
+        </Button>
+        <Button variant='contained' onClick={onClose}>
           Cancel
         </Button>
       </DialogActions>


### PR DESCRIPTION
This change restores the "toggle prometheus" feature button in old UI.
Still working on the dialog actions, but sending out early change to ensure i am on the right track.
Clicking enable is supposed to call appbert service and enable prometheus package.
Similarly disable removes it.