### PR TITLE
UX-615/remove the onboarding workflow

### DIFF
--- a/src/app/plugins/kubernetes/components/dashboard/DashboardPage.tsx
+++ b/src/app/plugins/kubernetes/components/dashboard/DashboardPage.tsx
@@ -313,15 +313,15 @@ const DashboardPage = () => {
     <section className={classes.cardColumn}>
       <Text variant="h5">Welcome{displayName ? ` ${displayName}` : ''}!</Text>
 
-      {showOnboarding && isLoading && <Progress loading={isLoading} overlay />}
-      {showOnboarding && !isLoading && (
+      {isLoading && <Progress loading={isLoading} overlay />}
+      {false && showOnboarding && !isLoading && (
         <>
           <ClusterSetup initialPanel={initialExpandedClusterPanel} onComplete={handleComplete} />
           <PodSetup onComplete={handleComplete} initialPanel={showClusters ? undefined : 0} />
         </>
       )}
 
-      {!showOnboarding && (
+      {!isLoading && (
         <div className={classes.dashboardMosaic}>
           {reportsWithPerms(reports, session.userDetails.role).map((report) => (
             <StatusCard key={report.route} {...report} className={classes[report.entity]} />


### PR DESCRIPTION
The current onboarding workflow is not very useful and we're seeing a lot of users never see the actual dashboard because they are always on onboarding. 