### PR TITLE
UX-523/Modified labels on multiple screens

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/actions.js
@@ -14,8 +14,8 @@ import ApiClient from 'api-client/ApiClient'
 const { qbert } = ApiClient.getInstance()
 
 const cloudProviderTypes = {
-  aws: 'AWS Provider',
-  azure: 'Microsoft Azure Provider',
+  aws: 'AWS',
+  azure: 'Azure',
   openstack: 'OpenStack',
 }
 

--- a/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/actions.js
@@ -14,7 +14,7 @@ import ApiClient from 'api-client/ApiClient'
 const { qbert } = ApiClient.getInstance()
 
 const cloudProviderTypes = {
-  aws: 'Amazon AWS Provider',
+  aws: 'AWS Provider',
   azure: 'Microsoft Azure Provider',
   openstack: 'OpenStack',
 }

--- a/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/actions.js
@@ -13,10 +13,11 @@ import ApiClient from 'api-client/ApiClient'
 
 const { qbert } = ApiClient.getInstance()
 
-const cloudProviderTypes = {
+export const cloudProviderTypes = {
   aws: 'AWS',
   azure: 'Azure',
   openstack: 'OpenStack',
+  local: 'BareOS',
 }
 
 export const cloudProvidersCacheKey = 'cloudProviders'

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterInfo.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterInfo.tsx
@@ -129,11 +129,11 @@ const awsCloudFields = [
   { id: 'cloudProperties.sshKey', title: 'SSH Key', required: true },
   { id: 'cloudProperties.serviceFqdn', title: 'Service FQDN', required: true },
   { id: 'cloudProperties.ami', title: 'AMI', required: true },
-  { id: 'cloudProperties.domainId', title: 'Domain Id', required: true },
+  { id: 'cloudProperties.domainId', title: 'Domain ID', required: true },
   { id: 'cloudProperties.isPrivate', title: 'Is Private', required: true, render: castBoolToStr() },
   {
     id: 'cloudProperties.usePf9Domain',
-    title: 'Use Pf9 Domain',
+    title: 'Use PF9 Domain',
     required: true,
     render: castBoolToStr(),
   },

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -167,7 +167,7 @@ export const options = {
     {
       id: 'cloudProviderType',
       label: 'Deployment Type',
-      render: (type) => cloudProviderTypes[type],
+      render: (type) => cloudProviderTypes[type] || capitalizeString(type),
     },
     { id: 'resource_utilization', label: 'Resource Utilization', render: renderStats },
     { id: 'version', label: 'Kubernetes Version' },

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -43,8 +43,11 @@ const renderUUID = (_, { uuid }) => {
 const renderCloudProviderType = (type, cluster) => {
   if (type === 'local') {
     return 'BareOS'
+  } else if (type === 'aws') {
+    return 'AWS'
+  } else {
+    return capitalizeString(type)
   }
-  return capitalizeString(type)
 }
 
 const renderConnectionStatus = (_, cluster) => <ClusterConnectionStatus cluster={cluster} />

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -24,6 +24,7 @@ import { routes } from 'core/utils/routes'
 import CodeBlock from 'core/components/CodeBlock'
 import DateCell from 'core/components/listTable/cells/DateCell'
 import CopyToClipboard from 'core/components/CopyToClipboard'
+import { cloudProviderTypes } from '../cloudProviders/actions'
 
 const useStyles = makeStyles((theme) => ({
   links: {
@@ -39,17 +40,6 @@ const renderUUID = (_, { uuid }) => {
     </CopyToClipboard>
   )
 }
-
-const renderCloudProviderType = (type, cluster) => {
-  if (type === 'local') {
-    return 'BareOS'
-  } else if (type === 'aws') {
-    return 'AWS'
-  } else {
-    return capitalizeString(type)
-  }
-}
-
 const renderConnectionStatus = (_, cluster) => <ClusterConnectionStatus cluster={cluster} />
 const renderHealthStatus = (_, cluster) => <ClusterHealthStatus cluster={cluster} />
 const renderClusterLink = (links, { usage }) => <ClusterLinks links={links} usage={usage} />
@@ -174,7 +164,11 @@ export const options = {
       label: 'Links',
       render: renderClusterLink,
     },
-    { id: 'cloudProviderType', label: 'Deployment Type', render: renderCloudProviderType },
+    {
+      id: 'cloudProviderType',
+      label: 'Deployment Type',
+      render: (type) => cloudProviderTypes[type],
+    },
     { id: 'resource_utilization', label: 'Resource Utilization', render: renderStats },
     { id: 'version', label: 'Kubernetes Version' },
     { id: 'created_at', label: 'Created at', render: (value) => <DateCell value={value} /> },


### PR DESCRIPTION
Changes made:

- Aws -> AWS (Infrastructure tab)
![cluster_](https://user-images.githubusercontent.com/23369276/91753137-50a9d180-eb7c-11ea-8ceb-2168772f1e4b.png)

- Amazon AWS Provider -> AWS Provider (Cloud providers tab)
![cloud_provider](https://user-images.githubusercontent.com/23369276/91753215-6cad7300-eb7c-11ea-8584-6feb992550db.png)

- Hypervisor type is already removed in the node details page

- Cloud properties on Cluster details page 
AMI (already changed)
Domain Id -> Domain ID
Use Pf9 Domain -> Use PF9 Domain
Internal Elb (already changed)
AZs (already changed)

![cluster_details](https://user-images.githubusercontent.com/23369276/91753359-a3838900-eb7c-11ea-97d8-023f6b48587f.png)

- Overview on Cluster details page
CloudProvider has already been changed to Cloud Provider
![cloud_provider_type](https://user-images.githubusercontent.com/23369276/91753508-d6c61800-eb7c-11ea-91c0-131f0949fb47.png)


