### PR TITLE
[PMK-2201] Force refetching of nodes when refreshing list

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/nodes/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/nodes/actions.js
@@ -42,5 +42,6 @@ export const loadNodes = createContextLoader(nodesCacheKey, async (params, loadF
     logs: `${qbertUrl}/logs/${node.uuid}`,
   }))
 }, {
+  refetchCascade: true,
   uniqueIdentifier: 'uuid',
 })


### PR DESCRIPTION
It turns out `loadNodes` is grabbing all its data from cached resources using `loadFromContext`, so even when we try to refetch the data, the data is being pulled out from the cache because `loadFromContext` doesn't refetch by default, unless either `refetchCascade` option is defined, or manually specifying so when calling `loadFromContext(cacheKey, params, refetch)` with `refetch = true`