### PR TITLE
[UX-572] Cluster Details - Nodes page is blank for a very long time

### DIFF
--- a/src/app/core/components/progress/Progress.js
+++ b/src/app/core/components/progress/Progress.js
@@ -181,7 +181,7 @@ Progress.defaultProps = {
   loading: false,
   overlay: true,
   inline: false,
-  renderContentOnMount: false,
+  renderContentOnMount: true,
   renderLoadingImage: true,
   message: 'Loading...',
   minHeight: 400,


### PR DESCRIPTION
Fix issue of components not being rendered upon mounting if data has previously been loaded