### PR TITLE
Add "custom" as a template choice option and move related fields to step1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7752,13 +7752,13 @@
       "dependencies": {
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
           "dev": true
         },
         "whatwg-fetch": {
           "version": "2.0.4",
-          "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
           "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
           "dev": true
         }


### PR DESCRIPTION
Improved template chooser options for AWS and Azure cluster creation.

This adds a `custom` option to the picklist that conditionally renders the cluster configuration fields.

The config fields have all been moved into the first step, eliminating the need for the 2nd step entirely.

Address the following PR's:
* PMK-2192
* PMK-2257
