### PR TITLE
UX-99/Add banner for upgradable clusters and added to cluster health …

### DIFF
--- a/src/app/core/banners/ClusterUpgradeBanner.tsx
+++ b/src/app/core/banners/ClusterUpgradeBanner.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import useReactRouter from 'use-react-router'
+import BannerButton from 'core/components/buttons/BannerButton'
+import { makeStyles, Theme } from '@material-ui/core'
+import BannerContainer from 'core/components/notifications/BannerContainer'
+import BannerContent from 'core/components/notifications/BannerContent'
+import useDataLoader from 'core/hooks/useDataLoader'
+import { clusterActions } from 'k8s/components/infrastructure/clusters/actions'
+
+const useStyles = makeStyles<Theme>((theme: Theme) => ({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexGrow: 1,
+    fontWeight: 'bold',
+  },
+}))
+
+const ClusterUpgradeBanner = () => {
+  const classes = useStyles({})
+  const { history } = useReactRouter()
+
+  const [clusters, clustersLoading] = useDataLoader(clusterActions.list)
+  const upgradableClusters = clusters.filter(cluster => cluster.canUpgrade)
+
+  const redirectToClusters = () => {
+    history.push('/ui/kubernetes/infrastructure')
+  }
+
+  return (!clustersLoading && upgradableClusters.length) ? (
+    <>
+      <BannerContainer />
+      <BannerContent>
+        <div className={classes.root}>
+          There's a new Platform9 release available. {upgradableClusters.length} clusters to upgrade.
+          <BannerButton onClick={redirectToClusters}>View Clusters</BannerButton>
+        </div>
+      </BannerContent>
+    </>
+  ) : null
+}
+
+export default ClusterUpgradeBanner

--- a/src/app/core/banners/ClusterUpgradeBanner.tsx
+++ b/src/app/core/banners/ClusterUpgradeBanner.tsx
@@ -6,6 +6,7 @@ import BannerContainer from 'core/components/notifications/BannerContainer'
 import BannerContent from 'core/components/notifications/BannerContent'
 import useDataLoader from 'core/hooks/useDataLoader'
 import { clusterActions } from 'k8s/components/infrastructure/clusters/actions'
+import { routes } from 'core/utils/routes'
 
 const useStyles = makeStyles<Theme>((theme: Theme) => ({
   root: {
@@ -25,7 +26,7 @@ const ClusterUpgradeBanner = () => {
   const upgradableClusters = clusters.filter(cluster => cluster.canUpgrade)
 
   const redirectToClusters = () => {
-    history.push('/ui/kubernetes/infrastructure')
+    history.push(routes.cluster.list.path())
   }
 
   return (!clustersLoading && upgradableClusters.length) ? (

--- a/src/app/core/components/buttons/BannerButton.tsx
+++ b/src/app/core/components/buttons/BannerButton.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import Button from '@material-ui/core/Button'
+import { Theme } from '@material-ui/core'
+import { makeStyles } from '@material-ui/styles'
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    backgroundColor: '#f3f3f4',
+    margin: theme.spacing(0, 1),
+    '&:hover': {
+      backgroundColor: '#FFFFFF',
+    },
+  }
+}))
+
+const BannerButton = ({ children, ...rest }) => {
+  const classes = useStyles({})
+  return (
+    <Button className={classes.root} {...rest}>{children}</Button>
+  )
+}
+
+export default BannerButton

--- a/src/app/core/containers/AuthenticatedContainer.js
+++ b/src/app/core/containers/AuthenticatedContainer.js
@@ -29,6 +29,7 @@ import PushEventsProvider from '../providers/PushEventsProvider'
 import BannerContainer from 'core/components/notifications/BannerContainer'
 import BannerContent from 'core/components/notifications/BannerContent'
 import { trackEvent } from 'utils/tracking'
+import ClusterUpgradeBanner from 'core/banners/ClusterUpgradeBanner'
 
 const { keystone } = ApiClient.getInstance()
 
@@ -287,6 +288,9 @@ const AuthenticatedContainer = () => {
                   </div>
                 </BannerContent>
               </>
+            )}
+            {pathStrOr(false, 'experimental.containervisor', features) && (
+              <ClusterUpgradeBanner/>
             )}
             <div className={classes.contentMain}>
               {renderRawComponents(plugins)}

--- a/src/app/core/themes/defaultTheme.js
+++ b/src/app/core/themes/defaultTheme.js
@@ -138,6 +138,9 @@ const theme = {
       main: '#4ADF74',
       dark: '#388E3C',
     },
+    upgrade: {
+      main: '#D82071',
+    },
     empty: {
       main: '#EDEFF1',
     },

--- a/src/app/core/themes/model.ts
+++ b/src/app/core/themes/model.ts
@@ -180,6 +180,11 @@ export interface Palette {
   code: Code
   warning: DefaultColorSwatch
   success: DefaultColorSwatch
+  upgrade: Upgrade
+}
+
+export interface Upgrade {
+  main: string
 }
 
 export interface Action {

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatus.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatus.tsx
@@ -24,6 +24,7 @@ const getIconOrBubbleColor = (status: IClusterStatus, theme: Theme) =>
     error: theme.palette.error.main,
     loading: theme.palette.sidebar.text,
     unknown: theme.palette.info.main,
+    upgrade: theme.palette.upgrade.main,
   }[status] || theme.palette.error.main)
 
 const useStyles = makeStyles<Theme, Props>((theme: Theme) => ({

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatusUtils.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatusUtils.ts
@@ -5,7 +5,7 @@ import { ICombinedNode } from '../nodes/model'
 type TransientStatus = 'creating' | 'deleting' | 'updating' | 'upgrading' | 'converging'
 type ConnectionStatus = 'connected' | 'partially_connected' | 'disconnected'
 
-export type IClusterStatus = 'ok' | 'pause' | 'fail' | 'unknown' | 'error' | 'loading'
+export type IClusterStatus = 'ok' | 'pause' | 'fail' | 'unknown' | 'error' | 'loading' | 'upgrade'
 
 interface INodeCount {
   total: number
@@ -119,9 +119,14 @@ export function getHealthStatus(
   connectionStatus: ConnectionStatus | TransientStatus,
   masterStatus: HealthStatus,
   workerStatus: HealthStatus,
+  canUpgrade,
 ) {
   if (isTransientStatus(connectionStatus)) {
     return connectionStatus
+  }
+
+  if (canUpgrade) {
+    return 'needs_upgrade'
   }
 
   const healthStatusAndMessage = findClusterHealthValues(masterStatus, workerStatus)
@@ -318,6 +323,10 @@ export const clusterHealthStatusFields: {
   converging: {
     status: 'loading',
     label: 'Converging',
+  },
+  needs_upgrade: {
+    status: 'upgrade',
+    label: 'Upgrade Available'
   },
 }
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
@@ -311,6 +311,7 @@ export const clusterActions = createCRUDActions(clustersCacheKey, {
         connectionStatus,
         masterNodesHealthStatus,
         workerNodesHealthStatus,
+        cluster.canUpgrade,
       )
       const hasMasterNode = healthyMasterNodes.length > 0
       const clusterOk = nodesInCluster.length > 0 && cluster.status === 'ok'

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/model.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/model.ts
@@ -1,7 +1,7 @@
 import { ICombinedNode } from '../nodes/model'
 import { CloudProviders } from '../cloudProviders/model'
 
-export type HealthStatus = 'healthy' | 'partially_healthy' | 'unhealthy' | 'unknown'
+export type HealthStatus = 'healthy' | 'partially_healthy' | 'unhealthy' | 'unknown' | 'needs_upgrade'
 
 export interface ICluster {
   name: string


### PR DESCRIPTION
…status

Link to JIRA for the wireframes (photos): https://platform9.atlassian.net/browse/UX-99

Looking for some feedback/thoughts on below bullets and screenshots:
- Not sure if the banner message makes the most sense with the wording.
- Held off on implementing the special cluster details banner, not sure if there is a very clean way to do so, and I don't see a huge benefit.

<img width="1475" alt="Screen Shot 2020-07-10 at 2 08 25 PM" src="https://user-images.githubusercontent.com/6668478/87203400-5e975080-c2b7-11ea-8ef2-56362d1191aa.png">

<img width="1476" alt="Screen Shot 2020-07-10 at 1 57 56 PM" src="https://user-images.githubusercontent.com/6668478/87203340-3d366480-c2b7-11ea-945c-062d6bc8da65.png">
