### PR TITLE
UX-432/Added flags for sandbox

### DIFF
--- a/src/app/core/components/Navbar.js
+++ b/src/app/core/components/Navbar.js
@@ -626,6 +626,7 @@ class Navbar extends PureComponent {
 
     // const { features } = getContext()
     const isDecco = pathStrOr(false, 'experimental.kplane', features)
+    const isSandbox = pathStrOr(false, 'experimental.sandbox', features)
     const version = pathStrOr('4', 'releaseVersion', features)
 
     return (
@@ -666,13 +667,15 @@ class Navbar extends PureComponent {
 
           <div
             className={clsx(classes.bottomContent, {
-              [classes.bottomContentClose]: !open || isDecco,
+              [classes.bottomContentClose]: !open,
             })}
           >
-            <Button onClick={this.handleNavigateToClarity}>
-              Back to Legacy UI
-              <FontAwesomeIcon size="md">undo</FontAwesomeIcon>
-            </Button>
+            {!(isDecco || isSandbox) && (
+              <Button onClick={this.handleNavigateToClarity}>
+                Back to Legacy UI
+                <FontAwesomeIcon size="md">undo</FontAwesomeIcon>
+              </Button>
+            )}
             <SimpleLink src={helpUrl} className={classes.helpLink}>
               <FontAwesomeIcon>question-circle</FontAwesomeIcon> <span>Need Help?</span>
             </SimpleLink>

--- a/src/app/core/containers/AppContainer.tsx
+++ b/src/app/core/containers/AppContainer.tsx
@@ -89,12 +89,15 @@ const getUserDetails = async (activeTenant) => {
   // Ignore exception if features.json not found (for local development)
   const features = await axios.get('/clarity/features.json').catch(() => null)
   const sandbox = pathStrOr(false, 'data.experimental.sandbox', features)
-
   // Identify the user in Segment using Keystone ID
   if (typeof window.analytics !== 'undefined') {
-    window.analytics.identify(user.id, {
-      email: user.name,
-    })
+    if (sandbox) {
+      window.analytics.identify()
+    } else {
+      window.analytics.identify(user.id, {
+        email: user.name,
+      })
+    }
   }
 
   // Drift tracking code for live demo


### PR DESCRIPTION
Changes Made:

1. Added segment analytics.identify() before login with no UUID provided in order to enable Appcues

2. Intercom chat has already been removed so no additional changes were made

3. For both Sandbox and Decco DU, the UI toggle button to the old UI has been removed

![Screen Shot 2020-09-16 at 10 47 29 AM](https://user-images.githubusercontent.com/23369276/93376300-3de6fc00-f80e-11ea-9c14-2d4c103aa522.png)

4. Drift chat box is already present so no additional changes were made
