### PR TITLE
Add See details action to cluster table

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -5,6 +5,7 @@ import ExternalLink from 'core/components/ExternalLink'
 import SimpleLink from 'core/components/SimpleLink'
 import ScaleIcon from '@material-ui/icons/TrendingUp'
 import UpgradeIcon from '@material-ui/icons/PresentToAll'
+import SeeDetailsIcon from '@material-ui/icons/Subject'
 import InsertChartIcon from '@material-ui/icons/InsertChart'
 import DescriptionIcon from '@material-ui/icons/Description'
 import { clustersCacheKey } from '../common/actions'
@@ -236,6 +237,11 @@ export const options = {
   multiSelection: false,
   deleteCond: both(isAdmin, canDeleteCluster),
   batchActions: [
+    {
+      icon: <SeeDetailsIcon />,
+      label: 'See details',
+      routeTo: rows => `/ui/kubernetes/infrastructure/clusters/${rows[0].uuid}`,
+    },
     {
       cond: both(isAdmin, canScaleMasters),
       icon: <ScaleIcon />,


### PR DESCRIPTION
This PR adds `See details` action to clusters table

Card: https://platform9.atlassian.net/browse/PMK-2163

<img width="893" alt="Screen Shot 2019-11-26 at 20 34 06" src="https://user-images.githubusercontent.com/1504544/69681222-304c6400-108c-11ea-97d6-a80223c60589.png">
