### PR TITLE
Link to cluster node details

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDetailsPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDetailsPage.js
@@ -29,8 +29,8 @@ const ClusterDetailsPage = () => {
       « Back to Cluster List
     </SimpleLink></>}>
     <Tabs>
-      <Tab value="info" label="Info"><ClusterInfo /></Tab>
-      <Tab value="nodes" label="Nodes"><ClusterNodes /></Tab>
+      <Tab value="configuration" label="Configuration"><ClusterInfo /></Tab>
+      <Tab value="nodesAndHealthInfo" label="Nodes & Health Info"><ClusterNodes /></Tab>
     </Tabs>
   </PageContainer>
 }

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -49,7 +49,11 @@ const renderCloudProviderType = (type, cluster) => {
   return capitalizeString(type)
 }
 
-const renderConnectionStatus = (_, { taskStatus, nodes, progressPercent }) => {
+const getNodesDetailsUrl = (uuid) => `/ui/kubernetes/infrastructure/clusters/${uuid}#nodesAndHealthInfo`
+
+const renderConnectionStatus = (_, { taskStatus, nodes, progressPercent, uuid }) => {
+  const nodesDetailsUrl = getNodesDetailsUrl(uuid)
+
   if (isTransientState(taskStatus, nodes)) {
     return renderTransientStatus(taskStatus, nodes, progressPercent)
   }
@@ -61,7 +65,7 @@ const renderConnectionStatus = (_, { taskStatus, nodes, progressPercent }) => {
     <ClusterStatusSpan
       title={fields.message}
       status={fields.clusterStatus}>
-      {fields.label}
+      <SimpleLink src={nodesDetailsUrl}>{fields.label}</SimpleLink>
     </ClusterStatusSpan>
   )
 }
@@ -127,7 +131,7 @@ const renderHealthStatus = (status, {
   }
 
   if (isSteadyState(taskStatus, nodes)) {
-    const nodesDetailsUrl = `/ui/kubernetes/infrastructure/clusters/${uuid}#nodesAndHealthInfo`
+    const nodesDetailsUrl = getNodesDetailsUrl(uuid)
     return renderClusterHealthStatus(healthyMasterNodes, nodes, numMasters, numWorkers, taskError, nodesDetailsUrl)
   }
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -87,15 +87,15 @@ const renderTransientStatus = (taskStatus, nodes, progressPercent) => {
   )
 }
 
-const renderErrorStatus = (taskError) =>
+const renderErrorStatus = (taskError, nodesDetailsUrl) =>
   <ClusterStatusSpan
     title={taskError}
     status='error'
   >
-    Error
+    <SimpleLink src={nodesDetailsUrl}>Error</SimpleLink>
   </ClusterStatusSpan>
 
-const renderClusterHealthStatus = (healthyMasterNodes, nodes, numMasters, numWorkers, taskError) => {
+const renderClusterHealthStatus = (healthyMasterNodes, nodes, numMasters, numWorkers, taskError, nodesDetailsUrl) => {
   const [healthStatus, message] = getHealthStatusAndMessage(healthyMasterNodes, nodes, numMasters, numWorkers)
   const fields = clusterHealthStatusFields[healthStatus]
 
@@ -105,9 +105,9 @@ const renderClusterHealthStatus = (healthyMasterNodes, nodes, numMasters, numWor
         title={message}
         status={fields.status}
       >
-        {fields.label}
+        <SimpleLink src={nodesDetailsUrl}>{fields.label}</SimpleLink>
       </ClusterStatusSpan>
-      {taskError && renderErrorStatus(taskError)}
+      {taskError && renderErrorStatus(taskError, nodesDetailsUrl)}
     </div>
   )
 }
@@ -120,13 +120,15 @@ const renderHealthStatus = (status, {
   nodes,
   numMasters,
   numWorkers,
+  uuid,
 }) => {
   if (isTransientState(taskStatus, nodes)) {
     return renderTransientStatus(taskStatus, nodes, progressPercent)
   }
 
   if (isSteadyState(taskStatus, nodes)) {
-    return renderClusterHealthStatus(healthyMasterNodes, nodes, numMasters, numWorkers, taskError)
+    const nodesDetailsUrl = `/ui/kubernetes/infrastructure/clusters/${uuid}#nodesAndHealthInfo`
+    return renderClusterHealthStatus(healthyMasterNodes, nodes, numMasters, numWorkers, taskError, nodesDetailsUrl)
   }
 
   return status && <ClusterStatusSpan>{capitalizeString(status)}</ClusterStatusSpan>


### PR DESCRIPTION
This PR:
- Renames ClusterNodes tabs to `Configuration` and `Nodes & Health Info`
- Clicking on `Connection Status` or `Health Status` redirects to `Nodes & Health Info`

<img width="580" alt="Screen Shot 2019-12-10 at 17 45 43" src="https://user-images.githubusercontent.com/1504544/70567580-f80d5100-1b74-11ea-8103-7642130bfb09.png">
<img width="279" alt="Screen Shot 2019-12-10 at 17 45 59" src="https://user-images.githubusercontent.com/1504544/70567581-f80d5100-1b74-11ea-91de-0a9a7689fa50.png">
