### PR TITLE
UX-720/Disabled scaling workers for Azure autoscaling clusters

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.tsx
@@ -33,6 +33,7 @@ import {
   canScaleWorkers,
   canUpgradeCluster,
   notBusy,
+  isAzureAutoscalingCluster,
 } from './helpers'
 import { IClusterSelector } from './model'
 
@@ -266,6 +267,10 @@ export const options = {
       icon: 'expand-alt',
       label: 'Scale Workers',
       routeTo: (rows) => `/ui/kubernetes/infrastructure/clusters/scaleWorkers/${rows[0].uuid}`,
+      disabledInfo: ([cluster]) =>
+        !!cluster && isAzureAutoscalingCluster(cluster)
+          ? 'Scaling Azure autoscaling clusters is not yet supported'
+          : 'Cannot scale workers: cluster is busy',
     },
     {
       cond: both(isAdmin, canUpgradeCluster),

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/helpers.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/helpers.ts
@@ -21,15 +21,14 @@ export const clusterNotBusy = (cluster) =>
 export const isBareOsMultiMasterCluster = (cluster) =>
   cluster.cloudProviderType === CloudProviders.BareOS && !!cluster.masterVipIpv4
 
-export const isAzureCluster = (cluster) => cluster.cloudProviderType === CloudProviders.Azure
-
-export const isAzureAutoscalingCluster = (cluster) => isAzureCluster(cluster) && cluster.enableCAS
+export const isAzureAutoscalingCluster = (cluster) =>
+  cluster.cloudProviderType === CloudProviders.Azure && cluster.enableCAS
 
 export const canScaleMasters = ([cluster]) =>
   isBareOsMultiMasterCluster(cluster) && clusterIsHealthy(cluster) && clusterNotBusy(cluster)
 
 export const canScaleWorkers = ([cluster]) =>
-  clusterNotBusy(cluster) && (!isAzureCluster(cluster) || !isAzureAutoscalingCluster(cluster))
+  clusterNotBusy(cluster) && !isAzureAutoscalingCluster(cluster)
 
 export const canUpgradeCluster = ([cluster]) => !!(cluster && cluster.canUpgrade)
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/helpers.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/helpers.ts
@@ -21,10 +21,15 @@ export const clusterNotBusy = (cluster) =>
 export const isBareOsMultiMasterCluster = (cluster) =>
   cluster.cloudProviderType === CloudProviders.BareOS && !!cluster.masterVipIpv4
 
+export const isAzureCluster = (cluster) => cluster.cloudProviderType === CloudProviders.Azure
+
+export const isAzureAutoscalingCluster = (cluster) => isAzureCluster(cluster) && cluster.enableCAS
+
 export const canScaleMasters = ([cluster]) =>
   isBareOsMultiMasterCluster(cluster) && clusterIsHealthy(cluster) && clusterNotBusy(cluster)
 
-export const canScaleWorkers = ([cluster]) => cluster.taskStatus === 'success'
+export const canScaleWorkers = ([cluster]) =>
+  clusterNotBusy(cluster) && (!isAzureCluster(cluster) || !isAzureAutoscalingCluster(cluster))
 
 export const canUpgradeCluster = ([cluster]) => !!(cluster && cluster.canUpgrade)
 


### PR DESCRIPTION
Changes Made:

- Scaling workers for Azure autoscaling clusters has been disabled
- A disabled info message now shows up for autoscaling clusters and for busy clusters. "Scaling Azure autoscaling clusters is not yet supported"  and "Cannot scale workers: cluster is busy"


![Screen Shot 2020-11-17 at 3 28 13 PM](https://user-images.githubusercontent.com/23369276/99463020-ba1ebe00-28e9-11eb-96c2-855be1d6c035.png)


![Screen Shot 2020-11-17 at 3 27 54 PM](https://user-images.githubusercontent.com/23369276/99463041-c1de6280-28e9-11eb-934d-3019f63ceb31.png)

