### PR TITLE
[PMK-2196] Display server error messages in toast notifications

### DIFF
--- a/src/api-client/ApiClient.js
+++ b/src/api-client/ApiClient.js
@@ -11,6 +11,7 @@ import Nova from './Nova'
 import Qbert from './Qbert'
 import ResMgr from './ResMgr'
 import { normalizeResponse } from 'api-client/helpers'
+import { pathStrOr } from 'utils/fp'
 
 class ApiClient {
   static init (options = {}) {
@@ -54,6 +55,10 @@ class ApiClient {
     this.activeRegion = null
 
     this.axiosInstance = axios.create({ ...defaultAxiosConfig, ...(options.axios || {}) })
+    this.axiosInstance.interceptors.response.use(
+      response => response,
+      error => Promise.reject(pathStrOr(error, 'response.data', error)),
+    )
   }
 
   serialize = () => {

--- a/src/app/core/components/CRUDListContainer.js
+++ b/src/app/core/components/CRUDListContainer.js
@@ -58,6 +58,7 @@ const CRUDListContainer = ({
     toggleConfirmDialog()
     await Promise.all(selectedItems.map(handleRemove))
     deletePromise.current()
+    reload()
   }, [selectedItems, handleRemove])
 
   const handleAdd = () => {
@@ -84,13 +85,18 @@ const CRUDListContainer = ({
     }
   }
 
+  const handleClose = toggleDialog => () => {
+    toggleDialog()
+    reload()
+  }
+
   return <>
     {AddDialog && showingAddDialog && <AddDialog
-      onClose={toggleAddDialog}
+      onClose={handleClose(toggleAddDialog)}
     />}
     {EditDialog && showingEditDialog && <EditDialog
       rows={selectedItems}
-      onClose={toggleEditDialog}
+      onClose={handleClose(toggleEditDialog)}
     />}
     {handleRemove && showingConfirmDialog && <ConfirmationDialog
       open={showingConfirmDialog}

--- a/src/app/core/components/toasts/ToastItem.tsx
+++ b/src/app/core/components/toasts/ToastItem.tsx
@@ -29,6 +29,7 @@ interface ToastItemProps {
   variant: MessageTypes
   onClose: () => void
   toastsTimeout: number
+
   [key: string]: any // ...rest props
 }
 
@@ -56,6 +57,9 @@ const useStyles = makeStyles<Theme>(theme => ({
     display: 'flex',
     alignItems: 'center',
   },
+  text: {
+    display: 'inline-block',
+  },
   close: {}
 }))
 
@@ -72,7 +76,9 @@ const ToastItem: FunctionComponent<ToastItemProps> = ({ message, variant, toasts
     message={
       <span id="client-snackbar" className={classes.message}>
         <Icon className={clsx(classes.icon, classes.iconVariant)} />
-        {message}
+        <div className={classes.text}>
+          {message.split('\n').map((i, key) => <div key={key}>{i}</div>)}
+        </div>
       </span>
     }
     action={[

--- a/src/app/core/helpers/createContextLoader.js
+++ b/src/app/core/helpers/createContextLoader.js
@@ -91,7 +91,7 @@ const createContextLoader = (cacheKey, dataFetchFn, options = {}) => {
         orderDirection === 'asc' ? identity : reverse,
       )(items),
     fetchSuccessMessage = (params) => `Successfully fetched ${entityName} items`,
-    fetchErrorMessage = (catchedErr, params) => `Error when trying to fetch ${entityName} items. ${pathStr('response.data.error.message', catchedErr)}`,
+    fetchErrorMessage = (catchedErr, params) => `Error when trying to fetch ${entityName} items`,
   } = options
   const uniqueIdentifierStrPaths = uniqueIdentifier ? ensureArray(uniqueIdentifier) : emptyArr
   const dataLens = lensPath([dataCacheKey, cacheKey])

--- a/src/app/core/hooks/useDataLoader.js
+++ b/src/app/core/hooks/useDataLoader.js
@@ -9,7 +9,7 @@ import { memoizedDep } from 'utils/misc'
 const onErrorHandler = moize((loaderFn, showToast) => (errorMessage, catchedErr, params) => {
   const key = loaderFn.getKey()
   console.error(`Error when fetching items for entity "${key}"`, catchedErr)
-  showToast(errorMessage, 'error')
+  showToast(errorMessage + (catchedErr.message ? `\n${catchedErr.message}` : ''), 'error')
 })
 
 /**

--- a/src/app/core/hooks/useDataUpdater.js
+++ b/src/app/core/hooks/useDataUpdater.js
@@ -30,7 +30,7 @@ const useDataUpdater = (updaterFn, onComplete) => {
     onError: (errorMessage, catchedErr, params) => {
       const key = updaterFn.getKey()
       console.error(`Error when updating entity "${key}"`, catchedErr)
-      showToast(errorMessage, 'error')
+      showToast(errorMessage + (catchedErr.message ? `\n${catchedErr.message}` : ''), 'error')
     },
   }), [showToast])
 

--- a/src/app/plugins/kubernetes/components/apps/AddRepoDialog.js
+++ b/src/app/plugins/kubernetes/components/apps/AddRepoDialog.js
@@ -55,13 +55,13 @@ export default ({ onClose }) => {
                     <TextField id="source" label="Source" info="URL that points to the source core" />
                   </ValidatedForm>
                 </WizardStep>
-                <WizardStep stepId="repoClusters" label="Repository clusters">
+                {clusters.length ? <WizardStep stepId="repoClusters" label="Repository clusters">
                   <Table>
                     <TableBody>
                       {clusters.map(renderClusterRow)}
                     </TableBody>
                   </Table>
-                </WizardStep>
+                </WizardStep> : null}
               </>
             }
           </Wizard>


### PR DESCRIPTION
Added an axios interceptor to return the server error messages instead of the generic javascript error, which then I show in the toast errors:
![image](https://user-images.githubusercontent.com/339539/69463174-8fb92400-0dad-11ea-9a51-359bb534789c.png)
Also fixed the refresh of the tables after editing/add an item in the CRUD containers.