### PR TITLE
UX-232/Remove segment identify call for live demo DU

### DIFF
--- a/src/app/core/containers/AuthenticatedContainer.js
+++ b/src/app/core/containers/AuthenticatedContainer.js
@@ -28,6 +28,7 @@ import { pathJoin } from 'utils/misc'
 import PushEventsProvider from '../providers/PushEventsProvider'
 import BannerContainer from 'core/components/notifications/BannerContainer'
 import BannerContent from 'core/components/notifications/BannerContent'
+import { trackEvent } from 'utils/tracking'
 
 const { keystone } = ApiClient.getInstance()
 
@@ -260,11 +261,27 @@ const AuthenticatedContainer = () => {
                 <BannerContent>
                   <div className={classes.sandboxBanner}>
                     Welcome! You are in the Platform9 live demo.{' '}
-                    <Button component="a" target="_blank" href={getSandboxUrl('signup')}>
+                    <Button
+                      component="a"
+                      target="_blank"
+                      href={getSandboxUrl('signup')}
+                      onClick={() => trackEvent(
+                        'CTA Deploy a Cluster Now',
+                        { 'CTA-Page': 'PMK Live Demo' }
+                      )}
+                    >
                       Deploy a Cluster Now
                     </Button>{' '}
                     or{' '}
-                    <Button component="a" target="_blank" href={getSandboxUrl('pricing')}>
+                    <Button
+                      component="a"
+                      target="_blank"
+                      href={getSandboxUrl('pricing')}
+                      onClick={() => trackEvent(
+                        'CTA View Pricing Plans',
+                        { 'CTA-Page': 'PMK Live Demo' }
+                      )}
+                    >
                       View Plans
                     </Button>
                   </div>


### PR DESCRIPTION
Not sure if that was the best spot to put it or if it should be in a more general spot. In the future, the login screen will also need to query features.json like this to know whether or not SSO is active. Could make more sense to put it into the component's state so that it can be passed to child components, but then calling restoreSession would need to be gated on the API and state being set.