### PR TITLE
UX-89/Consider node as disconnected if resmgr is not responding for node

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
@@ -23,7 +23,7 @@ import {
   mergeLeft,
   partition,
 } from 'ramda'
-import { rawNodesCacheKey } from 'k8s/components/infrastructure/nodes/actions'
+import { nodesCacheKey } from 'k8s/components/infrastructure/nodes/actions'
 import {
   getMasterNodesHealthStatus,
   getWorkerNodesHealthStatus,
@@ -273,13 +273,13 @@ export const clusterActions = createCRUDActions(clustersCacheKey, {
   listFn: async (params, loadFromContext) => {
     const [
       clustersWithTasks = [],
-      rawNodes,
+      nodes,
       combinedHosts,
       rawClusters,
       qbertEndpoint,
     ] = await Promise.all([
       loadFromContext(clusterTagsCacheKey, undefined, true), // tell the loader to refetch the data
-      loadFromContext(rawNodesCacheKey),
+      loadFromContext(nodesCacheKey),
       loadFromContext(combinedHostsCacheKey),
       qbert.getClusters(),
       qbert.baseUrl(),
@@ -287,7 +287,7 @@ export const clusterActions = createCRUDActions(clustersCacheKey, {
 
     return mapAsync(async (cluster) => {
       const clusterWithTasks = clustersWithTasks.find(({ uuid }) => cluster.uuid === uuid)
-      const nodesInCluster = rawNodes.filter((node) => node.clusterUuid === cluster.uuid)
+      const nodesInCluster = nodes.filter((node) => node.clusterUuid === cluster.uuid)
       const nodeIds = pluck('uuid', nodesInCluster)
       const combinedNodes = combinedHosts.filter((x) => nodeIds.includes(x.resmgr.id))
       const calcNodesTotals = calcUsageTotalByPath(combinedNodes)

--- a/src/app/plugins/kubernetes/components/infrastructure/nodes/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/nodes/actions.js
@@ -51,6 +51,9 @@ export const loadNodes = createContextLoader(
     // associate nodes with the combinedHost entry
     return rawNodes.map((node) => ({
       ...node,
+      // if hostagent is not responding, then the nodes info is outdated
+      // set the status to disconnected manually
+      status: combinedHostsObj[node.uuid].responding ? node.status : 'disconnected',
       combined: combinedHostsObj[node.uuid],
       // qbert v3 link fails authorization so we have to use v1 link for logs
       logs: `${qbertUrl}/logs/${node.uuid}`.replace(/v3/, 'v1'),


### PR DESCRIPTION
If the node hostagent is not working, it seems that resmgr will report not responding while the nodes API may not know this information. So use the resmgr response to help determine the node status property.