### PR TITLE
Reimplement health status to not use numMasters and numWorkers anymore

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatusUtils.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatusUtils.ts
@@ -57,10 +57,11 @@ export const connectionStatusFieldsTable: {[status in ConnectionStatus]: Connect
 }
 
 export function getHealthStatusAndMessage (
-  healthyMasterNodes = [],
   nodes: Node[] = [],
-  numMasters: number,
-  numWorkers: number,
+  masterNodes: Node[] = [],
+  workerNodes: Node[] = [],
+  healthyMasterNodes: Node[] = [],
+  healthyWorkerNodes: Node[] = [],
 ): [HealthStatus, string] {
   const connectionStatus = getConnectionStatus(nodes)
 
@@ -69,11 +70,11 @@ export function getHealthStatusAndMessage (
   }
 
   const healthyMasterNodesCount = healthyMasterNodes.length
-  const healthyWorkersNodesCount = nodes.filter(node => !node.isMaster && node.status === 'ok').length
-  const mastersQuorumNumber = numMasters // TODO: how to get quorum number of masters?
-  const workersQuorumNumber = Math.ceil(numWorkers/2)
-  const mastersHealthStatus = getNodesHealthStatus(healthyMasterNodesCount, numMasters, mastersQuorumNumber)
-  const workersHealthStatus = getNodesHealthStatus(healthyWorkersNodesCount, numWorkers, workersQuorumNumber)
+  const healthyWorkersNodesCount = healthyWorkerNodes.length
+  const mastersQuorumNumber = healthyMasterNodesCount // TODO: how to get quorum number of masters?
+  const workersQuorumNumber = Math.ceil(workerNodes.length/2)
+  const mastersHealthStatus = getNodesHealthStatus(healthyMasterNodesCount, masterNodes.length, mastersQuorumNumber)
+  const workersHealthStatus = getNodesHealthStatus(healthyWorkersNodesCount, workerNodes.length, workersQuorumNumber)
   const healthStatusAndMessage = clusterHealthStatusAndMessageTable.find(item =>
     item.mastersHealthStatus === mastersHealthStatus &&
     item.workersHealthStatus === workersHealthStatus

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatusUtils.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatusUtils.ts
@@ -56,13 +56,19 @@ export const connectionStatusFieldsTable: {[status in ConnectionStatus]: Connect
   },
 }
 
-export function getHealthStatusAndMessage (
-  nodes: Node[] = [],
-  masterNodes: Node[] = [],
-  workerNodes: Node[] = [],
-  healthyMasterNodes: Node[] = [],
-  healthyWorkerNodes: Node[] = [],
-): [HealthStatus, string] {
+export function getHealthStatusAndMessage ({
+  nodes = [],
+  masterNodes = [],
+  workerNodes = [],
+  healthyMasterNodes = [],
+  healthyWorkerNodes = [],
+}: {
+  nodes: Node[]
+  masterNodes: Node[]
+  workerNodes: Node[]
+  healthyMasterNodes: Node[]
+  healthyWorkerNodes: Node[]
+}): [HealthStatus, string] {
   const connectionStatus = getConnectionStatus(nodes)
 
   if (connectionStatus === 'disconnected') {

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -99,8 +99,8 @@ const renderErrorStatus = (taskError, nodesDetailsUrl) =>
     <SimpleLink src={nodesDetailsUrl}>Error</SimpleLink>
   </ClusterStatusSpan>
 
-const renderClusterHealthStatus = (nodes, masterNodes, workerNodes, healthyMasterNodes, healthyWorkerNodes, taskError, nodesDetailsUrl) => {
-  const [healthStatus, message] = getHealthStatusAndMessage(nodes, masterNodes, workerNodes, healthyMasterNodes, healthyWorkerNodes)
+const renderClusterHealthStatus = ({ nodes, masterNodes, workerNodes, healthyMasterNodes, healthyWorkerNodes, taskError, nodesDetailsUrl }) => {
+  const [healthStatus, message] = getHealthStatusAndMessage({ nodes, masterNodes, workerNodes, healthyMasterNodes, healthyWorkerNodes })
   const fields = clusterHealthStatusFields[healthStatus]
 
   return (
@@ -133,7 +133,7 @@ const renderHealthStatus = (status, {
 
   if (isSteadyState(taskStatus, nodes)) {
     const nodesDetailsUrl = getNodesDetailsUrl(uuid)
-    return renderClusterHealthStatus(nodes, masterNodes, workerNodes, healthyMasterNodes, healthyWorkerNodes, taskError, nodesDetailsUrl)
+    return renderClusterHealthStatus({ nodes, masterNodes, workerNodes, healthyMasterNodes, healthyWorkerNodes, taskError, nodesDetailsUrl })
   }
 
   return status && <ClusterStatusSpan>{capitalizeString(status)}</ClusterStatusSpan>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -99,8 +99,8 @@ const renderErrorStatus = (taskError, nodesDetailsUrl) =>
     <SimpleLink src={nodesDetailsUrl}>Error</SimpleLink>
   </ClusterStatusSpan>
 
-const renderClusterHealthStatus = (healthyMasterNodes, nodes, numMasters, numWorkers, taskError, nodesDetailsUrl) => {
-  const [healthStatus, message] = getHealthStatusAndMessage(healthyMasterNodes, nodes, numMasters, numWorkers)
+const renderClusterHealthStatus = (nodes, masterNodes, workerNodes, healthyMasterNodes, healthyWorkerNodes, taskError, nodesDetailsUrl) => {
+  const [healthStatus, message] = getHealthStatusAndMessage(nodes, masterNodes, workerNodes, healthyMasterNodes, healthyWorkerNodes)
   const fields = clusterHealthStatusFields[healthStatus]
 
   return (
@@ -120,10 +120,11 @@ const renderHealthStatus = (status, {
   taskStatus,
   taskError,
   progressPercent,
-  healthyMasterNodes,
   nodes,
-  numMasters,
-  numWorkers,
+  masterNodes,
+  workerNodes,
+  healthyMasterNodes,
+  healthyWorkerNodes,
   uuid,
 }) => {
   if (isTransientState(taskStatus, nodes)) {
@@ -132,7 +133,7 @@ const renderHealthStatus = (status, {
 
   if (isSteadyState(taskStatus, nodes)) {
     const nodesDetailsUrl = getNodesDetailsUrl(uuid)
-    return renderClusterHealthStatus(healthyMasterNodes, nodes, numMasters, numWorkers, taskError, nodesDetailsUrl)
+    return renderClusterHealthStatus(nodes, masterNodes, workerNodes, healthyMasterNodes, healthyWorkerNodes, taskError, nodesDetailsUrl)
   }
 
   return status && <ClusterStatusSpan>{capitalizeString(status)}</ClusterStatusSpan>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
@@ -9,7 +9,7 @@ import {
 import { filterIf, isTruthy, updateWith, adjustWith } from 'utils/fp'
 import { mapAsync } from 'utils/async'
 import {
-  pluck, pathOr, pick, pipe, either, propSatisfies, compose, path, propEq, mergeLeft,
+  pluck, pathOr, pick, pipe, either, propSatisfies, compose, path, propEq, mergeLeft, partition,
 } from 'ramda'
 import { rawNodesCacheKey } from 'k8s/components/infrastructure/nodes/actions'
 
@@ -182,8 +182,8 @@ export const clusterActions = createCRUDActions(clustersCacheKey, {
         disk: calcNodesTotals('usage.disk.current', 'usage.disk.max'),
         grafanaLink: hasPrometheusEnabled(cluster) ? grafanaLink : null,
       }
-      const masterNodes = nodesInCluster.filter(node => node.isMaster === 1)
-      const workerNodes = nodesInCluster.filter(node => node.isMaster === 0)
+      const isMasterNode = node => node.isMaster === 1
+      const [masterNodes, workerNodes] = partition(isMasterNode, nodesInCluster)
       const healthyMasterNodes = masterNodes.filter(node => node.status === 'ok')
       const healthyWorkerNodes = workerNodes.filter(node => node.status === 'ok')
       const hasMasterNode = healthyMasterNodes.length > 0

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
@@ -183,8 +183,11 @@ export const clusterActions = createCRUDActions(clustersCacheKey, {
         grafanaLink: hasPrometheusEnabled(cluster) ? grafanaLink : null,
       }
       const masterNodes = nodesInCluster.filter(node => node.isMaster === 1)
+      const workerNodes = nodesInCluster.filter(node => node.isMaster === 0)
       const healthyMasterNodes = masterNodes.filter(
-        node => node.status === 'ok' && node.api_responding === 1)
+        node => node.status === 'ok')
+      const healthyWorkerNodes = workerNodes.filter(
+        node => node.status === 'ok')
       const hasMasterNode = healthyMasterNodes.length > 0
       const clusterOk = nodesInCluster.length > 0 && cluster.status === 'ok'
       const fuzzyBools = ['allowWorkloadsOnMaster', 'privileged', 'appCatalogEnabled'].reduce(
@@ -207,8 +210,10 @@ export const clusterActions = createCRUDActions(clustersCacheKey, {
         version: version || 'N/A',
         nodes: nodesInCluster,
         masterNodes,
+        workerNodes,
         progressPercent,
         healthyMasterNodes,
+        healthyWorkerNodes,
         hasMasterNode,
         highlyAvailable: healthyMasterNodes.length > 2,
         links: {

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
@@ -184,10 +184,8 @@ export const clusterActions = createCRUDActions(clustersCacheKey, {
       }
       const masterNodes = nodesInCluster.filter(node => node.isMaster === 1)
       const workerNodes = nodesInCluster.filter(node => node.isMaster === 0)
-      const healthyMasterNodes = masterNodes.filter(
-        node => node.status === 'ok')
-      const healthyWorkerNodes = workerNodes.filter(
-        node => node.status === 'ok')
+      const healthyMasterNodes = masterNodes.filter(node => node.status === 'ok')
+      const healthyWorkerNodes = workerNodes.filter(node => node.status === 'ok')
       const hasMasterNode = healthyMasterNodes.length > 0
       const clusterOk = nodesInCluster.length > 0 && cluster.status === 'ok'
       const fuzzyBools = ['allowWorkloadsOnMaster', 'privileged', 'appCatalogEnabled'].reduce(


### PR DESCRIPTION
This PR reimplements the way `Health Status` is calculated so that we don't use `numMasters` and `numWorkers` anymore. We had to do this because BareOS clusters don't have these properties filled.