### PR TITLE
Fix crashing due to retrieving userDetails and renew SSO tokens using…

### DIFF
--- a/src/api-client/Keystone.ts
+++ b/src/api-client/Keystone.ts
@@ -16,6 +16,24 @@ const constructAuthFromToken = (token: string, projectId?: string) => {
   }
 }
 
+const constructAuthFromSaml = (token: string, projectId?: string) => {
+  return {
+    auth: {
+      identity: {
+        methods: ['saml2'],
+        saml2: {
+          id: token,
+        },
+      },
+      scope: {
+        project: {
+          id: projectId,
+        },
+      },
+    },
+  }
+}
+
 const constructAuthFromCredentials = (username, password) => {
   return {
     auth: {
@@ -212,8 +230,10 @@ class Keystone extends ApiService {
     }
   }
 
-  changeProjectScope = async (projectId) => {
-    const body = constructAuthFromToken(this.client.unscopedToken, projectId)
+  changeProjectScope = async (projectId, isSsoUser) => {
+    const body = isSsoUser
+      ? constructAuthFromSaml(this.client.unscopedToken, projectId)
+      : constructAuthFromToken(this.client.unscopedToken, projectId)
     try {
       const response = await this.client.rawPost(this.tokensUrl, body)
       const scopedToken = response.headers['x-subject-token']

--- a/src/app/plugins/openstack/components/tenants/TenantChooser.js
+++ b/src/app/plugins/openstack/components/tenants/TenantChooser.js
@@ -20,6 +20,7 @@ const TenantChooser = (props) => {
   const [currentTenantName, setCurrentTenantName] = useState(propOr('', 'name', currentTenant))
   const [tooltipOpen, setTooltipOpen] = useState(false)
   const [tenants, loadingTenants] = useDataLoader(loadUserTenants)
+  const { ssoToken } = getStorage('tokens')
 
   const updateCurrentTenant = async (tenantName) => {
     setLoading(true)
@@ -30,7 +31,7 @@ const TenantChooser = (props) => {
       return
     }
 
-    const { user, role, scopedToken } = await keystone.changeProjectScope(tenant.id)
+    const { user, role, scopedToken } = await keystone.changeProjectScope(tenant.id, ssoToken)
     // Update localStorage scopedToken upon changing project scope
     const existingTokens = getStorage('tokens')
     setStorage('tokens', { ...existingTokens, currentToken: scopedToken })


### PR DESCRIPTION
… saml2 authentication

Tested on cfe-support-playground and the saml2 auth endpoint was used. Was also able to load UI without crashing due to the userDetails. Would like to try hot-patching snapfish with their permission to see if it works.