### PR TITLE
Change instructions on monitoring page on no data

### DIFF
--- a/src/app/core/helpers/createCRUDComponents.js
+++ b/src/app/core/helpers/createCRUDComponents.js
@@ -41,6 +41,7 @@ const createCRUDComponents = options => {
     rowActions = [],
     uniqueIdentifier = 'id',
     addText = 'Add',
+    emptyText = 'No data found',
     addButton,
     addUrl,
     AddDialog,
@@ -69,6 +70,7 @@ const createCRUDComponents = options => {
       <ListTable
         {...rest}
         onAdd={null}
+        emptyText={emptyText}
         columns={columns}
         deleteCond={deleteCond}
         deleteDisabledInfo={deleteDisabledInfo}

--- a/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
+++ b/src/app/plugins/kubernetes/components/prometheus/PrometheusInstances.js
@@ -32,7 +32,8 @@ export const columns = [
 export const options = {
   cacheKey: prometheusInstancesCacheKey,
   addUrl: '/ui/kubernetes/prometheus/instances/add',
-  addText: 'New Instance',
+  addText: 'New Monitoring Stack',
+  emptyText: 'Please enable monitoring on at least one cluster',
   columns,
   editUrl: '/ui/kubernetes/prometheus/instances/edit',
   name: 'PrometheusInstances',


### PR DESCRIPTION
This change customizes the no data text for monitoring list page.
Unlike other pages, monitoring  feature is not enabled by default.

When monitoring is enabled on a cluster, the backend deploys one prometheus instance for monitoring kubernets and worker nodes. Its absence indicates that monitoring feature is not properly enabled. 
This change also updates the add button text.