### PR TITLE
UX-586/Added API FQDN field to cluster creation review tables and cluster de…

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/AwsClusterReviewTable.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/AwsClusterReviewTable.js
@@ -30,6 +30,7 @@ const AwsClusterReviewTable = ({ data }) => {
             label="Enable workloads on all master nodes"
             value={castBoolToStr()(data.allowWorkloadsOnMaster)}
           />
+          <DataRow label="API FQDN" value={data.externalDnsName} />
           <DataRow label="Containers CIDR" value={data.containersCidr} />
           <DataRow label="Services CIDR" value={data.servicesCidr} />
           <DataRow label="Network backend" value={data.networkPlugin} />

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/AzureClusterReviewTable.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/AzureClusterReviewTable.js
@@ -39,6 +39,7 @@ const AzureClusterReviewTable = ({ data }) => {
             value={castBoolToStr()(data.allowWorkloadsOnMaster)}
           />
           <DataRow label="Assign public IP's" value={castBoolToStr()(data.assignPublicIps)} />
+          <DataRow label="API FQDN" value={data.externalDnsName} />
           <DataRow label="Containers CIDR" value={data.containersCidr} />
           <DataRow label="Services CIDR" value={data.servicesCidr} />
           <DataRow label="Privileged" value={castBoolToStr()(data.privileged)} />

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterInfo.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterInfo.tsx
@@ -68,6 +68,7 @@ const clusterOverviewFields: IClusterDetailFields[] = [
   { id: 'version', title: 'Kubernetes Version', required: true },
   { id: 'containersCidr', title: 'Containers CIDR', required: true },
   { id: 'servicesCidr', title: 'Services CIDR', required: true },
+  { id: 'externalDnsName', title: 'API FQDN' },
   { id: 'endpoint', title: 'API Endpoint', required: true },
   {
     id: 'allowWorkloadsOnMaster',


### PR DESCRIPTION
…tails

- BareOs, AWS, and Azure cluster creation review tables now all show the API FQDN field (BareOs already showed the field so I only modified AWS and Azure)
- API FDQN is also now shown in cluster details if the cluster has one

![Screen Shot 2020-09-17 at 1 46 14 PM](https://user-images.githubusercontent.com/23369276/93527873-5b8b9280-f8ee-11ea-9f7b-88ea61ec8e38.png)

![Screen Shot 2020-09-17 at 1 47 27 PM](https://user-images.githubusercontent.com/23369276/93527881-5e868300-f8ee-11ea-9f08-ddfe71b821bc.png)

![Screen Shot 2020-09-17 at 1 53 07 PM](https://user-images.githubusercontent.com/23369276/93527885-60504680-f8ee-11ea-9762-da20ef7a65e4.png)

![Screen Shot 2020-09-17 at 2 03 12 PM](https://user-images.githubusercontent.com/23369276/93528021-94c40280-f8ee-11ea-9c7f-c727cefd306d.png)


