### PR TITLE
Add requiredRoles option in context loaders

### DIFF
--- a/src/app/core/components/ExternalLink.js
+++ b/src/app/core/components/ExternalLink.js
@@ -2,9 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import SimpleLink from 'core/components/SimpleLink'
 
-const ExternalLink = ({ url, children, newWindow = true }) => {
-  const moreProps = newWindow ? { target: '_blank', rel: 'noopener' } : {}
-  return (<SimpleLink src={url} {...moreProps}>{children || url}</SimpleLink>)
+const ExternalLink = ({ url, children, newWindow = true, ...rest }) => {
+  const targetBlankProps = newWindow ? { target: '_blank', rel: 'noopener' } : {}
+  return (<SimpleLink src={url} {...targetBlankProps} {...rest}>{children || url}</SimpleLink>)
 }
 
 ExternalLink.propTypes = {

--- a/src/app/core/helpers/createContextLoader.js
+++ b/src/app/core/helpers/createContextLoader.js
@@ -142,8 +142,7 @@ const createContextLoader = (cacheKey, dataFetchFn, options = {}) => {
    */
   const contextLoaderFn = memoizePromise(
     async ({ getContext, setContext, params = emptyObj, refetch = contextLoaderFn._invalidatedCache, dumpCache = false, additionalOptions = emptyObj }) => {
-
-      // Make sure the user has to the required roles
+      // Make sure the user has the required roles
       const { role } = getContext(propOr(emptyObj, 'userDetails'))
       if (!isNilOrEmpty(requiredRoles) && !ensureArray(requiredRoles).includes(role)) {
         return emptyArr

--- a/src/app/plugins/kubernetes/components/apiAccess/endpoints/EndpointsListPage.js
+++ b/src/app/plugins/kubernetes/components/apiAccess/endpoints/EndpointsListPage.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import endpointsActions from './actions'
-import SimpleLink from 'core/components/SimpleLink'
+import ExternalLink from 'core/components/ExternalLink'
 
 const useStyles = makeStyles(theme => ({
   link: {
@@ -31,7 +31,7 @@ const EndpointsListPage = () => {
     <>
       <h2>API Endpoints</h2>
       <ListPage />
-      <SimpleLink className={classes.link} href="/clarity/docs/qbert/">See qbert API Documentation</SimpleLink>
+      <ExternalLink className={classes.link} url="/clarity/docs/qbert/">See qbert API Documentation</ExternalLink>
     </>
   )
 }

--- a/src/app/plugins/kubernetes/components/apiAccess/kubeConfig/KubeConfigListPage.js
+++ b/src/app/plugins/kubernetes/components/apiAccess/kubeConfig/KubeConfigListPage.js
@@ -8,6 +8,7 @@ import DownloadDialog from './DownloadDialog'
 import SimpleLink from 'core/components/SimpleLink'
 import useToggler from 'core/hooks/useToggler'
 import ApiClient from 'api-client/ApiClient'
+import ExternalLink from 'core/components/ExternalLink'
 
 const { qbert } = ApiClient.getInstance()
 
@@ -104,12 +105,12 @@ const KubeConfigListPage = () => {
     <>
       <h2>Download kubeconfig</h2>
       <p>The kubeconfig file is required to authenticate with a cluster and switch between multiple clusters between multiple users while using the kubectl command line.</p>
-      <SimpleLink className={classes.link} href="https://kubernetes.io/docs/user-guide/kubectl-overview/">
+      <ExternalLink className={classes.link} url="https://kubernetes.io/docs/user-guide/kubectl-overview/">
         Learn more about kubectl
-      </SimpleLink>
-      <SimpleLink className={classes.link} href="https://kubernetes.io/docs/user-guide/kubeconfig-file/">
+      </ExternalLink>
+      <ExternalLink className={classes.link} url="https://kubernetes.io/docs/user-guide/kubeconfig-file/">
         Learn more about kubeconfig
-      </SimpleLink>
+      </ExternalLink>
       <ListPage />
       <p className={classes.clusterConfig}>Select a cluster above to populate its kubeconfig below.</p>
       <ValidatedForm>

--- a/src/app/plugins/kubernetes/components/userManagement/tenants/actions.js
+++ b/src/app/plugins/kubernetes/components/userManagement/tenants/actions.js
@@ -14,11 +14,8 @@ export const mngmTenantsCacheKey = 'managementTenants'
 const reservedTenantNames = ['admin', 'services', 'Default', 'heat']
 export const filterValidTenants = tenant => !reservedTenantNames.includes(tenant.name)
 export const mngmTenantActions = createCRUDActions(mngmTenantsCacheKey, {
-  listFn: (params, loadFromContext, getContext) => {
-    const { role } = getContext(prop('userDetails'))
-    return role === 'admin'
-      ? keystone.getAllTenantsAllUsers()
-      : emptyArr
+  listFn: () => {
+    return keystone.getAllTenantsAllUsers()
   },
   deleteFn: async ({ id }) => {
     await keystone.deleteProject(id)
@@ -121,6 +118,7 @@ export const mngmTenantActions = createCRUDActions(mngmTenantsCacheKey, {
       })),
     )(allTenantsAllUsers)
   },
+  requiredRoles: 'admin',
 })
 
 export const mngmTenantRoleAssignmentsCacheKey = 'managementTenantRoleAssignments'

--- a/src/app/plugins/kubernetes/components/userManagement/users/actions.js
+++ b/src/app/plugins/kubernetes/components/userManagement/users/actions.js
@@ -19,11 +19,10 @@ export const isSystemUser = ({ username }) => {
   return uuidRegex.test(username)
 }
 export const mngmCredentialsCacheKey = 'managementCredentials'
-createContextLoader(mngmCredentialsCacheKey, (params, loadFromContext, getContext) => {
-  const { role } = getContext(prop('userDetails'))
-  return role === 'admin'
-    ? keystone.getCredentials()
-    : emptyArr
+createContextLoader(mngmCredentialsCacheKey, () => {
+  return keystone.getCredentials()
+}, {
+  requiredRoles: 'admin'
 })
 
 const adminUserNames = ['heatadmin', 'admin@platform9.net']


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/339539/69605656-4a1d8500-1053-11ea-8998-a7a7b0057f4d.png)
If the user doesn't have the required roles an empty array will be returned. This is just a life insurance as loaders that require this roles should not even be called in the first place (the routes are protected)

Unfortunately in some cases other loaders are used that reuse other loaders via `loadFromContext` function, that was the case in the Dashboard page where the users are being loaded, and as a side effect the credentials and tenants are being loaded to perform some extra logic that is just required in the user management section.