### PR TITLE
Add cache option and fix alerts page

### DIFF
--- a/src/api-client/Qbert.ts
+++ b/src/api-client/Qbert.ts
@@ -1182,7 +1182,6 @@ class Qbert extends ApiService {
       startTime,
       endTime,
       clusterId: clusterUuid,
-      id: `${alert.metric.alertname}${clusterUuid}`,
     }))
   }
 

--- a/src/api-client/qbert.model.ts
+++ b/src/api-client/qbert.model.ts
@@ -1093,7 +1093,6 @@ export interface IGetPrometheusAlertsOverTime {
   startTime: any
   endTime: any
   clusterId: any
-  id: string
   metric: {
     [key: string]: string
   }

--- a/src/app/core/components/progress/Progress.js
+++ b/src/app/core/components/progress/Progress.js
@@ -137,7 +137,8 @@ class Progress extends PureComponent {
     }
     return (
       <div
-        className={clsx(classes.content, {
+        className={clsx(classes.content, 'progressContent', {
+          loading,
           [classes.hiddenContent]: loading && !overlay,
           [classes.contentLoading]: loading,
         })}

--- a/src/app/core/helpers/createContextLoader.js
+++ b/src/app/core/helpers/createContextLoader.js
@@ -83,6 +83,7 @@ const createContextLoader = (cacheKey, dataFetchFn, options = {}) => {
     fetchErrorMessage = (catchedErr, params) => `Unable to fetch ${entityName} items`,
     selector = getDataSelector(cacheKey, indexBy),
     selectorCreator = getDefaultSelectorCreator(selector),
+    noCache = false,
   } = options
   const allIndexKeys = indexBy ? ensureArray(indexBy) : emptyArr
   const allRequiredParams = requiredParams ? ensureArray(requiredParams) : emptyArr
@@ -145,12 +146,12 @@ const createContextLoader = (cacheKey, dataFetchFn, options = {}) => {
       )
 
       // Perfom the cache update operations
-      if (invalidateCache || refetch) {
+      if (noCache || invalidateCache || refetch) {
         dispatch(
           cacheActions.replaceAll({
             cacheKey,
             items: itemsWithParams,
-            params: providedIndexedParams,
+            params: noCache ? null : providedIndexedParams,
           }),
         )
       } else {
@@ -183,6 +184,7 @@ const createContextLoader = (cacheKey, dataFetchFn, options = {}) => {
    */
   contextLoaderFn.cacheKey = cacheKey
   contextLoaderFn.indexBy = allIndexKeys
+  contextLoaderFn.noCache = noCache
   contextLoaderFn.fetchErrorMessage = fetchErrorMessage
   contextLoaderFn.selectorCreator = selectorCreator
 

--- a/src/app/core/helpers/createContextLoader.js
+++ b/src/app/core/helpers/createContextLoader.js
@@ -83,7 +83,7 @@ const createContextLoader = (cacheKey, dataFetchFn, options = {}) => {
     fetchErrorMessage = (catchedErr, params) => `Unable to fetch ${entityName} items`,
     selector = getDataSelector(cacheKey, indexBy),
     selectorCreator = getDefaultSelectorCreator(selector),
-    noCache = false,
+    cache = true,
   } = options
   const allIndexKeys = indexBy ? ensureArray(indexBy) : emptyArr
   const allRequiredParams = requiredParams ? ensureArray(requiredParams) : emptyArr
@@ -146,12 +146,12 @@ const createContextLoader = (cacheKey, dataFetchFn, options = {}) => {
       )
 
       // Perfom the cache update operations
-      if (noCache || invalidateCache || refetch) {
+      if (!cache || invalidateCache || refetch) {
         dispatch(
           cacheActions.replaceAll({
             cacheKey,
             items: itemsWithParams,
-            params: noCache ? null : providedIndexedParams,
+            params: cache ? providedIndexedParams : null,
           }),
         )
       } else {
@@ -184,7 +184,7 @@ const createContextLoader = (cacheKey, dataFetchFn, options = {}) => {
    */
   contextLoaderFn.cacheKey = cacheKey
   contextLoaderFn.indexBy = allIndexKeys
-  contextLoaderFn.noCache = noCache
+  contextLoaderFn.cache = cache
   contextLoaderFn.fetchErrorMessage = fetchErrorMessage
   contextLoaderFn.selectorCreator = selectorCreator
 

--- a/src/app/core/hooks/useDataLoader.js
+++ b/src/app/core/hooks/useDataLoader.js
@@ -32,14 +32,14 @@ const onErrorHandler = moize(
  */
 const useDataLoader = (loaderFn, params = emptyObj, options = emptyObj) => {
   const { loadOnDemand = false, defaultParams = emptyObj, loadingFeedback = true } = options
-  const { cacheKey, fetchErrorMessage, selectorCreator, indexBy } = loaderFn
+  const { cacheKey, fetchErrorMessage, selectorCreator, indexBy, noCache } = loaderFn
   const [{ currentTenant, currentRegion }] = useScopedPreferences()
 
   // Memoize the params dependency as we want to make sure it really changed and not just got a new reference
   const memoizedParams = memoizedDep(params)
-  const memoizedIndexedParams = memoizedDep(
-    pipe(pickAll(indexBy), reject(either(isNil, equals(allKey))))(memoizedParams),
-  )
+  const memoizedIndexedParams = noCache
+    ? memoizedParams
+    : memoizedDep(pipe(pickAll(indexBy), reject(either(isNil, equals(allKey))))(memoizedParams))
 
   const selector = useMemo(() => {
     return selectorCreator(defaultParams)

--- a/src/app/core/hooks/useDataLoader.js
+++ b/src/app/core/hooks/useDataLoader.js
@@ -32,14 +32,14 @@ const onErrorHandler = moize(
  */
 const useDataLoader = (loaderFn, params = emptyObj, options = emptyObj) => {
   const { loadOnDemand = false, defaultParams = emptyObj, loadingFeedback = true } = options
-  const { cacheKey, fetchErrorMessage, selectorCreator, indexBy, noCache } = loaderFn
+  const { cacheKey, fetchErrorMessage, selectorCreator, indexBy, cache } = loaderFn
   const [{ currentTenant, currentRegion }] = useScopedPreferences()
 
   // Memoize the params dependency as we want to make sure it really changed and not just got a new reference
   const memoizedParams = memoizedDep(params)
-  const memoizedIndexedParams = noCache
-    ? memoizedParams
-    : memoizedDep(pipe(pickAll(indexBy), reject(either(isNil, equals(allKey))))(memoizedParams))
+  const memoizedIndexedParams = cache
+    ? memoizedDep(pipe(pickAll(indexBy), reject(either(isNil, equals(allKey))))(memoizedParams))
+    : memoizedParams
 
   const selector = useMemo(() => {
     return selectorCreator(defaultParams)

--- a/src/app/plugins/kubernetes/components/alarms/AlarmsListPage.tsx
+++ b/src/app/plugins/kubernetes/components/alarms/AlarmsListPage.tsx
@@ -5,9 +5,9 @@ import SeverityPicklist from './SeverityPicklist'
 import useDataLoader from 'core/hooks/useDataLoader'
 import { loadAlerts, loadTimeSeriesAlerts } from './actions'
 import { createUsePrefParamsHook } from 'core/hooks/useParams'
-import { listTablePrefs } from 'app/constants'
+import { listTablePrefs, allKey } from 'app/constants'
 import { pick } from 'ramda'
-import { allKey } from 'app/constants'
+
 import StackedAreaChart from 'core/components/graphs/StackedAreaChart'
 import { makeStyles } from '@material-ui/styles'
 import DateCell from 'core/components/listTable/cells/DateCell'
@@ -21,6 +21,7 @@ import ClusterPicklistDefault from 'k8s/components/common/ClusterPicklist'
 import TimePicklistDefault from './TimePicklist'
 import AlarmDetailsLink from './AlarmDetailsLink'
 import { ActionDataKeys } from 'k8s/DataKeys'
+import Progress from 'core/components/progress/Progress'
 const ClusterPicklist: any = ClusterPicklistDefault
 const TimePicklist: any = TimePicklistDefault
 
@@ -35,6 +36,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     border: `1px solid ${theme.palette.grey['500']}`,
     padding: theme.spacing(2),
     marginTop: theme.spacing(1),
+    '& .progressContent.loading': {
+      display: 'none',
+    },
   },
   chartContainerHeader: {
     fontSize: 11,
@@ -104,10 +108,7 @@ const ListPage = ({ ListContainer }) => {
     const [data, loading, reload] = useDataLoader(loadAlerts, params)
     // Provide specific param properties to timeSeries data loader
     // so that it doesn't reload unless those props are changed
-    const [
-      timeSeriesData,
-      // timeSeriesLoading,
-    ] = useDataLoader(loadTimeSeriesAlerts, {
+    const [timeSeriesData, timeSeriesLoading] = useDataLoader(loadTimeSeriesAlerts, {
       chartTime: params.chartTime,
       clusterId: params.clusterId,
     })
@@ -158,16 +159,18 @@ const ListPage = ({ ListContainer }) => {
           </div>
         </div>
         <div className={classes.chartContainer}>
-          <div className={classes.chartContainerHeader}>Alarms</div>
-          <div className={classes.moveLeft}>
-            <StackedAreaChart
-              values={timeSeriesData}
-              keys={filteredChartKeys}
-              xAxis="time"
-              responsive={true}
-              CustomTooltip={<AlarmsChartTooltip keys={filteredChartKeys} />}
-            />
-          </div>
+          <Progress loading={timeSeriesLoading} overlay={false} maxHeight={160} minHeight={320}>
+            <div className={classes.chartContainerHeader}>Alarms</div>
+            <div className={classes.moveLeft}>
+              <StackedAreaChart
+                values={timeSeriesData}
+                keys={filteredChartKeys}
+                xAxis="time"
+                responsive
+                CustomTooltip={<AlarmsChartTooltip keys={filteredChartKeys} />}
+              />
+            </div>
+          </Progress>
         </div>
         <ListContainer
           loading={loading}

--- a/src/app/plugins/kubernetes/components/alarms/actions.js
+++ b/src/app/plugins/kubernetes/components/alarms/actions.js
@@ -50,15 +50,11 @@ const timestampSteps = {
   '3.h': [30, 'm'],
   '1.h': [10, 'm'],
 }
+const selector = makeParamsClustersSelector()
 
 export const loadTimeSeriesAlerts = createContextLoader(
   ActionDataKeys.AlertsTimeSeries,
   async ({ chartTime, ...params }) => {
-    // Invalidate cache -- can't get cache working properly for this
-    // collection. Collection is somewhat different from all other
-    // types of collections.
-    loadTimeSeriesAlerts.invalidateCache()
-
     const timeNow = moment().unix()
     const [number, period] = chartTime.split('.')
     const timePast = moment
@@ -68,7 +64,6 @@ export const loadTimeSeriesAlerts = createContextLoader(
     const step = timestampSteps[chartTime].join('')
 
     const [clusterId] = await parseClusterParams(params)
-    const selector = makeParamsClustersSelector()
     const prometheusClusters = selector(store.getState(), {
       ...params,
       healthyClusters: true,
@@ -86,11 +81,7 @@ export const loadTimeSeriesAlerts = createContextLoader(
   },
   {
     entityName: 'AlertTimeSeries',
-    // make uniqueIdentifier timestamp bc of autosort
-    // not sure if this has to do with the reason why the
-    // cache does not work properly
-    uniqueIdentifier: 'id',
     selectorCreator: makeTimeSeriesSelector,
-    indexBy: ['clusterId', 'chartTime'],
+    cache: false,
   },
 )

--- a/src/app/plugins/kubernetes/components/alarms/selectors.ts
+++ b/src/app/plugins/kubernetes/components/alarms/selectors.ts
@@ -104,10 +104,7 @@ export const makeTimeSeriesSelector = (
 ) => {
   return createSelector(
     [
-      getDataSelector<DataKeys.AlertsTimeSeries>(DataKeys.AlertsTimeSeries, [
-        'clusterId',
-        'chartTime',
-      ]),
+      getDataSelector<DataKeys.AlertsTimeSeries>(DataKeys.AlertsTimeSeries),
       (_, params) => mergeLeft(params, defaultParams),
     ],
     (timeSeriesRaw = [], params) => {


### PR DESCRIPTION
Added a `cache` option that is `true` by default but can be set to `false` to allow disabling the caching of the items so that they will always be fetched and replaced entirely in the redux store when using the `useDataLoader` hook, instead of "upserted".

Note that with `cache: false` option, data will be fetched and the store cached data replaced every time any of the `params` passed to the `useDataLoader` hook change, so beware of just updating those params when the data actually needs to be retrieved.

Whereas when using the `cache: true` option (the default) data will only be re-fetched and the store updated when the params defined by the `indexBy` option change.