### PR TITLE
[PMK-2581] Fix network plugin field when creating a cluster

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
@@ -25,10 +25,7 @@ import {
 } from 'ramda'
 import { rawNodesCacheKey } from 'k8s/components/infrastructure/nodes/actions'
 import {
-  getMasterNodesHealthStatus,
-  getWorkerNodesHealthStatus,
-  getConnectionStatus,
-  getHealthStatus,
+  getMasterNodesHealthStatus, getWorkerNodesHealthStatus, getConnectionStatus, getHealthStatus,
 } from './ClusterStatusUtils'
 import { trackEvent } from 'utils/tracking'
 
@@ -232,6 +229,7 @@ const createGenericCluster = async (body, data, loadFromContext) => {
   if (data.networkPlugin === 'calico') {
     body.mtuSize = data.mtuSize
   }
+  body.networkPlugin = data.networkPlugin
   body.runtimeConfig = {
     default: '',
     all: 'api/all=true',


### PR DESCRIPTION
This fixes the issue with network plugin not being properly set when creating a new cluster:

![image](https://user-images.githubusercontent.com/339539/73736485-69cbda80-4773-11ea-83a2-19379ae826e2.png)
