### PR TITLE
UX-264/Make wording on Sandbox less confusing

### DIFF
--- a/src/app/core/containers/AuthenticatedContainer.js
+++ b/src/app/core/containers/AuthenticatedContainer.js
@@ -163,8 +163,6 @@ const renderRawComponents = moize((plugins) =>
     .flat(),
 )
 
-const getSandboxUrl = (pathPart) => `https://platform9.com/${pathPart}/`
-
 const redirectToAppropriateStack = (ironicEnabled, kubernetesEnabled, history) => {
   // If it is neither ironic nor kubernetes, bump user to old UI
   // TODO: For production, I need to always bump user to old UI in both ironic
@@ -210,6 +208,8 @@ const determineStack = (history, features) => {
   }
   return history.location.pathname.includes('openstack') ? 'openstack' : 'kubernetes'
 }
+
+const getSandboxUrl = (pathPart) => `https://platform9.com/${pathPart}/`
 
 const AuthenticatedContainer = () => {
   const [drawerOpen, toggleDrawer] = useToggler(true)
@@ -276,13 +276,13 @@ const AuthenticatedContainer = () => {
                     <Button
                       component="a"
                       target="_blank"
-                      href={getSandboxUrl('pricing')}
+                      href={getSandboxUrl('contact')}
                       onClick={() => trackEvent(
-                        'CTA View Pricing Plans',
+                        'CTA Contact Us',
                         { 'CTA-Page': 'PMK Live Demo' }
                       )}
                     >
-                      View Plans
+                      Contact Us
                     </Button>
                   </div>
                 </BannerContent>

--- a/src/app/core/containers/AuthenticatedContainer.js
+++ b/src/app/core/containers/AuthenticatedContainer.js
@@ -270,7 +270,7 @@ const AuthenticatedContainer = () => {
                         { 'CTA-Page': 'PMK Live Demo' }
                       )}
                     >
-                      Deploy a Cluster Now
+                      Start your Free Plan Now
                     </Button>{' '}
                     or{' '}
                     <Button


### PR DESCRIPTION
The below button is confusing because we already have an `Add Cluster` button on the same page right below.  The button really asks them to sign up for Free Tier so we should word it accordingly.

Spoke with Madhura about the change already.

![deploy-now](https://user-images.githubusercontent.com/289156/84706183-6874a080-af11-11ea-86f1-f9d8802fa6e3.png)

