### PR TITLE
[PMK-2670] Put cluster details tab as the first tab

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDetailsPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDetailsPage.js
@@ -138,6 +138,11 @@ const ClusterDetailsPage = () => {
         <PollingData hidden loading={loading} onReload={reload} refreshDuration={oneSecond * 10} />
         <ClusterStatusAndUsage cluster={cluster} loading={loading} />
         <Tabs>
+          <Tab value="clusterDetails" label="Cluster Details">
+            <div className={classes.tabContainer}>
+              <ClusterInfo />
+            </div>
+          </Tab>
           <Tab value="nodes" label="Nodes">
             <div className={classes.tabContainer}>
               <ClusterNodes />
@@ -146,11 +151,6 @@ const ClusterDetailsPage = () => {
           <Tab value="nodeHealth" label="Node Health">
             <div className={classes.tabContainer}>
               <NodeHealthWithTasksToggler />
-            </div>
-          </Tab>
-          <Tab value="clusterDetails" label="Cluster Details">
-            <div className={classes.tabContainer}>
-              <ClusterInfo />
             </div>
           </Tab>
         </Tabs>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -99,7 +99,7 @@ const renderStats = (_, { usage }) => {
 }
 
 const renderClusterDetailLink = (name, cluster) => (
-  <SimpleLink src={routes.cluster.nodes.path({ id: cluster.uuid })}>{name}</SimpleLink>
+  <SimpleLink src={routes.cluster.detail.path({ id: cluster.uuid })}>{name}</SimpleLink>
 )
 
 const renderBooleanField = (key) => (_, cluster) => (


### PR DESCRIPTION
Put cluster details tab as the first tab and use it by default when opening cluster details page