### PR TITLE
Hide the pf9-system:monitoring tag from the user

### DIFF
--- a/src/app/core/components/KeyValues.js
+++ b/src/app/core/components/KeyValues.js
@@ -7,7 +7,6 @@ import uuid from 'uuid'
 import { assoc } from 'ramda'
 import { makeStyles } from '@material-ui/styles'
 import { Button } from '@material-ui/core'
-import clsx from 'clsx'
 
 const useKeyValueStyles = makeStyles((theme) => ({
   root: {
@@ -28,9 +27,6 @@ const useKeyValueStyles = makeStyles((theme) => ({
   deleteButton: {
     flexGrow: 0,
     padding: 0,
-  },
-  hidden: {
-    display: 'none',
   },
 }))
 

--- a/src/app/core/components/KeyValues.js
+++ b/src/app/core/components/KeyValues.js
@@ -34,7 +34,7 @@ const useKeyValueStyles = makeStyles((theme) => ({
   },
 }))
 
-const KeyValue = ({ entry = {}, onChange, onDelete, keySuggestions, valueSuggestions, blacklistedTags }) => {
+const KeyValue = ({ entry = {}, onChange, onDelete, keySuggestions, valueSuggestions }) => {
   const classes = useKeyValueStyles()
   const [state, setState] = useState({
     id: entry.id || uuid.v4(),
@@ -49,9 +49,7 @@ const KeyValue = ({ entry = {}, onChange, onDelete, keySuggestions, valueSuggest
   const handleChange = (field) => (value) => setState(assoc(field, value, state))
 
   return (
-    <div className={clsx(classes.root, {
-      [classes.hidden]: blacklistedTags.includes(state.key)
-    })}>
+    <div className={classes.root}>
       <AutocompleteBase
         inputProps={{ size: 14 }}
         fullWidth
@@ -116,9 +114,11 @@ const KeyValues = ({ entries: _entries, onChange, keySuggestions, valueSuggestio
     onChange && onChange(sanitized)
   }, [entries])
 
+  const filteredEntries = entries.filter(entry => !blacklistedTags.includes(entry.key))
+
   return (
     <div className={classes.root}>
-      {entries.map((entry) => (
+      {filteredEntries.map((entry) => (
         <KeyValue
           key={entry.id}
           keySuggestions={keySuggestions}
@@ -126,7 +126,6 @@ const KeyValues = ({ entries: _entries, onChange, keySuggestions, valueSuggestio
           entry={entry}
           onChange={handleChange}
           onDelete={deleteEntry(entry.id)}
-          blacklistedTags={blacklistedTags}
         />
       ))}
       <Button className={classes.addButton} variant="text" onClick={addBlankEntry}>

--- a/src/app/core/components/KeyValues.js
+++ b/src/app/core/components/KeyValues.js
@@ -7,6 +7,7 @@ import uuid from 'uuid'
 import { assoc } from 'ramda'
 import { makeStyles } from '@material-ui/styles'
 import { Button } from '@material-ui/core'
+import clsx from 'clsx'
 
 const useKeyValueStyles = makeStyles((theme) => ({
   root: {
@@ -28,9 +29,12 @@ const useKeyValueStyles = makeStyles((theme) => ({
     flexGrow: 0,
     padding: 0,
   },
+  hidden: {
+    display: 'none',
+  },
 }))
 
-const KeyValue = ({ entry = {}, onChange, onDelete, keySuggestions, valueSuggestions }) => {
+const KeyValue = ({ entry = {}, onChange, onDelete, keySuggestions, valueSuggestions, hideMonitoringTags }) => {
   const classes = useKeyValueStyles()
   const [state, setState] = useState({
     id: entry.id || uuid.v4(),
@@ -45,7 +49,9 @@ const KeyValue = ({ entry = {}, onChange, onDelete, keySuggestions, valueSuggest
   const handleChange = (field) => (value) => setState(assoc(field, value, state))
 
   return (
-    <div className={classes.root}>
+    <div className={clsx(classes.root, {
+      [classes.hidden]: hideMonitoringTags && state.key === 'pf9-system:monitoring'
+    })}>
       <AutocompleteBase
         inputProps={{ size: 14 }}
         fullWidth
@@ -93,7 +99,7 @@ const newEntry = () => ({ id: uuid.v4(), key: '', value: '' })
 // filter it out before submitting. :(
 const addId = (entry) => ({ ...entry, id: uuid.v4() })
 
-const KeyValues = ({ entries: _entries, onChange, keySuggestions, valueSuggestions }) => {
+const KeyValues = ({ entries: _entries, onChange, keySuggestions, valueSuggestions, hideMonitoringTags }) => {
   const classes = useStyles()
   const entriesWithId = [...(_entries || []).map(addId), newEntry()]
   const [entries, setEntries] = useState(entriesWithId)
@@ -120,6 +126,7 @@ const KeyValues = ({ entries: _entries, onChange, keySuggestions, valueSuggestio
           entry={entry}
           onChange={handleChange}
           onDelete={deleteEntry(entry.id)}
+          hideMonitoringTags={hideMonitoringTags}
         />
       ))}
       <Button className={classes.addButton} variant="text" onClick={addBlankEntry}>
@@ -139,6 +146,7 @@ KeyValues.propTypes = {
   valueSuggestions: PropTypes.arrayOf(PropTypes.string),
   entries: PropTypes.arrayOf(EntryShape),
   onChange: PropTypes.func,
+  hideMonitoringTags: PropTypes.bool,
 }
 
 export default KeyValues

--- a/src/app/core/components/KeyValues.js
+++ b/src/app/core/components/KeyValues.js
@@ -34,7 +34,7 @@ const useKeyValueStyles = makeStyles((theme) => ({
   },
 }))
 
-const KeyValue = ({ entry = {}, onChange, onDelete, keySuggestions, valueSuggestions, hideMonitoringTags }) => {
+const KeyValue = ({ entry = {}, onChange, onDelete, keySuggestions, valueSuggestions, blacklistedTags }) => {
   const classes = useKeyValueStyles()
   const [state, setState] = useState({
     id: entry.id || uuid.v4(),
@@ -50,7 +50,7 @@ const KeyValue = ({ entry = {}, onChange, onDelete, keySuggestions, valueSuggest
 
   return (
     <div className={clsx(classes.root, {
-      [classes.hidden]: hideMonitoringTags && state.key === 'pf9-system:monitoring'
+      [classes.hidden]: blacklistedTags.includes(state.key)
     })}>
       <AutocompleteBase
         inputProps={{ size: 14 }}
@@ -99,7 +99,7 @@ const newEntry = () => ({ id: uuid.v4(), key: '', value: '' })
 // filter it out before submitting. :(
 const addId = (entry) => ({ ...entry, id: uuid.v4() })
 
-const KeyValues = ({ entries: _entries, onChange, keySuggestions, valueSuggestions, hideMonitoringTags }) => {
+const KeyValues = ({ entries: _entries, onChange, keySuggestions, valueSuggestions, blacklistedTags }) => {
   const classes = useStyles()
   const entriesWithId = [...(_entries || []).map(addId), newEntry()]
   const [entries, setEntries] = useState(entriesWithId)
@@ -126,7 +126,7 @@ const KeyValues = ({ entries: _entries, onChange, keySuggestions, valueSuggestio
           entry={entry}
           onChange={handleChange}
           onDelete={deleteEntry(entry.id)}
-          hideMonitoringTags={hideMonitoringTags}
+          blacklistedTags={blacklistedTags}
         />
       ))}
       <Button className={classes.addButton} variant="text" onClick={addBlankEntry}>
@@ -146,7 +146,7 @@ KeyValues.propTypes = {
   valueSuggestions: PropTypes.arrayOf(PropTypes.string),
   entries: PropTypes.arrayOf(EntryShape),
   onChange: PropTypes.func,
-  hideMonitoringTags: PropTypes.bool,
+  blacklistedTags: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default KeyValues

--- a/src/app/core/components/validatedForm/KeyValuesField.js
+++ b/src/app/core/components/validatedForm/KeyValuesField.js
@@ -21,7 +21,7 @@ const KeyValuesField = React.forwardRef(
       onChange,
       keySuggestions,
       valueSuggestions,
-      hideMonitoringTags,
+      blacklistedTags,
       ...restProps
     },
     ref,
@@ -33,7 +33,7 @@ const KeyValuesField = React.forwardRef(
         onChange={onChange}
         keySuggestions={keySuggestions}
         valueSuggestions={valueSuggestions}
-        hideMonitoringTags={hideMonitoringTags}
+        blacklistedTags={blacklistedTags}
       />
       {errorMessage && <FormHelperText>{errorMessage}</FormHelperText>}
     </FormControl>
@@ -45,9 +45,7 @@ KeyValuesField.propTypes = {
   label: PropTypes.string,
   onChange: PropTypes.func,
   initialValue: PropTypes.arrayOf(EntryShape),
-  // Hide pf9-system:monitoring tag from the display
-  // because that tag should be handled completely by appbert
-  hideMonitoringTags: PropTypes.bool,
+  blacklistedTags: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default compose(

--- a/src/app/core/components/validatedForm/KeyValuesField.js
+++ b/src/app/core/components/validatedForm/KeyValuesField.js
@@ -21,6 +21,7 @@ const KeyValuesField = React.forwardRef(
       onChange,
       keySuggestions,
       valueSuggestions,
+      hideMonitoringTags,
       ...restProps
     },
     ref,
@@ -32,6 +33,7 @@ const KeyValuesField = React.forwardRef(
         onChange={onChange}
         keySuggestions={keySuggestions}
         valueSuggestions={valueSuggestions}
+        hideMonitoringTags={hideMonitoringTags}
       />
       {errorMessage && <FormHelperText>{errorMessage}</FormHelperText>}
     </FormControl>
@@ -43,6 +45,9 @@ KeyValuesField.propTypes = {
   label: PropTypes.string,
   onChange: PropTypes.func,
   initialValue: PropTypes.arrayOf(EntryShape),
+  // Hide pf9-system:monitoring tag from the display
+  // because that tag should be handled completely by appbert
+  hideMonitoringTags: PropTypes.bool,
 }
 
 export default compose(

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -13,7 +13,7 @@ import {
 import ResourceUsageTable from 'k8s/components/infrastructure/common/ResourceUsageTable'
 import CreateButton from 'core/components/buttons/CreateButton'
 import { AppContext } from 'core/providers/AppProvider'
-import { both, path } from 'ramda'
+import { both, path, omit } from 'ramda'
 import PrometheusAddonDialog from 'k8s/components/prometheus/PrometheusAddonDialog'
 import ClusterUpgradeDialog from 'k8s/components/infrastructure/clusters/ClusterUpgradeDialog'
 import ClusterDeleteDialog from './ClusterDeleteDialog'
@@ -107,7 +107,10 @@ const renderCloudProvider = (_, { cloudProviderType, cloudProviderName }) => (
 )
 
 const renderMetaData = (_, { tags }) => {
-  const content = JSON.stringify(tags, null, 2)
+  // Hide pf9-system:monitoring tag from the display
+  // because that tag should be handled completely by appbert
+  const _tags = omit(['pf9-system:monitoring'], tags)
+  const content = JSON.stringify(_tags, null, 2)
 
   return (
     <Tooltip title={<CodeBlock>{content}</CodeBlock>}>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/EditClusterPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/EditClusterPage.js
@@ -18,6 +18,12 @@ import EtcdBackupFields from './EtcdBackupFields'
 
 const listUrl = pathJoin(k8sPrefix, 'infrastructure')
 
+// Hide pf9-system:monitoring tag from the display
+// bc that tag should be handled completely by appbert.
+// If the tag exists, we do not want to remove it
+// so just hide it from view.
+const tagsToOmit = ['pf9-system:monitoring']
+
 const EditClusterPage = () => {
   const { match, history } = useReactRouter()
   const clusterId = match.params.id
@@ -96,7 +102,7 @@ const EditClusterPage = () => {
           id="tags"
           label="Tags"
           info="Edit tag metadata on this cluster"
-          hideMonitoringTags
+          blacklistedTags={tagsToOmit}
         />
       </ValidatedForm>
     </FormWrapper>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/EditClusterPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/EditClusterPage.js
@@ -92,7 +92,12 @@ const EditClusterPage = () => {
         {params.etcdBackup && <EtcdBackupFields />}
 
         {/* Tags */}
-        <KeyValuesField id="tags" label="Tags" info="Edit tag metadata on this cluster" />
+        <KeyValuesField
+          id="tags"
+          label="Tags"
+          info="Edit tag metadata on this cluster"
+          hideMonitoringTags
+        />
       </ValidatedForm>
     </FormWrapper>
   )


### PR DESCRIPTION
Hide the pf9-system:monitoring tag from the user bc the backend does not detect cluster label changes to enable/disable prometheus on clusters