### PR TITLE
UX-433, UX-495/ Modified scaling masters constraints. Allow user to scale master nodes 1 at a time. Changed cluster connection and health status to show loading icon loading.

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/AddCloudProviderVerificationStep.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/AddCloudProviderVerificationStep.tsx
@@ -13,9 +13,6 @@ import WizardMeta from 'core/components/wizard/WizardMeta'
 const objSwitchCaseAny: any = objSwitchCase // types on forward ref .js file dont work well.
 
 const useStyles = makeStyles((theme: Theme) => ({
-  wizardMeta: {
-    marginTop: theme.spacing(4),
-  },
   cpName: {
     color: theme.palette.grey['700'],
     paddingTop: theme.spacing(2),
@@ -49,7 +46,6 @@ const AddCloudProviderVerificationStep = ({ wizardContext, setWizardContext }: P
       <WizardMeta
         fields={wizardContext}
         icon={<CloudProviderCard active type={wizardContext.provider} />}
-        className={classes.wizardMeta}
       >
         <div className={classes.form}>
           <ValidatedForm

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatus.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatus.tsx
@@ -135,6 +135,7 @@ interface IClusterStatusProps {
   cluster: IClusterSelector
   variant?: StatusVariant
   message?: string
+  iconStatus?: boolean
 }
 
 export const ClusterHealthStatus: FC<IClusterStatusProps> = ({
@@ -156,7 +157,6 @@ export const ClusterHealthStatus: FC<IClusterStatusProps> = ({
           title={fields.message}
           status={fields.status}
           variant={variant}
-          iconStatus={fields.status === 'loading' ? true : false}
           {...rest}
         >
           {variant === 'header' ? (
@@ -195,7 +195,6 @@ export const ClusterConnectionStatus: FC<IClusterStatusProps> = ({
       title={fields.message}
       status={fields.clusterStatus}
       variant={variant}
-      iconStatus={fields.clusterStatus === 'loading' ? true : false}
       {...rest}
     >
       {variant === 'header' ? (

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatus.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatus.tsx
@@ -133,7 +133,7 @@ const renderTransientStatus = ({ uuid, connectionStatus }, variant) => {
 
 interface IClusterStatusProps {
   cluster: IClusterSelector
-  variant: StatusVariant
+  variant?: StatusVariant
   message?: string
 }
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatus.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatus.tsx
@@ -156,6 +156,7 @@ export const ClusterHealthStatus: FC<IClusterStatusProps> = ({
           title={fields.message}
           status={fields.status}
           variant={variant}
+          iconStatus={fields.status === 'loading' ? true : false}
           {...rest}
         >
           {variant === 'header' ? (
@@ -194,6 +195,7 @@ export const ClusterConnectionStatus: FC<IClusterStatusProps> = ({
       title={fields.message}
       status={fields.clusterStatus}
       variant={variant}
+      iconStatus={fields.clusterStatus === 'loading' ? true : false}
       {...rest}
     >
       {variant === 'header' ? (

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.js
@@ -27,6 +27,8 @@ import { cloudProviderTypes } from '../cloudProviders/selectors'
 import ClusterDeleteDialog from './ClusterDeleteDialog'
 import DownloadKubeConfigLink from './DownloadKubeConfigLink'
 import ResourceUsageTables from '../common/ResourceUsageTables'
+import { CloudProviders } from '../cloudProviders/model'
+import { hasConvergingNodes } from './ClusterStatusUtils'
 
 const useStyles = makeStyles((theme) => ({
   links: {
@@ -131,9 +133,12 @@ const renderMetaData = (_, { tags }) => {
 }
 
 const canScaleMasters = ([cluster]) =>
+  cluster.cloudProviderType === CloudProviders.BareOS &&
+  cluster.status === 'ok' &&
   cluster.taskStatus === 'success' &&
-  cluster.cloudProviderType === 'local' &&
-  (cluster.nodes || []).length > 1
+  ((cluster.nodes || []).length > 1 || cluster.masterVipIpv4 != '') &&
+  cluster.masterNodesHealthStatus === 'healthy' &&
+  !hasConvergingNodes(cluster.nodes)
 const canScaleWorkers = ([cluster]) => cluster.taskStatus === 'success'
 const canUpgradeCluster = ([cluster]) => !!(cluster && cluster.canUpgrade)
 const canDeleteCluster = ([cluster]) => !['creating', 'deleting'].includes(cluster.taskStatus)

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ScaleMastersPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ScaleMastersPage.tsx
@@ -177,14 +177,7 @@ const ScaleMasters: FunctionComponent<ScaleMasterProps> = ({
   const bareOsValidator = useCallback(() => {
     return customValidator(() => {
       // BareOs clusters with single master node cannot scale without a virtial IP
-      if (
-        cluster.cloudProviderType === CloudProviders.BareOS &&
-        numMasters === 1 &&
-        !hasMasterVip
-      ) {
-        return false
-      }
-      return true
+      return cluster.cloudProviderType === CloudProviders.BareOS && (numMasters > 1 || hasMasterVip)
     }, 'No Virtual IP Detected. To scale Masters a Virtual IP is required. Please recreate this cluster and provide a Virtual IP on the Network step')
   }, [cluster, params])()
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ScaleMastersPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ScaleMastersPage.tsx
@@ -39,16 +39,17 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }))
 
-const oneNodeMessage =
-  "A single master cluster is thus never recommended for production environments as it can not tolerate any loss of masters. Its only recommended for test environments where you wish to quickly deploy a cluster and you can tolerate the possibility of cluster downtime caused by the master going down. You can not add more master nodes to a cluster that's created with a single master node today. You need to start with a cluster that has atleast 2 master nodes before you can add any more masters to it."
-const twoNodeMessage =
-  'A 2 master cluster can not tolerate any master loss. Losing 1 master will cause quorum to be lost and so the etcd cluster and hence the Kubernetes cluster will not function.'
-const threeNodeMessage =
-  '3 masters is the minimum we recommend for a highly available cluster. A 3 master cluster can tolerate loss of at most 1 master at a given time. In that case, the remaining 2 masters will elect a new active master if necessary.'
-const fourNodeMessage =
-  'A 4 master cluster can tolerate loss of at most 1 master at a given time. In that case, the remaining 3 masters will have majroity and will elect a new active master if necessary.'
-const fiveNodeMessage =
-  '	A 5 master cluster can tolerate loss of at most 2 masters at a given time. In that case, the remaining 4 or 3 masters will have majroity and will elect a new active master if necessary.'
+// Quorum Messages
+const zeroMasterMsg =
+  'You cannot remove master node from a single master cluster.  If you wish to delete the cluster, please choose the ‘delete’ operation on the cluster on the infrastructure page instead.'
+const oneMasterMsg =
+  'Quorum Risk. A single master cluster is not recommended for production environments. An outage of the master will bring the cluster offline. Recommended for test environments only.'
+const twoMastersMsg =
+  'Quorum Risk. A two master cluster does not hold quorum. Losing 1 master will cause the Kubernetes cluster to not function.'
+const threeMastersMsg = 'Quorum Achieved with a tolerance of 1.'
+const fourMastersMsg =
+  'Quorum Achieved with a tolerance of 1. Operating four masters can tolerate a loss of at  most 1 node as quorum is majority, 3 of 4.'
+const fiveMastersMsg = 'Quorum Achieved with a tolerance of 2.'
 
 interface IConstraint {
   startNum: number
@@ -64,32 +65,31 @@ export const scaleConstraints: IConstraint[] = [
     startNum: 5,
     desiredNum: 4,
     relation: 'allow',
-    message: fourNodeMessage,
+    message: fourMastersMsg,
   },
   {
     startNum: 4,
     desiredNum: 3,
     relation: 'allow',
-    message: threeNodeMessage,
+    message: threeMastersMsg,
   },
   {
     startNum: 3,
     desiredNum: 2,
     relation: 'allow',
-    message: twoNodeMessage,
+    message: twoMastersMsg,
   },
   {
     startNum: 2,
     desiredNum: 1,
     relation: 'allow',
-    message: oneNodeMessage,
+    message: oneMasterMsg,
   },
   {
     startNum: 1,
     desiredNum: 0,
     relation: 'deny',
-    message:
-      'You cannot remove master node from a single master cluster.  If you wish to delete the cluster, please choose the ‘delete’ operation on the cluster on the infrastructure page instead.',
+    message: zeroMasterMsg,
   },
 
   // grow
@@ -97,25 +97,25 @@ export const scaleConstraints: IConstraint[] = [
     startNum: 1,
     desiredNum: 2,
     relation: 'allow',
-    message: twoNodeMessage,
+    message: twoMastersMsg,
   },
   {
     startNum: 2,
     desiredNum: 3,
     relation: 'allow',
-    message: threeNodeMessage,
+    message: threeMastersMsg,
   },
   {
     startNum: 3,
     desiredNum: 4,
     relation: 'allow',
-    message: fourNodeMessage,
+    message: fourMastersMsg,
   },
   {
     startNum: 4,
     desiredNum: 5,
     relation: 'allow',
-    message: fiveNodeMessage,
+    message: fiveMastersMsg,
   },
 ]
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/helpers.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/helpers.ts
@@ -17,8 +17,7 @@ export const clusterNotBusy = (cluster) =>
   cluster.taskStatus === 'success' && !hasConvergingNodes(cluster.nodes)
 
 export const isBareOsMultiMasterCluster = (cluster) =>
-  cluster.cloudProviderType === CloudProviders.BareOS &&
-  (cluster.masterNodes?.length > 1 || !!cluster.masterVipIpv4)
+  cluster.cloudProviderType === CloudProviders.BareOS && !!cluster.masterVipIpv4
 
 export const canScaleMasters = ([cluster]) =>
   isBareOsMultiMasterCluster(cluster) && clusterIsHealthy(cluster) && clusterNotBusy(cluster)

--- a/src/app/plugins/kubernetes/components/infrastructure/common/ResourceUsageTables.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/common/ResourceUsageTables.tsx
@@ -3,7 +3,7 @@ import ResourceUsageTable from './ResourceUsageTable'
 
 interface Props {
   usage: Usage
-  valueOff: boolean
+  valueOff?: boolean
 }
 
 interface Usage {


### PR DESCRIPTION
**Changes:**
- User can only scale master nodes one at a time

- User cannot scale master nodes while there are master nodes converging

- Master nodes can only be scaled when all master nodes in the cluster are healthy

- BareOs clusters with a single master node can only be scaled up with a virtual IP



![Screen Shot 2020-11-03 at 2 27 49 PM](https://user-images.githubusercontent.com/23369276/98047476-cd596600-1de0-11eb-8208-3a63e51865c8.png)



**Non-related changes:**

- Loading icon is now shown when cluster is converging

![Screen Shot 2020-11-02 at 5 05 39 PM](https://user-images.githubusercontent.com/23369276/97935666-1dc3bb80-1d2e-11eb-84cc-ba846046327a.png)


- Removed top margin from cloud provider verification page

![Screen Shot 2020-11-04 at 2 10 05 PM](https://user-images.githubusercontent.com/23369276/98176125-cef06000-1eac-11eb-9bce-5d907ed3e678.png)


