### PR TITLE
PMK-2394: Added code to not show tooltip if component is in disabled state

### DIFF
--- a/src/app/core/components/InfoTooltip.js
+++ b/src/app/core/components/InfoTooltip.js
@@ -60,11 +60,16 @@ InfoTooltip.propTypes = {
 }
 
 // We need to use `forwardRef` as a workaround of an issue with material-ui Tooltip https://github.com/gregnb/mui-datatables/issues/595
-const withInfoTooltip = Component => React.forwardRef(({ info, ...props }, ref) =>
-  <InfoTooltip info={info}>
-    <Component {...props} ref={ref} />
-  </InfoTooltip>,
-)
+const withInfoTooltip = (Component) =>
+  React.forwardRef(({ info, disabled, ...props }, ref) =>
+    disabled ? (
+      <Component disabled {...props} ref={ref} />
+    ) : (
+      <InfoTooltip info={info}>
+        <Component {...props} ref={ref} />
+      </InfoTooltip>
+    ),
+  )
 
 export { withInfoTooltip }
 

--- a/src/app/core/components/validatedForm/PicklistField.js
+++ b/src/app/core/components/validatedForm/PicklistField.js
@@ -23,7 +23,7 @@ const useStyles = makeStyles(() => ({
 const PicklistField = React.forwardRef(({
   DropdownComponent, id, info, placement,
   label, required, value, showNone, updateFieldValue, getCurrentValue,
-  hasError, errorMessage, options, ...restProps
+  hasError, errorMessage, options, disabled, ...restProps
 }, ref) => {
   const classes = useStyles()
   const [open, setOpen] = React.useState(false)
@@ -35,6 +35,7 @@ const PicklistField = React.forwardRef(({
     <InfoTooltip open={open} info={info} placement={placement}>
       <DropdownComponent
         {...restProps}
+        disabled={disabled}
         InputLabelProps={{
           classes: {
             root: classes.label,
@@ -42,9 +43,9 @@ const PicklistField = React.forwardRef(({
         }}
         formField
         label={required ? `${label} *` : label}
-        onMouseEnter={openTooltip}
+        onMouseEnter={!disabled ? openTooltip : undefined}
         onMouseLeave={closeTooltip}
-        onFocus={openTooltip}
+        onFocus={!disabled ? openTooltip : undefined}
         onBlur={closeTooltip}
         onClick={closeTooltip}
         ref={ref}


### PR DESCRIPTION
Added code to not show tooltip if the component is in a disabled state

![DoNotShowToolTipifComponentIsDisabled](https://user-images.githubusercontent.com/8025925/70434062-3c331f80-1aa9-11ea-913f-8793409a7524.gif)
