### PR TITLE
Remove duplicated contextUpdater "updateRemoteSupport"

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/nodes/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/nodes/actions.js
@@ -70,32 +70,3 @@ export const deAuthNode = createContextUpdater('nodes', async (node, prevItems) 
     return `Successfully de-authorized node ${node.name} (${node.primaryIp})`
   },
 })
-
-// Important: How do I get this function to also trigger a nodes list refresh?
-export const updateRemoteSupport = createContextUpdater(combinedHostsCacheKey, async (data, currentItems) => {
-  const { id, enableSupport } = data
-  const host = currentItems.find(x => x.id === id)
-  const supportRoleName = 'pf9-support'
-  // If the role push/delete fails, how do I handle that?
-  // Temporary solution using the pre-existing host object
-  // Future solution will require consumption of pf9-notifications for reactive updates
-  if (enableSupport) {
-    await resmgr.addRole(id, supportRoleName)
-    return {
-      ...host,
-      roles: [...host.roles, supportRoleName],
-      roleStatus: 'converging',
-      uiState: 'pending',
-      supportRole: true
-    }
-  } else {
-    await resmgr.removeRole(id, supportRoleName)
-    return {
-      ...host,
-      roles: host.roles.filter(role => role !== supportRoleName),
-      roleStatus: 'converging',
-      uiState: 'pending',
-      supportRole: false
-    }
-  }
-}, { operation: 'update' })


### PR DESCRIPTION
Already defined in `src/app/plugins/kubernetes/components/infrastructure/common/actions.js`