### PR TITLE
Disable incomplete managed apps featureset

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -22,7 +22,6 @@ import { both, prop } from 'ramda'
 import PrometheusAddonDialog from 'k8s/components/prometheus/PrometheusAddonDialog'
 import ClusterUpgradeDialog from 'k8s/components/infrastructure/clusters/ClusterUpgradeDialog'
 import ClusterSync from './ClusterSync'
-import LoggingAddonDialog from 'k8s/components/logging/LoggingAddonDialog'
 import { Typography } from '@material-ui/core'
 import { makeStyles } from '@material-ui/styles'
 import {
@@ -286,12 +285,14 @@ export const options = {
       label: 'Monitoring',
       dialog: PrometheusAddonDialog,
     },
-    {
-      cond: isAdmin,
+    // Disable logging till all CRUD features for log datastores are implemented.
+    /* {
+      
+      cond: false,
       icon: <DescriptionIcon />,
       label: 'Logging',
       dialog: LoggingAddonDialog,
-    },
+    }, */
   ],
 }
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -7,7 +7,6 @@ import ScaleIcon from '@material-ui/icons/TrendingUp'
 import UpgradeIcon from '@material-ui/icons/PresentToAll'
 import SeeDetailsIcon from '@material-ui/icons/Subject'
 import InsertChartIcon from '@material-ui/icons/InsertChart'
-import DescriptionIcon from '@material-ui/icons/Description'
 import { clustersCacheKey } from '../common/actions'
 import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import { capitalizeString } from 'utils/misc'
@@ -287,7 +286,6 @@ export const options = {
     },
     // Disable logging till all CRUD features for log datastores are implemented.
     /* {
-      
       cond: false,
       icon: <DescriptionIcon />,
       label: 'Logging',

--- a/src/app/plugins/kubernetes/index.js
+++ b/src/app/plugins/kubernetes/index.js
@@ -458,8 +458,9 @@ Kubernetes.registerPlugin = pluginManager => {
     },
     { name: 'Storage Classes', icon: 'hdd', link: { path: '/storage_classes' } },
     { name: 'Namespaces', icon: 'object-group', link: { path: '/namespaces' } },
-    { name: 'Monitoring (beta)', icon: 'chart-area', link: { path: '/prometheus' } },
-    { name: 'Logging (beta)', icon: 'clipboard-list', link: { path: '/logging' } },
+    // TODO: Disabled till all CRUD operations are implemented
+    // { name: 'Monitoring (beta)', icon: 'chart-area', link: { path: '/prometheus' } },
+    // { name: 'Logging (beta)', icon: 'clipboard-list', link: { path: '/logging' } },
     {
       name: 'RBAC',
       icon: 'user-shield',


### PR DESCRIPTION
In preparation for launch, following features are to be disabled due to incompleteness
1. Monitoring tab
2. Logging tab and enable/disable button.
These features can be enabled after full CRUD featureset for it is implemented.