### PR TITLE
Form early validation issue

### DIFF
--- a/src/app/core/components/validatedForm/ValidatedForm.js
+++ b/src/app/core/components/validatedForm/ValidatedForm.js
@@ -48,7 +48,11 @@ class ValidatedForm extends PureComponent {
    * This function will be called by the child components when they are initialized.
    */
   defineField = moize(field => spec => {
-    this.setState(setStateLens(spec, ['fields', field]))
+    this.setState(setStateLens(spec, ['fields', field]), () => {
+      if (this.state.showingErrors) {
+        this.validateField(field)(null)
+      }
+    })
   })
 
   removeField = field => {
@@ -108,6 +112,10 @@ class ValidatedForm extends PureComponent {
    */
   validateField = moize(field => () => {
     const { fields, values } = this.state
+    // Skip validation if the field has not been defined yet
+    if (!fields.hasOwnProperty(field)) {
+      return true
+    }
     const fieldValue = values[field]
     const { validations } = fields[field]
 

--- a/src/app/plugins/openstack/components/regions/RegionChooser.js
+++ b/src/app/plugins/openstack/components/regions/RegionChooser.js
@@ -31,10 +31,7 @@ const RegionChooser = props => {
     if (lastRegion && find(propEq('id', lastRegion.id), regions)) {
       return lastRegion.id
     }
-    // Old UI requires lastRegion to initialize
-    const defaultRegion = pipe(head, prop('id'))(regions)
-    updatePrefs({ lastRegion: defaultRegion })
-    return defaultRegion
+    return pipe(head, prop('id'))(regions)
   }, [regions, lastRegion, selectedRegion])
 
   const handleRegionSelect = useCallback(async region => {


### PR DESCRIPTION
Fixed an issue on delayed field definition when the form is in active validation state (ie. the user has tried to submit the form) before all the fields defined in the form values have been added to it, which caused an uncaught exception and crashed the app with a white screen. 
To fix this I check the field existence in the form upon validation, and then I perform the validation when the field is defined (if the form is in validation state)

Example of the issue:
![validation-error](https://user-images.githubusercontent.com/339539/69814647-3cb8f400-1227-11ea-9e70-91ff151df85b.gif)

Also fixed warning caused by https://github.com/platform9/pf9-ui-plugin/pull/521:
![image](https://user-images.githubusercontent.com/339539/69815744-8efb1480-1229-11ea-987f-31ea78e0ca42.png)
