### PR TITLE
UX-193/Workaround for tenant role table field not recording selected …

### DIFF
--- a/src/app/plugins/kubernetes/components/userManagement/common/RolesPicklist.js
+++ b/src/app/plugins/kubernetes/components/userManagement/common/RolesPicklist.js
@@ -18,7 +18,11 @@ const RolesPicklist = forwardRef(
       if (selectFirst && !(disabled || value || isEmpty(options))) {
         onChange(propOr(allKey, 'value', head(options)))
       }
-    }, [options, disabled, selectFirst])
+      // workaround for memoized updateFieldValue in TenantRolesTableField component
+      if (value) {
+        onChange(value)
+      }
+    }, [options, disabled, selectFirst, value])
 
     return (
       <Picklist


### PR DESCRIPTION
…role properly

I think a real fix would involve fixing up the ValidatedForm / FormContext to account for the bug we're seeing with the tenant roles field, but I'm not too comfortable with changing that up.

Another fix could be to change the user create/edit forms to rely solely on the WizardContext, but that may also be considered a workaround considering the tenant roles field component could be used outside of the Wizard component.