### PR TITLE
UX-507/Fixed ironic wizard loading issue if no networks present

### DIFF
--- a/src/app/plugins/openstack/components/ironicSetup/IronicSetupPage.tsx
+++ b/src/app/plugins/openstack/components/ironicSetup/IronicSetupPage.tsx
@@ -47,7 +47,7 @@ const networkConfigured = async (networks) => {
     finished: alreadyConfigured && provisioningNetwork,
     step: 0,
     data: {
-      provisioningNetwork: provisioningNetwork.id,
+      provisioningNetwork: provisioningNetwork?.id,
       dnsDomain: dnsDomain,
       dnsForwardingAddresses: dnsForwardingAddresses,
       networkName: provisioningNetwork?.name,


### PR DESCRIPTION
After ironic wizard refactor, didn't test on a fresh DU to catch this issue. Prob worth a backport to 4.4