### PR TITLE
UX-683/Fixed Azure RegionName and DisplayName bug

### DIFF
--- a/src/app/plugins/kubernetes/components/common/CloudProviderRegionPicklist.js
+++ b/src/app/plugins/kubernetes/components/common/CloudProviderRegionPicklist.js
@@ -4,6 +4,7 @@ import Picklist from 'core/components/Picklist'
 import useDataLoader from 'core/hooks/useDataLoader'
 import { pluck } from 'ramda'
 import { loadCloudProviderDetails } from 'k8s/components/infrastructure/cloudProviders/actions'
+import { CloudProviders } from '../infrastructure/cloudProviders/model'
 
 // We need to use `forwardRef` as a workaround of an issue with material-ui Tooltip https://github.com/gregnb/mui-datatables/issues/595
 // TODO use the CloudProviders enum to strongly type this type field once moved to TS
@@ -12,8 +13,11 @@ const CloudProviderRegionPicklist = forwardRef(({ cloudProviderId, type, ...rest
     cloudProviderId: cloudProviderId,
   })
 
-  const displayField = cloudProviderId && type === 'azure' ? 'DisplayName' : 'RegionName'
-  const options = pluck(displayField, details)
+  const displayField = cloudProviderId && type === CloudProviders.Aws ? 'RegionName' : 'DisplayName'
+  const options = details.map((detail) => ({
+    label: detail[displayField],
+    value: detail.RegionName,
+  }))
 
   return <Picklist {...rest} ref={ref} loading={loading} options={options} />
 })

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/custom.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/custom.tsx
@@ -290,7 +290,11 @@ const AdvancedAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                 )}
 
                 {/* SSH Key */}
-                <SshKeyField dropdownComponent={AwsClusterSshKeyPicklist} values={values} />
+                <SshKeyField
+                  dropdownComponent={AwsClusterSshKeyPicklist}
+                  cloudProviderType={CloudProviders.Aws}
+                  values={values}
+                />
 
                 {/* Template Chooser */}
                 <ClusterTemplatesField
@@ -309,6 +313,7 @@ const AdvancedAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                     {/* Master node instance type */}
                     <MasterNodeInstanceTypeField
                       dropdownComponent={AwsRegionFlavorPicklist}
+                      cloudProviderType={CloudProviders.Aws}
                       values={values}
                     />
 
@@ -318,6 +323,7 @@ const AdvancedAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                     {/* Worker node instance type */}
                     <WorkerNodeInstanceTypeField
                       dropdownComponent={AwsRegionFlavorPicklist}
+                      cloudProviderType={CloudProviders.Aws}
                       values={values}
                     />
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/custom.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/custom.tsx
@@ -294,6 +294,7 @@ const AdvancedAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                   dropdownComponent={AwsClusterSshKeyPicklist}
                   cloudProviderType={CloudProviders.Aws}
                   values={values}
+                  wizardContext={wizardContext}
                 />
 
                 {/* Template Chooser */}
@@ -315,6 +316,7 @@ const AdvancedAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                       dropdownComponent={AwsRegionFlavorPicklist}
                       cloudProviderType={CloudProviders.Aws}
                       values={values}
+                      wizardContext={wizardContext}
                     />
 
                     {/* Num master nodes */}
@@ -325,6 +327,7 @@ const AdvancedAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                       dropdownComponent={AwsRegionFlavorPicklist}
                       cloudProviderType={CloudProviders.Aws}
                       values={values}
+                      wizardContext={wizardContext}
                     />
 
                     {/* Num worker nodes */}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/custom.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/custom.tsx
@@ -181,7 +181,7 @@ const templateOptions = [
 // small (single dev) - 1 node master + worker - select instance type (default t2.small)
 // medium (internal team) - 1 master + 3 workers - select instance (default t2.medium)
 // large (production) - 3 master + 5 workers - no workload on masters (default t2.large)
-const handleTemplateChoice = ({ setWizardContext, setFieldValue }) => (option) => {
+const handleTemplateChoice = ({ setFieldValue }) => (option) => {
   const options = {
     small: {
       numMasters: 1,
@@ -215,8 +215,6 @@ const handleTemplateChoice = ({ setWizardContext, setFieldValue }) => (option) =
 
   // setImmediate is used because we need the fields to show up in the form before their values can be set
   setImmediate(() => {
-    setWizardContext({ template: option })
-    setWizardContext(options[option])
     Object.entries(options[option]).forEach(([key, value]) => {
       setFieldValue(key)(value)
     })
@@ -290,18 +288,12 @@ const AdvancedAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                 )}
 
                 {/* SSH Key */}
-                <SshKeyField
-                  dropdownComponent={AwsClusterSshKeyPicklist}
-                  cloudProviderType={CloudProviders.Aws}
-                  values={values}
-                  wizardContext={wizardContext}
-                />
+                <SshKeyField dropdownComponent={AwsClusterSshKeyPicklist} values={values} />
 
                 {/* Template Chooser */}
                 <ClusterTemplatesField
                   options={templateOptions}
                   onChange={handleTemplateChoice({
-                    setWizardContext,
                     setFieldValue,
                   })}
                 />
@@ -314,9 +306,7 @@ const AdvancedAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                     {/* Master node instance type */}
                     <MasterNodeInstanceTypeField
                       dropdownComponent={AwsRegionFlavorPicklist}
-                      cloudProviderType={CloudProviders.Aws}
                       values={values}
-                      wizardContext={wizardContext}
                     />
 
                     {/* Num master nodes */}
@@ -325,9 +315,7 @@ const AdvancedAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                     {/* Worker node instance type */}
                     <WorkerNodeInstanceTypeField
                       dropdownComponent={AwsRegionFlavorPicklist}
-                      cloudProviderType={CloudProviders.Aws}
                       values={values}
-                      wizardContext={wizardContext}
                     />
 
                     {/* Num worker nodes */}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/one-click.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/one-click.tsx
@@ -144,6 +144,7 @@ const OneClickAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                 dropdownComponent={AwsClusterSshKeyPickList}
                 cloudProviderType={CloudProviders.Aws}
                 values={values}
+                wizardContext={wizardContext}
               />
 
               {/* Cluster Domain */}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/one-click.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/one-click.tsx
@@ -140,12 +140,7 @@ const OneClickAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
               )}
 
               {/* SSH Key */}
-              <SshKeyField
-                dropdownComponent={AwsClusterSshKeyPickList}
-                cloudProviderType={CloudProviders.Aws}
-                values={values}
-                wizardContext={wizardContext}
-              />
+              <SshKeyField dropdownComponent={AwsClusterSshKeyPickList} values={values} />
 
               {/* Cluster Domain */}
               <ClusterDomainField

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/one-click.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/one-click.tsx
@@ -140,7 +140,11 @@ const OneClickAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
               )}
 
               {/* SSH Key */}
-              <SshKeyField dropdownComponent={AwsClusterSshKeyPickList} values={values} />
+              <SshKeyField
+                dropdownComponent={AwsClusterSshKeyPickList}
+                cloudProviderType={CloudProviders.Aws}
+                values={values}
+              />
 
               {/* Cluster Domain */}
               <ClusterDomainField

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/azure/AddAzureClusterPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/azure/AddAzureClusterPage.tsx
@@ -8,10 +8,8 @@ import { clusterActions } from 'k8s/components/infrastructure/clusters/actions'
 import { pathJoin } from 'utils/misc'
 import { k8sPrefix } from 'app/constants'
 import { CloudProviders } from '../../cloudProviders/model'
-
 import { routes } from 'core/utils/routes'
 import { ClusterCreateTypeNames, ClusterCreateTypes } from '../model'
-
 import WizardMeta from 'core/components/wizard/WizardMeta'
 import { getFormTitle } from '../helpers'
 import DocumentMeta from 'core/components/DocumentMeta'

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/azure/azure-availability-zone.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/azure/azure-availability-zone.tsx
@@ -24,7 +24,7 @@ const AzureAvailabilityZoneFields = ({ values, setWizardContext }) => {
         label="Use all availability zones"
         value={!values.region ? false : values.useAllAvailabilityZones}
         info=""
-        disabled={!values.cloudProviderRegionId}
+        disabled={!values.region}
       />
 
       {/* Azure Availability Zone */}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/azure/create-templates/custom.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/azure/create-templates/custom.tsx
@@ -7,13 +7,10 @@ import FormReviewTable from 'core/components/validatedForm/review-table'
 import ValidatedForm from 'core/components/validatedForm/ValidatedForm'
 import WizardStep from 'core/components/wizard/WizardStep'
 import useDataLoader from 'core/hooks/useDataLoader'
-import {
-  loadCloudProviderDetails,
-  loadCloudProviderRegionDetails,
-} from 'k8s/components/infrastructure/cloudProviders/actions'
+import { loadCloudProviderRegionDetails } from 'k8s/components/infrastructure/cloudProviders/actions'
 import { CloudProviders } from 'k8s/components/infrastructure/cloudProviders/model'
 import { azurePrerequisitesLink } from 'k8s/links'
-import React, { FC, useCallback } from 'react'
+import React, { FC } from 'react'
 import { pathStrOr } from 'utils/fp'
 import { castBoolToStr } from 'utils/misc'
 import { trackEvent } from 'utils/tracking'
@@ -180,7 +177,7 @@ const templateOptions = [
 // small (single dev) - 1 node master + worker - select instance type (default t2.small)
 // medium (internal team) - 1 master + 3 workers - select instance (default t2.medium)
 // large (production) - 3 master + 5 workers - no workload on masters (default t2.large)
-const handleTemplateChoice = ({ setWizardContext, setFieldValue }) => (option) => {
+const handleTemplateChoice = ({ setFieldValue }) => (option) => {
   const options = {
     small: {
       numMasters: 1,
@@ -214,8 +211,6 @@ const handleTemplateChoice = ({ setWizardContext, setFieldValue }) => (option) =
 
   // setImmediate is used because we need the fields to show up in the form before their values can be set
   setImmediate(() => {
-    setWizardContext({ template: option })
-    setWizardContext(options[option])
     Object.entries(options[option]).forEach(([key, value]) => {
       setFieldValue(key)(value)
     })
@@ -241,38 +236,13 @@ interface Props {
 const AdvancedAzureCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext }) => {
   const classes = useStyles()
 
-  const [cloudProviderDetails] = useDataLoader(loadCloudProviderDetails, {
-    cloudProviderId: wizardContext.cloudProviderId,
-  })
-
   const [cloudProviderRegionDetails] = useDataLoader(loadCloudProviderRegionDetails, {
     cloudProviderId: wizardContext.cloudProviderId,
     cloudProviderRegionId: wizardContext.location,
   })
   const virtualNetworks = pathStrOr([], '0.virtualNetworks', cloudProviderRegionDetails)
 
-  const mapRegionName = useCallback(
-    (displayName) => {
-      return cloudProviderDetails.find((x) => x.DisplayName === displayName).RegionName
-    },
-    [cloudProviderDetails],
-  )
-
-  /**
-   * Maps Azure's region display name to the actual region name
-   *
-   * Ex. East US -> eastus
-   *
-   * wizardContext.region contains the display name (Ex. East US)
-   * wizardContext.location will contain the region name (Ex. eastus)
-   */
-  const handleRegionChange = useCallback(
-    (displayName) => {
-      const regionName = mapRegionName(displayName)
-      setWizardContext({ location: regionName })
-    },
-    [cloudProviderDetails],
-  )
+  const handleRegionChange = (regionName) => setWizardContext({ location: regionName })
 
   return (
     <>
@@ -317,16 +287,15 @@ const AdvancedAzureCluster: FC<Props> = ({ wizardContext, setWizardContext, onNe
                 <ClusterTemplatesField
                   options={templateOptions}
                   onChange={handleTemplateChoice({
-                    setWizardContext,
                     setFieldValue,
                   })}
                 />
 
-                {wizardContext.template !== 'custom' && (
+                {values.template !== 'custom' && (
                   <AllowWorkloadsOnMasterField setWizardContext={setWizardContext} />
                 )}
 
-                {wizardContext.template === 'custom' && (
+                {values.template === 'custom' && (
                   <>
                     {/* Use All Availability Zones Checkbox Field and Azure Availability Zone Chooser */}
                     <AzureAvailabilityZoneFields
@@ -338,23 +307,13 @@ const AdvancedAzureCluster: FC<Props> = ({ wizardContext, setWizardContext, onNe
                     <NumMasterNodesField />
 
                     {/* Master node SKU */}
-                    <MasterNodeSkuField
-                      dropdownComponent={AzureSkuPicklist}
-                      cloudProviderType={CloudProviders.Azure}
-                      wizardContext={wizardContext}
-                      values={values}
-                    />
+                    <MasterNodeSkuField dropdownComponent={AzureSkuPicklist} values={values} />
 
                     {/* Num worker nodes */}
                     <NumWorkerNodesField />
 
                     {/* Worker node SKU */}
-                    <WorkerNodeSkuField
-                      dropdownComponent={AzureSkuPicklist}
-                      cloudProviderType={CloudProviders.Azure}
-                      wizardContext={wizardContext}
-                      values={values}
-                    />
+                    <WorkerNodeSkuField dropdownComponent={AzureSkuPicklist} values={values} />
 
                     {/* Allow workloads on masters */}
                     <AllowWorkloadsOnMasterField setWizardContext={setWizardContext} />
@@ -409,31 +368,21 @@ const AdvancedAzureCluster: FC<Props> = ({ wizardContext, setWizardContext, onNe
                     {/* Resource group */}
                     <ResourceGroupField
                       dropdownComponent={AzureResourceGroupPicklist}
-                      cloudProviderType={CloudProviders.Azure}
                       wizardContext={wizardContext}
                     />
 
                     {/* Existing network.  I don't get the point of this field. */}
-                    <ExistingNetworkField
-                      dropdownComponent={AzureVnetPicklist}
-                      cloudProviderType={CloudProviders.Azure}
-                      values={values}
-                      wizardContext={wizardContext}
-                    />
+                    <ExistingNetworkField dropdownComponent={AzureVnetPicklist} values={values} />
 
                     {/* Master node subnet */}
                     <MasterNodeSubnetField
                       dropdownComponent={AzureSubnetPicklist}
-                      cloudProviderType={CloudProviders.Azure}
-                      wizardContext={wizardContext}
                       values={values}
                     />
 
                     {/* Worker node subnet */}
                     <WorkerNodeSubnetField
                       dropdownComponent={AzureSubnetPicklist}
-                      cloudProviderType={CloudProviders.Azure}
-                      wizardContext={wizardContext}
                       values={values}
                     />
                   </>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/azure/create-templates/custom.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/azure/create-templates/custom.tsx
@@ -238,7 +238,7 @@ const AdvancedAzureCluster: FC<Props> = ({ wizardContext, setWizardContext, onNe
 
   const [cloudProviderRegionDetails] = useDataLoader(loadCloudProviderRegionDetails, {
     cloudProviderId: wizardContext.cloudProviderId,
-    cloudProviderRegionId: wizardContext.location,
+    cloudProviderRegionId: wizardContext.region,
   })
   const virtualNetworks = pathStrOr([], '0.virtualNetworks', cloudProviderRegionDetails)
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/azure/create-templates/custom.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/azure/create-templates/custom.tsx
@@ -247,7 +247,7 @@ const AdvancedAzureCluster: FC<Props> = ({ wizardContext, setWizardContext, onNe
 
   const [cloudProviderRegionDetails] = useDataLoader(loadCloudProviderRegionDetails, {
     cloudProviderId: wizardContext.cloudProviderId,
-    cloudProviderRegionId: wizardContext.cloudProviderRegionId,
+    cloudProviderRegionId: wizardContext.location,
   })
   const virtualNetworks = pathStrOr([], '0.virtualNetworks', cloudProviderRegionDetails)
 
@@ -258,6 +258,14 @@ const AdvancedAzureCluster: FC<Props> = ({ wizardContext, setWizardContext, onNe
     [cloudProviderDetails],
   )
 
+  /**
+   * Maps Azure's region display name to the actual region name
+   *
+   * Ex. East US -> eastus
+   *
+   * wizardContext.region contains the display name (Ex. East US)
+   * wizardContext.location will contain the region name (Ex. eastus)
+   */
   const handleRegionChange = useCallback(
     (displayName) => {
       const regionName = mapRegionName(displayName)
@@ -330,13 +338,23 @@ const AdvancedAzureCluster: FC<Props> = ({ wizardContext, setWizardContext, onNe
                     <NumMasterNodesField />
 
                     {/* Master node SKU */}
-                    <MasterNodeSkuField dropdownComponent={AzureSkuPicklist} values={values} />
+                    <MasterNodeSkuField
+                      dropdownComponent={AzureSkuPicklist}
+                      cloudProviderType={CloudProviders.Azure}
+                      wizardContext={wizardContext}
+                      values={values}
+                    />
 
                     {/* Num worker nodes */}
                     <NumWorkerNodesField />
 
                     {/* Worker node SKU */}
-                    <WorkerNodeSkuField dropdownComponent={AzureSkuPicklist} values={values} />
+                    <WorkerNodeSkuField
+                      dropdownComponent={AzureSkuPicklist}
+                      cloudProviderType={CloudProviders.Azure}
+                      wizardContext={wizardContext}
+                      values={values}
+                    />
 
                     {/* Allow workloads on masters */}
                     <AllowWorkloadsOnMasterField setWizardContext={setWizardContext} />
@@ -391,19 +409,22 @@ const AdvancedAzureCluster: FC<Props> = ({ wizardContext, setWizardContext, onNe
                     {/* Resource group */}
                     <ResourceGroupField
                       dropdownComponent={AzureResourceGroupPicklist}
+                      cloudProviderType={CloudProviders.Azure}
                       wizardContext={wizardContext}
                     />
 
                     {/* Existing network.  I don't get the point of this field. */}
                     <ExistingNetworkField
                       dropdownComponent={AzureVnetPicklist}
+                      cloudProviderType={CloudProviders.Azure}
                       values={values}
-                      wizardContext={setWizardContext}
+                      wizardContext={wizardContext}
                     />
 
                     {/* Master node subnet */}
                     <MasterNodeSubnetField
                       dropdownComponent={AzureSubnetPicklist}
+                      cloudProviderType={CloudProviders.Azure}
                       wizardContext={wizardContext}
                       values={values}
                     />
@@ -411,6 +432,7 @@ const AdvancedAzureCluster: FC<Props> = ({ wizardContext, setWizardContext, onNe
                     {/* Worker node subnet */}
                     <WorkerNodeSubnetField
                       dropdownComponent={AzureSubnetPicklist}
+                      cloudProviderType={CloudProviders.Azure}
                       wizardContext={wizardContext}
                       values={values}
                     />
@@ -421,7 +443,7 @@ const AdvancedAzureCluster: FC<Props> = ({ wizardContext, setWizardContext, onNe
                   <Alert
                     small
                     variant="error"
-                    message={`No existing virtual networks in location ${wizardContext.cloudProviderRegionId}.`}
+                    message={`No existing virtual networks in location ${wizardContext.region}.`}
                   />
                 )}
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/azure/create-templates/one-click.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/azure/create-templates/one-click.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react'
+import React, { FC } from 'react'
 import ValidatedForm from 'core/components/validatedForm/ValidatedForm'
 import ClusterNameField from '../../form-components/name'
 import { CloudProviders } from 'k8s/components/infrastructure/cloudProviders/model'
@@ -6,8 +6,6 @@ import { FormFieldCard } from 'core/components/validatedForm/FormFieldCard'
 import { azurePrerequisitesLink } from 'k8s/links'
 import Text from 'core/elements/text'
 import ExternalLink from 'core/components/ExternalLink'
-import { loadCloudProviderDetails } from 'k8s/components/infrastructure/cloudProviders/actions'
-import useDataLoader from 'core/hooks/useDataLoader'
 import WizardStep from 'core/components/wizard/WizardStep'
 import { makeStyles } from '@material-ui/core/styles'
 import Theme from 'core/themes/model'
@@ -79,24 +77,7 @@ interface Props {
 const OneClickAzureCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext }) => {
   const classes = useStyles()
 
-  const [cloudProviderDetails] = useDataLoader(loadCloudProviderDetails, {
-    cloudProviderId: wizardContext.cloudProviderId,
-  })
-
-  const mapRegionName = useCallback(
-    (displayName) => {
-      return cloudProviderDetails.find((x) => x.DisplayName === displayName).RegionName
-    },
-    [cloudProviderDetails],
-  )
-
-  const handleRegionChange = useCallback(
-    (displayName) => {
-      const regionName = mapRegionName(displayName)
-      setWizardContext({ location: regionName })
-    },
-    [cloudProviderDetails],
-  )
+  const handleRegionChange = (regionName) => setWizardContext({ location: regionName })
 
   return (
     <WizardStep stepId="one-click" onNext={onNext}>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/existing-network.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/existing-network.tsx
@@ -1,9 +1,10 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
+import { CloudProviders } from '../../cloudProviders/model'
 
-const ExistingNetworkField = ({ dropdownComponent, values, wizardContext }) => {
+const ExistingNetworkField = ({ dropdownComponent, cloudProviderType, values, wizardContext }) => {
   const cloudProviderRegionId =
-    wizardContext.region !== 'undefined' ? wizardContext.region : wizardContext.location // AWS uses region. Azure uses location
+    cloudProviderType === CloudProviders.Aws ? wizardContext.region : wizardContext.location // For Azure, it's location, not region
 
   return (
     <PicklistField

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/existing-network.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/existing-network.tsx
@@ -1,24 +1,18 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
-import { CloudProviders } from '../../cloudProviders/model'
 
-const ExistingNetworkField = ({ dropdownComponent, cloudProviderType, values, wizardContext }) => {
-  const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? wizardContext.region : wizardContext.location // For Azure, it's location, not region
-
-  return (
-    <PicklistField
-      DropdownComponent={dropdownComponent}
-      disabled={!(wizardContext.cloudProviderId && cloudProviderRegionId)}
-      id="vnetName"
-      label="Select existing network"
-      cloudProviderId={wizardContext.cloudProviderId}
-      cloudProviderRegionId={cloudProviderRegionId}
-      resourceGroup={values.vnetResourceGroup}
-      info="Select the network for your cluster."
-      required
-    />
-  )
-}
+const ExistingNetworkField = ({ dropdownComponent, values }) => (
+  <PicklistField
+    DropdownComponent={dropdownComponent}
+    disabled={!(values.cloudProviderId && values.region)}
+    id="vnetName"
+    label="Select existing network"
+    cloudProviderId={values.cloudProviderId}
+    cloudProviderRegionId={values.region}
+    resourceGroup={values.vnetResourceGroup}
+    info="Select the network for your cluster."
+    required
+  />
+)
 
 export default ExistingNetworkField

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-instance-type.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-instance-type.tsx
@@ -2,9 +2,14 @@ import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
 import { CloudProviders } from '../../cloudProviders/model'
 
-const MasterNodeInstanceTypeField = ({ dropdownComponent, cloudProviderType, values }) => {
+const MasterNodeInstanceTypeField = ({
+  dropdownComponent,
+  cloudProviderType,
+  values,
+  wizardContext,
+}) => {
   const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? values.region : values.location // For Azure, it's location, not region
+    cloudProviderType === CloudProviders.Aws ? values.region : wizardContext.location // For Azure, it's location, not region
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-instance-type.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-instance-type.tsx
@@ -1,8 +1,10 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
+import { CloudProviders } from '../../cloudProviders/model'
 
-const MasterNodeInstanceTypeField = ({ dropdownComponent, values }) => {
-  const cloudProviderRegionId = values.region !== 'undefined' ? values.region : values.location // AWS uses region. Azure uses location
+const MasterNodeInstanceTypeField = ({ dropdownComponent, cloudProviderType, values }) => {
+  const cloudProviderRegionId =
+    cloudProviderType === CloudProviders.Aws ? values.region : values.location // For Azure, it's location, not region
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-instance-type.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-instance-type.tsx
@@ -1,27 +1,17 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
-import { CloudProviders } from '../../cloudProviders/model'
 
-const MasterNodeInstanceTypeField = ({
-  dropdownComponent,
-  cloudProviderType,
-  values,
-  wizardContext,
-}) => {
-  const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? values.region : wizardContext.location // For Azure, it's location, not region
-  return (
-    <PicklistField
-      DropdownComponent={dropdownComponent}
-      disabled={!(values.cloudProviderId && cloudProviderRegionId)}
-      id="masterFlavor"
-      label="Master Node Instance Type"
-      cloudProviderId={values.cloudProviderId}
-      cloudProviderRegionId={cloudProviderRegionId}
-      info="Choose an instance type used by master nodes."
-      required
-    />
-  )
-}
+const MasterNodeInstanceTypeField = ({ dropdownComponent, values }) => (
+  <PicklistField
+    DropdownComponent={dropdownComponent}
+    disabled={!(values.cloudProviderId && values.region)}
+    id="masterFlavor"
+    label="Master Node Instance Type"
+    cloudProviderId={values.cloudProviderId}
+    cloudProviderRegionId={values.region}
+    info="Choose an instance type used by master nodes."
+    required
+  />
+)
 
 export default MasterNodeInstanceTypeField

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-sku.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-sku.tsx
@@ -1,24 +1,19 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
-import { CloudProviders } from '../../cloudProviders/model'
 
-const MasterNodeSkuField = ({ dropdownComponent, cloudProviderType, wizardContext, values }) => {
-  const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? values.region : wizardContext.location // For Azure, it's location, not region
-  return (
-    <PicklistField
-      DropdownComponent={dropdownComponent}
-      disabled={!(values.cloudProviderId && cloudProviderRegionId)}
-      id="masterSku"
-      label="Master Node SKU"
-      cloudProviderId={values.cloudProviderId}
-      cloudProviderRegionId={cloudProviderRegionId}
-      filterByZones={!values.useAllAvailabilityZones}
-      selectedZones={wizardContext.zones}
-      info="Choose an instance type used by master nodes."
-      required
-    />
-  )
-}
+const MasterNodeSkuField = ({ dropdownComponent, values }) => (
+  <PicklistField
+    DropdownComponent={dropdownComponent}
+    disabled={!(values.cloudProviderId && values.region)}
+    id="masterSku"
+    label="Master Node SKU"
+    cloudProviderId={values.cloudProviderId}
+    cloudProviderRegionId={values.region}
+    filterByZones={!values.useAllAvailabilityZones}
+    selectedZones={values.zones}
+    info="Choose an instance type used by master nodes."
+    required
+  />
+)
 
 export default MasterNodeSkuField

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-sku.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-sku.tsx
@@ -1,8 +1,10 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
+import { CloudProviders } from '../../cloudProviders/model'
 
-const MasterNodeSkuField = ({ dropdownComponent, values }) => {
-  const cloudProviderRegionId = values.region !== 'undefined' ? values.region : values.location // AWS uses region. Azure uses location
+const MasterNodeSkuField = ({ dropdownComponent, cloudProviderType, wizardContext, values }) => {
+  const cloudProviderRegionId =
+    cloudProviderType === CloudProviders.Aws ? wizardContext.region : wizardContext.location // For Azure, it's location, not region
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}
@@ -12,7 +14,7 @@ const MasterNodeSkuField = ({ dropdownComponent, values }) => {
       cloudProviderId={values.cloudProviderId}
       cloudProviderRegionId={cloudProviderRegionId}
       filterByZones={!values.useAllAvailabilityZones}
-      selectedZones={values.zones}
+      selectedZones={wizardContext.zones}
       info="Choose an instance type used by master nodes."
       required
     />

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-sku.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-sku.tsx
@@ -4,7 +4,7 @@ import { CloudProviders } from '../../cloudProviders/model'
 
 const MasterNodeSkuField = ({ dropdownComponent, cloudProviderType, wizardContext, values }) => {
   const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? wizardContext.region : wizardContext.location // For Azure, it's location, not region
+    cloudProviderType === CloudProviders.Aws ? values.region : wizardContext.location // For Azure, it's location, not region
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-subnet.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-subnet.tsx
@@ -1,9 +1,10 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
+import { CloudProviders } from '../../cloudProviders/model'
 
-const MasterNodeSubnetField = ({ dropdownComponent, wizardContext, values }) => {
+const MasterNodeSubnetField = ({ dropdownComponent, cloudProviderType, wizardContext, values }) => {
   const cloudProviderRegionId =
-    wizardContext.region !== 'undefined' ? wizardContext.region : wizardContext.location // AWS uses region. Azure uses location
+    cloudProviderType === CloudProviders.Aws ? wizardContext.region : wizardContext.location // For Azure, it's location, not region
 
   return (
     <PicklistField

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-subnet.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/master-node-subnet.tsx
@@ -1,24 +1,18 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
-import { CloudProviders } from '../../cloudProviders/model'
 
-const MasterNodeSubnetField = ({ dropdownComponent, cloudProviderType, wizardContext, values }) => {
-  const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? wizardContext.region : wizardContext.location // For Azure, it's location, not region
-
-  return (
-    <PicklistField
-      DropdownComponent={dropdownComponent}
-      disabled={!(wizardContext.cloudProviderId && cloudProviderRegionId)}
-      id="masterSubnetName"
-      label="Master node subnet"
-      cloudProviderId={wizardContext.cloudProviderId}
-      cloudProviderRegionId={cloudProviderRegionId}
-      resourceGroup={values.vnetResourceGroup}
-      info="Select the subnet for your master nodes. Can be the same as worker node subnet."
-      required
-    />
-  )
-}
+const MasterNodeSubnetField = ({ dropdownComponent, values }) => (
+  <PicklistField
+    DropdownComponent={dropdownComponent}
+    disabled={!(values.cloudProviderId && values.region)}
+    id="masterSubnetName"
+    label="Master node subnet"
+    cloudProviderId={values.cloudProviderId}
+    cloudProviderRegionId={values.region}
+    resourceGroup={values.vnetResourceGroup}
+    info="Select the subnet for your master nodes. Can be the same as worker node subnet."
+    required
+  />
+)
 
 export default MasterNodeSubnetField

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/resource-group.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/resource-group.tsx
@@ -1,22 +1,17 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
-import { CloudProviders } from '../../cloudProviders/model'
 
-const ResourceGroupField = ({ dropdownComponent, cloudProviderType, wizardContext }) => {
-  const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? wizardContext.region : wizardContext.location // For Azure, it's location, not region
-  return (
-    <PicklistField
-      DropdownComponent={dropdownComponent}
-      disabled={!(wizardContext.cloudProviderId && cloudProviderRegionId)}
-      id="vnetResourceGroup"
-      label="Resource group"
-      cloudProviderId={wizardContext.cloudProviderId}
-      cloudProviderRegionId={cloudProviderRegionId}
-      info="Select the resource group that your networking resources belong to."
-      required
-    />
-  )
-}
+const ResourceGroupField = ({ dropdownComponent, wizardContext }) => (
+  <PicklistField
+    DropdownComponent={dropdownComponent}
+    disabled={!(wizardContext.cloudProviderId && wizardContext.region)}
+    id="vnetResourceGroup"
+    label="Resource group"
+    cloudProviderId={wizardContext.cloudProviderId}
+    cloudProviderRegionId={wizardContext.region}
+    info="Select the resource group that your networking resources belong to."
+    required
+  />
+)
 
 export default ResourceGroupField

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/resource-group.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/resource-group.tsx
@@ -1,9 +1,10 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
+import { CloudProviders } from '../../cloudProviders/model'
 
-const ResourceGroupField = ({ dropdownComponent, wizardContext }) => {
+const ResourceGroupField = ({ dropdownComponent, cloudProviderType, wizardContext }) => {
   const cloudProviderRegionId =
-    wizardContext.region !== 'undefined' ? wizardContext.region : wizardContext.location // AWS uses region. Azure uses location
+    cloudProviderType === CloudProviders.Aws ? wizardContext.region : wizardContext.location // For Azure, it's location, not region
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/ssh-key-picklist.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/ssh-key-picklist.tsx
@@ -1,18 +1,15 @@
 import React from 'react'
 import PicklistField from 'core/components/validatedForm/PicklistField'
-import { CloudProviders } from '../../cloudProviders/model'
 
-export default ({ dropdownComponent, cloudProviderType, values, wizardContext }) => {
-  const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? values.region : wizardContext.location // For Azure, it's location, not region
+export default ({ dropdownComponent, values }) => {
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}
-      disabled={!(values.cloudProviderId && cloudProviderRegionId)}
+      disabled={!(values.cloudProviderId && values.region)}
       id="sshKey"
       label="SSH Key"
       cloudProviderId={values.cloudProviderId}
-      cloudProviderRegionId={cloudProviderRegionId}
+      cloudProviderRegionId={values.region}
       info="Select an AWS SSH key to be associated with the nodes. This key can be used to access the nodes for debugging or other purposes."
       required
     />

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/ssh-key-picklist.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/ssh-key-picklist.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import { CloudProviders } from '../../cloudProviders/model'
 
-export default ({ dropdownComponent, cloudProviderType, values }) => {
+export default ({ dropdownComponent, cloudProviderType, values, wizardContext }) => {
   const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? values.region : values.location // For Azure, it's location, not region
+    cloudProviderType === CloudProviders.Aws ? values.region : wizardContext.location // For Azure, it's location, not region
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/ssh-key-picklist.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/ssh-key-picklist.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import PicklistField from 'core/components/validatedForm/PicklistField'
+import { CloudProviders } from '../../cloudProviders/model'
 
-export default ({ dropdownComponent, values }) => {
-  const cloudProviderRegionId = values.region !== 'undefined' ? values.region : values.location // AWS uses region. Azure uses location
+export default ({ dropdownComponent, cloudProviderType, values }) => {
+  const cloudProviderRegionId =
+    cloudProviderType === CloudProviders.Aws ? values.region : values.location // For Azure, it's location, not region
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-instance-type.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-instance-type.tsx
@@ -2,9 +2,14 @@ import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
 import { CloudProviders } from '../../cloudProviders/model'
 
-const WorkerNodeInstanceTypeField = ({ dropdownComponent, cloudProviderType, values }) => {
+const WorkerNodeInstanceTypeField = ({
+  dropdownComponent,
+  cloudProviderType,
+  values,
+  wizardContext,
+}) => {
   const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? values.region : values.location // For Azure, it's location, not region
+    cloudProviderType === CloudProviders.Aws ? values.region : wizardContext.location // For Azure, it's location, not region
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-instance-type.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-instance-type.tsx
@@ -1,8 +1,10 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
+import { CloudProviders } from '../../cloudProviders/model'
 
-const WorkerNodeInstanceTypeField = ({ dropdownComponent, values }) => {
-  const cloudProviderRegionId = values.region !== 'undefined' ? values.region : values.location // AWS uses region. Azure uses location
+const WorkerNodeInstanceTypeField = ({ dropdownComponent, cloudProviderType, values }) => {
+  const cloudProviderRegionId =
+    cloudProviderType === CloudProviders.Aws ? values.region : values.location // For Azure, it's location, not region
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-instance-type.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-instance-type.tsx
@@ -1,27 +1,17 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
-import { CloudProviders } from '../../cloudProviders/model'
 
-const WorkerNodeInstanceTypeField = ({
-  dropdownComponent,
-  cloudProviderType,
-  values,
-  wizardContext,
-}) => {
-  const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? values.region : wizardContext.location // For Azure, it's location, not region
-  return (
-    <PicklistField
-      DropdownComponent={dropdownComponent}
-      disabled={!(values.cloudProviderId && cloudProviderRegionId)}
-      id="workerFlavor"
-      label="Worker Node Instance Type"
-      cloudProviderId={values.cloudProviderId}
-      cloudProviderRegionId={cloudProviderRegionId}
-      info="Choose an instance type used by worker nodes."
-      required
-    />
-  )
-}
+const WorkerNodeInstanceTypeField = ({ dropdownComponent, values }) => (
+  <PicklistField
+    DropdownComponent={dropdownComponent}
+    disabled={!(values.cloudProviderId && values.region)}
+    id="workerFlavor"
+    label="Worker Node Instance Type"
+    cloudProviderId={values.cloudProviderId}
+    cloudProviderRegionId={values.region}
+    info="Choose an instance type used by worker nodes."
+    required
+  />
+)
 
 export default WorkerNodeInstanceTypeField

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-sku.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-sku.tsx
@@ -1,8 +1,10 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
+import { CloudProviders } from '../../cloudProviders/model'
 
-const WorkerNodeSkuField = ({ dropdownComponent, values }) => {
-  const cloudProviderRegionId = values.region !== 'undefined' ? values.region : values.location // AWS uses region. Azure uses location
+const WorkerNodeSkuField = ({ dropdownComponent, cloudProviderType, wizardContext, values }) => {
+  const cloudProviderRegionId =
+    cloudProviderType === CloudProviders.Aws ? wizardContext.region : wizardContext.location // For Azure, it's location, not region
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}
@@ -12,7 +14,7 @@ const WorkerNodeSkuField = ({ dropdownComponent, values }) => {
       cloudProviderId={values.cloudProviderId}
       cloudProviderRegionId={cloudProviderRegionId}
       filterByZones={!values.useAllAvailabilityZones}
-      selectedZones={values.zones}
+      selectedZones={wizardContext.zones}
       info="Choose an instance type used by worker nodes."
       required
     />

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-sku.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-sku.tsx
@@ -1,24 +1,19 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
-import { CloudProviders } from '../../cloudProviders/model'
 
-const WorkerNodeSkuField = ({ dropdownComponent, cloudProviderType, wizardContext, values }) => {
-  const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? wizardContext.region : wizardContext.location // For Azure, it's location, not region
-  return (
-    <PicklistField
-      DropdownComponent={dropdownComponent}
-      disabled={!(values.cloudProviderId && cloudProviderRegionId)}
-      id="workerSku"
-      label="Worker Node SKU"
-      cloudProviderId={values.cloudProviderId}
-      cloudProviderRegionId={cloudProviderRegionId}
-      filterByZones={!values.useAllAvailabilityZones}
-      selectedZones={wizardContext.zones}
-      info="Choose an instance type used by worker nodes."
-      required
-    />
-  )
-}
+const WorkerNodeSkuField = ({ dropdownComponent, values }) => (
+  <PicklistField
+    DropdownComponent={dropdownComponent}
+    disabled={!(values.cloudProviderId && values.region)}
+    id="workerSku"
+    label="Worker Node SKU"
+    cloudProviderId={values.cloudProviderId}
+    cloudProviderRegionId={values.region}
+    filterByZones={!values.useAllAvailabilityZones}
+    selectedZones={values.zones}
+    info="Choose an instance type used by worker nodes."
+    required
+  />
+)
 
 export default WorkerNodeSkuField

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-subnet.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-subnet.tsx
@@ -1,9 +1,11 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
+import { CloudProviders } from '../../cloudProviders/model'
 
-const WorkerNodeSubnetField = ({ dropdownComponent, wizardContext, values }) => {
+const WorkerNodeSubnetField = ({ dropdownComponent, cloudProviderType, wizardContext, values }) => {
   const cloudProviderRegionId =
-    wizardContext.region !== 'undefined' ? wizardContext.region : wizardContext.location // AWS uses region. Azure uses location
+    cloudProviderType === CloudProviders.Aws ? wizardContext.region : wizardContext.location // For Azure, it's location, not region
+
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-subnet.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/worker-node-subnet.tsx
@@ -1,24 +1,18 @@
 import PicklistField from 'core/components/validatedForm/PicklistField'
 import React from 'react'
-import { CloudProviders } from '../../cloudProviders/model'
 
-const WorkerNodeSubnetField = ({ dropdownComponent, cloudProviderType, wizardContext, values }) => {
-  const cloudProviderRegionId =
-    cloudProviderType === CloudProviders.Aws ? wizardContext.region : wizardContext.location // For Azure, it's location, not region
-
-  return (
-    <PicklistField
-      DropdownComponent={dropdownComponent}
-      disabled={!(wizardContext.cloudProviderId && cloudProviderRegionId)}
-      id="workerSubnetName"
-      label="Worker node subnet"
-      cloudProviderId={wizardContext.cloudProviderId}
-      cloudProviderRegionId={cloudProviderRegionId}
-      resourceGroup={values.vnetResourceGroup}
-      info="Select the subnet for your worker nodes. Can be the same as master node subnet."
-      required
-    />
-  )
-}
+const WorkerNodeSubnetField = ({ dropdownComponent, values }) => (
+  <PicklistField
+    DropdownComponent={dropdownComponent}
+    disabled={!(values.cloudProviderId && values.region)}
+    id="workerSubnetName"
+    label="Worker node subnet"
+    cloudProviderId={values.cloudProviderId}
+    cloudProviderRegionId={values.region}
+    resourceGroup={values.vnetResourceGroup}
+    info="Select the subnet for your worker nodes. Can be the same as master node subnet."
+    required
+  />
+)
 
 export default WorkerNodeSubnetField


### PR DESCRIPTION
When creating a custom Azure cluster,  existing networks are now shown in the Networks Configuration step.

The bug was related to Azure's display and region name mapping

![Screen Shot 2020-10-29 at 1 16 13 PM](https://user-images.githubusercontent.com/23369276/97631708-981ed380-19ee-11eb-9fe4-b3c5a965ca08.png)
