### PR TITLE
PMK-3045 Segment user invite

### DIFF
--- a/src/app/plugins/kubernetes/components/userManagement/users/actions.js
+++ b/src/app/plugins/kubernetes/components/userManagement/users/actions.js
@@ -78,6 +78,7 @@ export const mngmUserActions = createCRUDActions(mngmUsersCacheKey, {
           password: password || undefined,
           default_project_id: defaultTenantId,
         })
+      trackEvent('User Created', { username, displayname })
     } else {
       createdUser = await clemency.createUser({
         username,


### PR DESCRIPTION
Adding Segment events for when an admin creates another user and also when they invite another user.

We also want the invite associated with the actual invited user not the admin user but this can't be done cleanly in the UI so we are leaving the JIRA open and having the backend team add tracking to Clemency directly so that the `identify` calls can be associated correctly.