### PR TITLE
UX-241/Modified Welcome header message on dashboard

### DIFF
--- a/src/app/plugins/kubernetes/components/dashboard/DashboardPage.tsx
+++ b/src/app/plugins/kubernetes/components/dashboard/DashboardPage.tsx
@@ -14,7 +14,6 @@ import { cloudProviderActions } from '../infrastructure/cloudProviders/actions'
 // Components
 import StatusCard, { StatusCardProps } from './StatusCard'
 import { Typography } from '@material-ui/core'
-import { capitalizeString, normalizeUsername } from 'utils/misc'
 
 import ClusterSetup, {
   clustersHaveMonitoring,
@@ -313,7 +312,6 @@ const DashboardPage = () => {
   const [users, loadingUsers] = useDataLoader(mngmUserActions.list)
   const user = users.find((x) => x.username === session.username)
   const displayname = user?.displayname
-  const username = capitalizeString(normalizeUsername(session.username))
 
   if (loadingUsers) {
     return null
@@ -321,7 +319,7 @@ const DashboardPage = () => {
 
   return (
     <section className={classes.cardColumn}>
-      <Typography variant="h5">Welcome {displayname ? displayname : username}!</Typography>
+      <Typography variant="h5">Welcome{displayname ? ' ' + displayname : ''}!</Typography>
       {isLoading ? (
         <Progress loading={isLoading} overlay renderContentOnMount />
       ) : (

--- a/src/app/plugins/kubernetes/components/dashboard/DashboardPage.tsx
+++ b/src/app/plugins/kubernetes/components/dashboard/DashboardPage.tsx
@@ -290,7 +290,7 @@ const DashboardPage = () => {
   const classes = useStyles({})
   const { getContext, session } = useContext(AppContext)
   const isAdmin = isAdminRole(getContext)
-  const username = capitalizeString(normalizeUsername(session.username))
+
   const [clusters, loadingClusters] = useDataLoader(clusterActions.list)
   const [pods, loadingPods] = useDataLoader(podActions.list)
   const hasClusters = !!clusters.length
@@ -310,9 +310,18 @@ const DashboardPage = () => {
     return [hasClusters, hasAccess, hasMonitoring].findIndex((item) => !item)
   }, [hasClusters, hasMonitoring, hasAccess])
 
+  const [users, loadingUsers] = useDataLoader(mngmUserActions.list)
+  const user = users.find((x) => x.username === session.username)
+  const displayname = user?.displayname
+  const username = capitalizeString(normalizeUsername(session.username))
+
+  if (loadingUsers) {
+    return null
+  }
+
   return (
     <section className={classes.cardColumn}>
-      <Typography variant="h5">Welcome {username}!</Typography>
+      <Typography variant="h5">Welcome {displayname ? displayname : username}!</Typography>
       {isLoading ? (
         <Progress loading={isLoading} overlay renderContentOnMount />
       ) : (

--- a/src/app/utils/misc.js
+++ b/src/app/utils/misc.js
@@ -190,16 +190,18 @@ export const getCookieValue = (name) => {
   return val ? val.pop() : ''
 }
 
-export const normalizeUsername = (name = '') => {
-  if (!name) return name
+export const normalizeUsername = (emailAddress = '') => {
+  if (!emailAddress) return emailAddress
 
   // split emails from @ sign and take the left hand side
-  const [username] = name.split('@')
-  return username
+  const [username] = emailAddress.split('@')
+
+  // split username from  '.' for emails in this format: first.last@domain.tld => [first, last]
+  const name = username.split('.')
+
+  return name.map((n) => capitalizeString(n)).join(' ')
 }
 
 // Really simple indefinite article function, does not account for special
 // cases such as 'a user'
-export const indefiniteArticle = (word = '') => (
-  /^([aeiou])/i.test(word) ? 'an' : 'a'
-)
+export const indefiniteArticle = (word = '') => (/^([aeiou])/i.test(word) ? 'an' : 'a')

--- a/src/app/utils/misc.js
+++ b/src/app/utils/misc.js
@@ -190,16 +190,12 @@ export const getCookieValue = (name) => {
   return val ? val.pop() : ''
 }
 
-export const normalizeUsername = (emailAddress = '') => {
-  if (!emailAddress) return emailAddress
+export const normalizeUsername = (name = '') => {
+  if (!name) return name
 
   // split emails from @ sign and take the left hand side
-  const [username] = emailAddress.split('@')
-
-  // split username from  '.' for emails in this format: first.last@domain.tld => [first, last]
-  const name = username.split('.')
-
-  return name.map((n) => capitalizeString(n)).join(' ')
+  const [username] = name.split('@')
+  return username
 }
 
 // Really simple indefinite article function, does not account for special


### PR DESCRIPTION
Changes made:

- If a user has a displayname, the displayname will be displayed in the welcome header 

- If a user does not have a displayname, only 'Welcome!' will be displayed

<img width="1437" alt="Screen Shot 2020-08-27 at 11 56 15 AM" src="https://user-images.githubusercontent.com/23369276/91483304-5d68b580-e85c-11ea-9497-24b15f9e1640.png">


