### PR TITLE
PMK-2439 Change success update operations messages

### DIFF
--- a/src/app/core/helpers/createContextUpdater.js
+++ b/src/app/core/helpers/createContextUpdater.js
@@ -62,12 +62,12 @@ function createContextUpdater (cacheKey, dataUpdaterFn, options = {}) {
     operation = 'any',
     contextLoader,
     successMessage = (updatedItems, prevItems, params, operation) =>
-      `Successfully ${switchCase(
+      `${entityName} ${switchCase(
         'updated',
         ['create', 'created'],
         ['update', 'updated'],
         ['delete', 'deleted'],
-      )(operation)} ${entityName}`,
+      )(operation)} successfully`,
     errorMessage = (prevItems, params, catchedErr, operation) => {
       const action = switchCase(
         'update',

--- a/src/app/plugins/kubernetes/components/userManagement/tenants/actions.js
+++ b/src/app/plugins/kubernetes/components/userManagement/tenants/actions.js
@@ -1,8 +1,10 @@
 import ApiClient from 'api-client/ApiClient'
-import { keys, pluck, pipe, prop, find, propEq, filter, always, isNil, reject, map } from 'ramda'
+import {
+  keys, pluck, pipe, prop, find, propEq, filter, always, isNil, reject, map, last,
+} from 'ramda'
 import { namespacesCacheKey } from 'k8s/components/namespaces/actions'
 import createCRUDActions from 'core/helpers/createCRUDActions'
-import { filterIf, pathStr, emptyArr } from 'utils/fp'
+import { filterIf, pathStr, emptyArr, objSwitchCase } from 'utils/fp'
 import createContextLoader from 'core/helpers/createContextLoader'
 import { tryCatchAsync } from 'utils/async'
 import { mngmUsersCacheKey } from 'k8s/components/userManagement/users/actions'
@@ -119,6 +121,17 @@ export const mngmTenantActions = createCRUDActions(mngmTenantsCacheKey, {
   refetchCascade: true,
   requiredRoles: 'admin',
   entityName: 'Tenant',
+  successMessage: (updatedItems, prevItems, { id }, operation) => objSwitchCase({
+    create: `Tenant ${prop('name', last(updatedItems))} created successfully`,
+    update: `Tenant ${pipe(
+      find(propEq('id', id)),
+      prop('name'),
+    )(prevItems)} updated successfully`,
+    delete: `Tenant ${pipe(
+      find(propEq('id', id)),
+      prop('name'),
+    )(prevItems)} deleted successfully`,
+  })(operation),
 })
 
 export const mngmTenantRoleAssignmentsCacheKey = 'managementTenantRoleAssignments'

--- a/src/app/plugins/kubernetes/components/userManagement/users/actions.js
+++ b/src/app/plugins/kubernetes/components/userManagement/users/actions.js
@@ -5,9 +5,9 @@ import {
 } from 'k8s/components/userManagement/tenants/actions'
 import {
   partition, pluck, map, head, innerJoin, uniq, prop, pipe, find, propEq, when, isNil, always,
-  filter, flatten, groupBy, values, omit, keys, reject,
+  filter, flatten, groupBy, values, omit, keys, reject, last,
 } from 'ramda'
-import { emptyObj, upsertAllBy, emptyArr, pathStr } from 'utils/fp'
+import { emptyObj, upsertAllBy, emptyArr, pathStr, objSwitchCase } from 'utils/fp'
 import { uuidRegex } from 'app/constants'
 import createContextLoader from 'core/helpers/createContextLoader'
 import { castBoolToStr } from 'utils/misc'
@@ -176,6 +176,17 @@ export const mngmUserActions = createCRUDActions(mngmUsersCacheKey, {
   },
   refetchCascade: true,
   entityName: 'User',
+  successMessage: (updatedItems, prevItems, { id }, operation) => objSwitchCase({
+    create: `User ${prop('name', last(updatedItems))} created successfully`,
+    update: `User ${pipe(
+      find(propEq('id', id)),
+      prop('name'),
+    )(prevItems)} updated successfully`,
+    delete: `User ${pipe(
+      find(propEq('id', id)),
+      prop('name'),
+    )(prevItems)} deleted successfully`,
+  })(operation),
 })
 
 export const mngmUserRoleAssignmentsCacheKey = 'managementUserRoleAssignments'


### PR DESCRIPTION
* Changing default successful update/delete/create operation message to a more readable "XXX created successfully" instead of "Successfully created XXX"
* Customized success messages for update/delete/create operation messages of users/tenants to display the name of the updated user or tenant.