### PR TITLE
Fix login in simulator and theme manager

### DIFF
--- a/src/app/plugins/theme/components/examples/TablesExample.js
+++ b/src/app/plugins/theme/components/examples/TablesExample.js
@@ -4,7 +4,9 @@ import Panel from '../Panel'
 import faker from 'faker'
 import moment from 'moment'
 import { formattedValue } from 'core/utils/formatters'
-import { range } from 'ramda'
+import { range, pick } from 'ramda'
+import { listTablePrefs } from 'app/constants'
+import { createUsePrefParamsHook } from 'core/hooks/useParams'
 
 const nop = () => {}
 export const randomInt = (min, max) =>
@@ -19,7 +21,7 @@ const data = range(1, randomInt(20, 30)).map(id => ({
   date: faker.date.past(),
   storage: faker.finance.amount(),
   description: faker.lorem.sentence(),
-  active: faker.random.boolean()
+  active: faker.random.boolean(),
 }))
 
 const loadMockData = () => data
@@ -33,33 +35,45 @@ const columns = [
     label: 'Date',
     render: value => moment(value).format('LL'),
     sortWith: (prevDate, nextDate) =>
-      moment(prevDate).isBefore(nextDate) ? 1 : -1
+      moment(prevDate).isBefore(nextDate) ? 1 : -1,
   },
   {
     id: 'storage',
     label: 'Storage',
     render: value => formattedValue(value),
     sortWith: (prevValue, nextValue) =>
-      +prevValue > +nextValue ? 1 : -1
+      +prevValue > +nextValue ? 1 : -1,
   },
   { id: 'description', label: 'Description', sort: false, display: false },
-  { id: 'active', label: 'Active', sort: false, display: false }
+  { id: 'active', label: 'Active', sort: false, display: false },
 ]
+const usePrefParams = createUsePrefParamsHook('ThemeTableExample', listTablePrefs)
+const ListPage = ({ ListContainer }) => {
+  return () => {
+    const { params, getParamsUpdater } = usePrefParams()
+    return <ListContainer
+      getParamsUpdater={getParamsUpdater}
+      data={data}
+      columns={columns}
+      {...pick(listTablePrefs, params)}
+    />
+  }
+}
 
 export const options = {
   columns,
-  cacheKey: 'example',
   deleteFn: nop,
   editUrl: '/ui/theme/examples/edit',
   loaderFn: loadMockData,
   title: 'Tables Example',
+  ListPage,
 }
 
-const { ListPage } = createCRUDComponents(options)
+const { ListPage: TablesExampleContent } = createCRUDComponents(options)
 
 const TablesExample = ({ expanded = false }) => (
   <Panel title="Tables" defaultExpanded={expanded}>
-    <ListPage />
+    <TablesExampleContent />
   </Panel>
 )
 

--- a/src/server/models/openstack/Token.js
+++ b/src/server/models/openstack/Token.js
@@ -2,6 +2,7 @@
 import context from '../../context'
 import ActiveModel from '../ActiveModel'
 import { findById, mapAsJson, jsonOrNull } from '../../helpers'
+import moment from 'moment'
 
 const coll = () => context.tokens
 
@@ -27,6 +28,8 @@ class Token extends ActiveModel {
   asJson = () => {
     const json = {
       ...super.asJson(),
+      expires_at: moment().add(1, 'day').format(),
+      issued_at: moment().format(),
       project: jsonOrNull(this.tenant),
       roles: mapAsJson(this.roles),
       user: jsonOrNull(this.user),

--- a/src/server/models/openstack/__tests__/Token.test.js
+++ b/src/server/models/openstack/__tests__/Token.test.js
@@ -61,7 +61,7 @@ describe('Token', () => {
     it('creates a JSON version of the Token', () => {
       const token = new Token()
       const json = token.asJson()
-      expect(Object.keys(json)).toEqual(['id', 'project', 'roles', 'user'])
+      expect(Object.keys(json)).toEqual(['id', 'expires_at', 'issued_at', 'project', 'roles', 'user'])
     })
   })
 })


### PR DESCRIPTION
* Fixed the incorrect `useDataLoader` hook use by the `TablesExample` component
* Returning `expire_at` and `issued_at` fields in the authentication response to prevent instantly logging out the user upon login