### PR TITLE
Fix invalid hex error

### DIFF
--- a/src/app/core/themes/defaultTheme.js
+++ b/src/app/core/themes/defaultTheme.js
@@ -195,7 +195,7 @@ const theme = {
     },
     card: {
       background: 'rgba(2, 194, 172, 0.1)',
-      status: 'rgba(243, 243, 243, 1.0)',
+      status: '#f3f3f3',
     },
     wizard: {
       dark: '#02c2ac',


### PR DESCRIPTION
Quick fix for
![image](https://user-images.githubusercontent.com/339539/70371160-364f0a00-1902-11ea-9606-37ed0da2a0f2.png)

This was caused by:

![image](https://user-images.githubusercontent.com/339539/70371162-3cdd8180-1902-11ea-84f1-02c87f900bc0.png)

`theme.palette.status.card` was returning a rgba value instead of a hex