### PR TITLE
Fix outlined inputs height and font size

### DIFF
--- a/src/app/core/themes/defaultTheme.js
+++ b/src/app/core/themes/defaultTheme.js
@@ -52,11 +52,11 @@ const theme = {
     },
     MuiOutlinedInput: {
       root: {
-        fontSize: '16px',
+        fontSize: '14px',
         minWidth: '120px',
       },
       input: {
-        padding: '12px 16px',
+        padding: '8px 16px',
       },
     },
     MuiMenuItem: {


### PR DESCRIPTION
Outlined inputs height were too tall and fonts too big and therefore looking inconsistent with other elements of the UI

Before:
![image](https://user-images.githubusercontent.com/339539/70826639-029c4480-1e1a-11ea-90d5-b6d6eeb67e69.png)

After:
![image](https://user-images.githubusercontent.com/339539/70826329-37f46280-1e19-11ea-8b58-c041828d3597.png)