### PR TITLE
UX-717/Fixed AWS regions not showing in update cloud provider page

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/AwsCloudProviderVerification.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/AwsCloudProviderVerification.tsx
@@ -3,7 +3,6 @@ import { makeStyles } from '@material-ui/styles'
 import Theme from 'core/themes/model'
 import FontAwesomeIcon from 'core/components/FontAwesomeIcon'
 import PicklistField from 'core/components/validatedForm/PicklistField'
-import CloudProviderRegionPicklist from 'k8s/components/common/CloudProviderRegionPicklist'
 import ClusterDomainPicklist from '../clusters/ClusterDomainPicklist'
 import AwsClusterSshKeyPicklist from '../clusters/aws/AwsClusterSshKeyPicklist'
 import Info from 'core/components/validatedForm/Info'
@@ -15,6 +14,9 @@ import { pathStrOr } from 'utils/fp'
 import { FormFieldCard } from 'core/components/validatedForm/FormFieldCard'
 import Text from 'core/elements/text'
 import { getIcon, getIconClass, RegionAvailability } from './helpers'
+import { CloudProviders } from './model'
+import CloudProviderRegionField from '../clusters/form-components/cloud-provider-region'
+import SshKeyField from '../clusters/form-components/ssh-key-picklist'
 
 const useStyles = makeStyles((theme: Theme) => ({
   spaceRight: {
@@ -118,13 +120,10 @@ const AwsCloudProviderVerification = ({ wizardContext, setWizardContext }: Props
         <Text variant="body2">
           Platform9 deploys Kubernetes clusters into specified AWS Regions.
         </Text>
-        <PicklistField
-          DropdownComponent={CloudProviderRegionPicklist}
-          id="region"
-          label="Region"
-          cloudProviderId={wizardContext.cloudProviderId}
+        <CloudProviderRegionField
+          cloudProviderType={CloudProviders.Aws}
           onChange={(region) => setWizardContext({ cloudProviderRegionId: region })}
-          value={wizardContext.cloudProviderRegionId}
+          values={wizardContext}
         />
       </FormFieldCard>
       <FormFieldCard
@@ -181,14 +180,7 @@ const AwsCloudProviderVerification = ({ wizardContext, setWizardContext }: Props
         }
       >
         <Text variant="body2">SSH Keys are required for access to manage EC2 Instances.</Text>
-        <PicklistField
-          DropdownComponent={AwsClusterSshKeyPicklist}
-          disabled={!(wizardContext.cloudProviderId && wizardContext.cloudProviderRegionId)}
-          id="sshKey"
-          label="SSH Key"
-          cloudProviderId={wizardContext.cloudProviderId}
-          cloudProviderRegionId={wizardContext.cloudProviderRegionId}
-        />
+        <SshKeyField dropdownComponent={AwsClusterSshKeyPicklist} values={wizardContext} info="" />
       </FormFieldCard>
     </>
   )

--- a/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/AwsCloudProviderVerification.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/AwsCloudProviderVerification.tsx
@@ -97,8 +97,6 @@ const AwsCloudProviderVerification = ({ wizardContext, setWizardContext }: Props
     cloudProviderRegionId: wizardContext.region,
   })
 
-  console.log('region', details)
-
   const domains = pathStrOr([], '0.domains', details)
   const keypairs = pathStrOr([], '0.keyPairs', details)
 

--- a/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/AwsCloudProviderVerification.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/AwsCloudProviderVerification.tsx
@@ -94,8 +94,10 @@ const AwsCloudProviderVerification = ({ wizardContext, setWizardContext }: Props
 
   const [details, loading] = useDataLoader(loadCloudProviderRegionDetails, {
     cloudProviderId: wizardContext.cloudProviderId,
-    cloudProviderRegionId: wizardContext.cloudProviderRegionId,
+    cloudProviderRegionId: wizardContext.region,
   })
+
+  console.log('region', details)
 
   const domains = pathStrOr([], '0.domains', details)
   const keypairs = pathStrOr([], '0.keyPairs', details)
@@ -122,7 +124,7 @@ const AwsCloudProviderVerification = ({ wizardContext, setWizardContext }: Props
         </Text>
         <CloudProviderRegionField
           cloudProviderType={CloudProviders.Aws}
-          onChange={(region) => setWizardContext({ cloudProviderRegionId: region })}
+          onChange={(value) => setWizardContext({ region: value })}
           values={wizardContext}
         />
       </FormFieldCard>
@@ -131,7 +133,7 @@ const AwsCloudProviderVerification = ({ wizardContext, setWizardContext }: Props
         middleHeader={
           <Route53Availability
             loading={loading}
-            regionId={wizardContext.cloudProviderRegionId}
+            regionId={wizardContext.region}
             domains={domains}
           />
         }
@@ -149,10 +151,10 @@ const AwsCloudProviderVerification = ({ wizardContext, setWizardContext }: Props
           id="awsDomain"
           label="Route 53 Domain"
           cloudProviderId={wizardContext.cloudProviderId}
-          cloudProviderRegionId={wizardContext.cloudProviderRegionId}
-          disabled={!(wizardContext.cloudProviderId && wizardContext.cloudProviderRegionId)}
+          cloudProviderRegionId={wizardContext.region}
+          disabled={!(wizardContext.cloudProviderId && wizardContext.region)}
         />
-        {wizardContext.cloudProviderRegionId && !loading && !domains.length && (
+        {wizardContext.region && !loading && !domains.length && (
           <Info>
             <div>No registered Route53 Domains have been detected.</div>
             <div>Please register at least one domain with AWS Route53 to use Platform9.</div>
@@ -169,7 +171,7 @@ const AwsCloudProviderVerification = ({ wizardContext, setWizardContext }: Props
         middleHeader={
           <SshKeyAvailability
             loading={loading}
-            regionId={wizardContext.cloudProviderRegionId}
+            regionId={wizardContext.region}
             keypairs={keypairs}
           />
         }

--- a/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/AzureCloudProviderVerification.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/AzureCloudProviderVerification.tsx
@@ -59,7 +59,7 @@ const AzureCloudProviderVerification = ({ wizardContext, setWizardContext }: Pro
         </Text>
         <CloudProviderRegionField
           cloudProviderType={CloudProviders.Azure}
-          onChange={(region) => setWizardContext({ cloudProviderRegionId: region })}
+          onChange={(value) => setWizardContext({ region: value })}
           values={wizardContext}
         />
       </FormFieldCard>

--- a/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/AzureCloudProviderVerification.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/AzureCloudProviderVerification.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import { makeStyles } from '@material-ui/styles'
 import Theme from 'core/themes/model'
-import PicklistField from 'core/components/validatedForm/PicklistField'
-import CloudProviderRegionPicklist from 'k8s/components/common/CloudProviderRegionPicklist'
 import ExternalLink from 'core/components/ExternalLink'
 import { azurePrerequisitesLink } from 'k8s/links'
 import useDataLoader from 'core/hooks/useDataLoader'
@@ -10,6 +8,8 @@ import { loadCloudProviderDetails } from './actions'
 import { FormFieldCard } from 'core/components/validatedForm/FormFieldCard'
 import Text from 'core/elements/text'
 import { RegionAvailability } from './helpers'
+import { CloudProviders } from './model'
+import CloudProviderRegionField from '../clusters/form-components/cloud-provider-region'
 
 const useStyles = makeStyles((theme: Theme) => ({
   spaceRight: {
@@ -57,13 +57,10 @@ const AzureCloudProviderVerification = ({ wizardContext, setWizardContext }: Pro
         <Text variant="body2">
           Platform9 deploys Kubernetes clusters into specified Azure Regions.
         </Text>
-        <PicklistField
-          DropdownComponent={CloudProviderRegionPicklist}
-          id="region"
-          label="Region"
-          cloudProviderId={wizardContext.cloudProviderId}
+        <CloudProviderRegionField
+          cloudProviderType={CloudProviders.Azure}
           onChange={(region) => setWizardContext({ cloudProviderRegionId: region })}
-          value={wizardContext.cloudProviderRegionId}
+          values={wizardContext}
         />
       </FormFieldCard>
     </>

--- a/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/UpdateCloudProviderPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/UpdateCloudProviderPage.tsx
@@ -19,6 +19,7 @@ import { CloudProviders, ICloudProvidersSelector } from './model'
 import DocumentMeta from 'core/components/DocumentMeta'
 import WizardMeta from 'core/components/wizard/WizardMeta'
 import { pick } from 'ramda'
+import { routes } from 'core/utils/routes'
 const objSwitchCaseAny: any = objSwitchCase // types on forward ref .js file dont work well.
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -148,7 +149,7 @@ export const options = {
   FormComponent: UpdateCloudProviderForm,
   updateFn: cloudProviderActions.update,
   loaderFn: cloudProviderActions.list,
-  listUrl: '/ui/kubernetes/infrastructure#cloudProviders',
+  listUrl: routes.cloudProviders.list,
   name: 'UpdateCloudProvider',
   title: 'Update Cloud Provider',
   uniqueIdentifier: 'uuid',

--- a/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/UpdateCloudProviderPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/cloudProviders/UpdateCloudProviderPage.tsx
@@ -149,7 +149,7 @@ export const options = {
   FormComponent: UpdateCloudProviderForm,
   updateFn: cloudProviderActions.update,
   loaderFn: cloudProviderActions.list,
-  listUrl: routes.cloudProviders.list,
+  listUrl: routes.cloudProviders.list.path(),
   name: 'UpdateCloudProvider',
   title: 'Update Cloud Provider',
   uniqueIdentifier: 'uuid',

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/ssh-key-picklist.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/ssh-key-picklist.tsx
@@ -5,10 +5,6 @@ const additionalInfo =
   'Select an AWS SSH key to be associated with the nodes. This key can be used to access the nodes for debugging or other purposes.'
 
 export default ({ dropdownComponent, values, info = additionalInfo }) => {
-  console.log(
-    'disabled',
-    !(values.cloudProviderId && (values.region || values.cloudProviderRegionId)),
-  )
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/ssh-key-picklist.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/ssh-key-picklist.tsx
@@ -8,11 +8,11 @@ export default ({ dropdownComponent, values, info = additionalInfo }) => {
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}
-      disabled={!(values.cloudProviderId && (values.region || values.cloudProviderRegionId))}
+      disabled={!(values.cloudProviderId && values.region)}
       id="sshKey"
       label="SSH Key"
       cloudProviderId={values.cloudProviderId}
-      cloudProviderRegionId={values.region ? values.region : values.cloudProviderRegionId}
+      cloudProviderRegionId={values.region}
       info={info}
       required
     />

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/ssh-key-picklist.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/ssh-key-picklist.tsx
@@ -1,16 +1,23 @@
 import React from 'react'
 import PicklistField from 'core/components/validatedForm/PicklistField'
 
-export default ({ dropdownComponent, values }) => {
+const additionalInfo =
+  'Select an AWS SSH key to be associated with the nodes. This key can be used to access the nodes for debugging or other purposes.'
+
+export default ({ dropdownComponent, values, info = additionalInfo }) => {
+  console.log(
+    'disabled',
+    !(values.cloudProviderId && (values.region || values.cloudProviderRegionId)),
+  )
   return (
     <PicklistField
       DropdownComponent={dropdownComponent}
-      disabled={!(values.cloudProviderId && values.region)}
+      disabled={!(values.cloudProviderId && (values.region || values.cloudProviderRegionId))}
       id="sshKey"
       label="SSH Key"
       cloudProviderId={values.cloudProviderId}
-      cloudProviderRegionId={values.region}
-      info="Select an AWS SSH key to be associated with the nodes. This key can be used to access the nodes for debugging or other purposes."
+      cloudProviderRegionId={values.region ? values.region : values.cloudProviderRegionId}
+      info={info}
       required
     />
   )


### PR DESCRIPTION
What caused the bug:

- The cloud provider type wasn't passed to the region picklist component, so it defaulted to show the DisplayName, which is not available for AWS regions

Changes Made:

- Reused some cluster form components in the update cloud provider page
- Cloud provider type is now passed into the region picklist

![Screen Shot 2020-11-17 at 12 44 41 PM](https://user-images.githubusercontent.com/23369276/99445624-ab78dc80-28d2-11eb-984e-afea601c3f4f.png)
