### PR TITLE
dont make 2 requests on a delete

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDeleteDialog.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDeleteDialog.tsx
@@ -31,9 +31,13 @@ const ClusterDeleteDialog: React.FC<IClusterDeleteDialog> = ({ rows: [cluster], 
     false && success && cluster?.nodes?.length > 0 ? setShowDeauthNodeDialog(true) : onClose(),
   )
   const title = `Permanently delete cluster "${cluster?.name}"?`
-  const handleDelete = useCallback(async () => {
-    await deleteCluster(cluster)
-  }, [cluster])
+  const handleDelete = useCallback(
+    (e) => {
+      e && e.preventDefault()
+      deleteCluster(cluster)
+    },
+    [cluster],
+  )
 
   if (showDeauthNodeDialog) return <DeauthNodeDialog nodeList={cluster.nodes} onClose={onClose} />
 


### PR DESCRIPTION
we need to tell the event to `preventDefault` so that the form `onSubmit` doesn't fire the same delete call simultaneously 