### PR TITLE
UX-599/Added 'View Container Logs' option to Pods List Table

### DIFF
--- a/src/app/plugins/kubernetes/components/pods/PodsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/PodsListPage.js
@@ -82,12 +82,7 @@ const PodLinks = ({ pod }) => {
     <div className={classes.links}>
       <ExternalLink url={pod.dashboardUrl}>dashboard</ExternalLink>
       {pod.logs && (
-        <SimpleLink
-          src={pod.logs || ''}
-          target="_blank"
-          rel="noopener"
-          onClick={openLogsWindow(pod)}
-        >
+        <SimpleLink src={pod.logs} target="_blank" rel="noopener" onClick={openLogsWindow(pod)}>
           View Container Logs
         </SimpleLink>
       )}

--- a/src/app/plugins/kubernetes/components/pods/PodsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/PodsListPage.js
@@ -107,7 +107,6 @@ export const options = {
   deleteFn: podActions.delete,
   addUrl: routes.pods.add.path(),
   addText: 'Create New Pod',
-  multiSelection: false,
   columns: [
     { id: 'name', label: 'Name' },
     { id: 'clusterName', label: 'Cluster' },

--- a/src/app/plugins/kubernetes/components/pods/PodsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/PodsListPage.js
@@ -81,9 +81,16 @@ const PodLinks = ({ pod }) => {
   return (
     <div className={classes.links}>
       <ExternalLink url={pod.dashboardUrl}>dashboard</ExternalLink>
-      <SimpleLink src={pod.logs || ''} target="_blank" rel="noopener" onClick={openLogsWindow(pod)}>
-        View Container Logs
-      </SimpleLink>
+      {pod.logs && (
+        <SimpleLink
+          src={pod.logs || ''}
+          target="_blank"
+          rel="noopener"
+          onClick={openLogsWindow(pod)}
+        >
+          View Container Logs
+        </SimpleLink>
+      )}
     </div>
   )
 }

--- a/src/app/plugins/kubernetes/components/pods/PodsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/PodsListPage.js
@@ -122,13 +122,6 @@ export const options = {
       render: (value) => <DateAndTime value={value} />,
     },
   ],
-  batchActions: [
-    {
-      icon: 'info-circle',
-      label: 'View Container Logs',
-      action: ([pod]) => openLogsWindow(pod)(),
-    },
-  ],
   name: 'Pods',
   title: 'Pods',
   ListPage,

--- a/src/app/plugins/kubernetes/components/pods/PodsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/PodsListPage.js
@@ -12,6 +12,16 @@ import renderLabels from 'k8s/components/pods/renderLabels'
 import { DateAndTime } from 'core/components/listTable/cells/DateCell'
 import ClusterStatusSpan from '../infrastructure/clusters/ClusterStatus'
 import { routes } from 'core/utils/routes'
+import { trackEvent } from 'utils/tracking'
+import SimpleLink from 'core/components/SimpleLink'
+import { makeStyles } from '@material-ui/styles'
+
+const useStyles = makeStyles((theme) => ({
+  links: {
+    display: 'grid',
+    width: 'max-content',
+  },
+}))
 
 const defaultParams = {
   masterNodeClusters: true,
@@ -57,13 +67,24 @@ const ListPage = ({ ListContainer }) => {
     )
   }
 }
-const renderName = (name, { dashboardUrl }) => {
+const openLogsWindow = ({ name, id, clusterName, clusterId, logs }) => () => {
+  trackEvent('View Pod Logs', { name, id, clusterName, clusterId })
+  window.open(logs)
+}
+
+const renderLinks = (links, pod) => {
+  return <PodLinks pod={pod} />
+}
+
+const PodLinks = ({ pod }) => {
+  const classes = useStyles()
   return (
-    <span>
-      {name}
-      <br />
-      <ExternalLink url={dashboardUrl}>dashboard</ExternalLink>
-    </span>
+    <div className={classes.links}>
+      <ExternalLink url={pod.dashboardUrl}>dashboard</ExternalLink>
+      <SimpleLink src={pod.logs || ''} target="_blank" rel="noopener" onClick={openLogsWindow(pod)}>
+        View Container Logs
+      </SimpleLink>
+    </div>
   )
 }
 
@@ -86,17 +107,26 @@ export const options = {
   deleteFn: podActions.delete,
   addUrl: routes.pods.add.path(),
   addText: 'Create New Pod',
+  multiSelection: false,
   columns: [
-    { id: 'name', label: 'Name', render: renderName },
+    { id: 'name', label: 'Name' },
     { id: 'clusterName', label: 'Cluster' },
     { id: 'namespace', label: 'Namespace' },
     { id: 'labels', label: 'Labels', render: renderLabels('label') },
+    { id: 'links', label: 'Links', render: renderLinks },
     { id: 'status.phase', label: 'Status', render: renderStatus },
     { id: 'status.hostIP', label: 'Node IP' },
     {
       id: 'created',
       label: 'Age',
       render: (value) => <DateAndTime value={value} />,
+    },
+  ],
+  batchActions: [
+    {
+      icon: 'info-circle',
+      label: 'View Container Logs',
+      action: ([pod]) => openLogsWindow(pod)(),
     },
   ],
   name: 'Pods',

--- a/src/app/plugins/kubernetes/components/pods/selectors.ts
+++ b/src/app/plugins/kubernetes/components/pods/selectors.ts
@@ -14,8 +14,10 @@ import { FluffySelector, MatchLabelsClass } from 'api-client/qbert.model'
 const k8sDocUrl = 'namespaces/kube-system/qbertservices/https:kubernetes-dashboard:443/proxy/#'
 
 const getLogsUrl = (pod, cluster, rawServiceCatalog) => {
-  const qbertUrl =
-    pipeWhenTruthy(find(propEq('name', 'qbert')), prop('url'))(rawServiceCatalog) || ''
+  const qbertUrl = pipeWhenTruthy(find(propEq('name', 'qbert')), prop('url'))(rawServiceCatalog)
+  if (!qbertUrl) return null
+
+  // qbert v3 link fails authorization so we have to use v1 link for logs
   return `${qbertUrl}/clusters/${cluster?.uuid}/k8sapi/api/v1/namespaces/${pod?.metadata?.namespace}/pods/${pod?.metadata?.name}/log`.replace(
     /v3/,
     'v1',

--- a/src/app/plugins/kubernetes/components/pods/selectors.ts
+++ b/src/app/plugins/kubernetes/components/pods/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect'
-import { any, head, map, mergeLeft, pathEq, pipe, pluck, propEq, toPairs } from 'ramda'
-import { emptyArr, emptyObj, filterIf } from 'utils/fp'
+import { any, find, head, map, mergeLeft, pathEq, pipe, pluck, prop, propEq, toPairs } from 'ramda'
+import { emptyArr, emptyObj, filterIf, pipeWhenTruthy } from 'utils/fp'
 import { allKey } from 'app/constants'
 import { pathJoin } from 'utils/misc'
 import DataKeys from 'k8s/DataKeys'
@@ -14,8 +14,12 @@ import { FluffySelector, MatchLabelsClass } from 'api-client/qbert.model'
 const k8sDocUrl = 'namespaces/kube-system/qbertservices/https:kubernetes-dashboard:443/proxy/#'
 
 export const podsSelector = createSelector(
-  [getDataSelector<DataKeys.Pods>(DataKeys.Pods, ['clusterId']), clustersSelector],
-  (rawPods, clusters) => {
+  [
+    getDataSelector<DataKeys.Pods>(DataKeys.Pods, ['clusterId']),
+    clustersSelector,
+    getDataSelector<DataKeys.ServiceCatalog>(DataKeys.ServiceCatalog),
+  ],
+  (rawPods, clusters, rawServiceCatalog) => {
     // associate nodes with the combinedHost entry
     return pipe<IDataKeys[DataKeys.Pods], IPodSelector[]>(
       // Filter by namespace
@@ -29,6 +33,9 @@ export const podsSelector = createSelector(
           pod?.metadata?.namespace, // pathStr('metadata.namespace', pod),
           pod?.metadata?.name, // pathStr('metadata.name', pod),
         )
+        const qbertUrl =
+          pipeWhenTruthy(find(propEq('name', 'qbert')), prop('url'))(rawServiceCatalog) || ''
+
         return {
           ...pod,
           dashboardUrl,
@@ -37,6 +44,10 @@ export const podsSelector = createSelector(
           namespace: pod?.metadata?.namespace, // pathStr('metadata.namespace', pod),
           labels: pod?.metadata?.labels, // pathStr('metadata.labels', pod),
           clusterName: cluster?.name,
+          logs: `${qbertUrl}/clusters/${cluster?.uuid}/k8sapi/api/v1/namespaces/${pod?.metadata?.namespace}/pods/${pod?.metadata?.name}/log`.replace(
+            /v3/,
+            'v1',
+          ),
         }
       }),
     )(rawPods)


### PR DESCRIPTION
- Added a links column to the pods list table

- Added 'View Container Logs' link to the links column

![Screen Shot 2020-12-01 at 10 52 06 AM](https://user-images.githubusercontent.com/23369276/100784124-8fd9ff80-33c3-11eb-9604-f690340f7c6e.png)


When "View Container Logs' is clicked, a new window will open showing the logs

![Screen Shot 2020-11-30 at 4 29 05 PM](https://user-images.githubusercontent.com/23369276/100681739-450ba980-3329-11eb-9538-887bf8b0480e.png)
