### PR TITLE
UX-636/Made username and password field for KubeConfig download form bigger

### DIFF
--- a/src/app/plugins/kubernetes/components/apiAccess/kubeConfig/DownloadKubeConfigForm.js
+++ b/src/app/plugins/kubernetes/components/apiAccess/kubeConfig/DownloadKubeConfigForm.js
@@ -28,6 +28,9 @@ const useStyles = makeStyles((theme) => ({
   errorContainer: {
     paddingLeft: '12px',
   },
+  inputFields: {
+    width: '100% !important',
+  },
 }))
 
 const DownloadKubeConfigForm = ({ cluster, onSubmit, autoDownload = true }) => {
@@ -99,7 +102,7 @@ const DownloadKubeConfigForm = ({ cluster, onSubmit, autoDownload = true }) => {
         </Grid>
         {authMethod === 'password' && (
           <Grid item xs={12} zeroMinWidth>
-            <PasswordForm classes={classes} />
+            <PasswordForm />
           </Grid>
         )}
         {!!errorMessage && (
@@ -121,21 +124,30 @@ const DownloadKubeConfigForm = ({ cluster, onSubmit, autoDownload = true }) => {
   )
 }
 
-const PasswordForm = ({ classes }) => (
-  <Grid container item xs={12}>
-    <Grid item xs={4} zeroMinWidth>
-      <h4>Username</h4>
+const PasswordForm = () => {
+  const classes = useStyles()
+  return (
+    <Grid container item xs={12}>
+      <Grid item xs={4} zeroMinWidth>
+        <h4>Username</h4>
+      </Grid>
+      <Grid item xs={8} zeroMinWidth>
+        <TextField className={classes.inputFields} id="username" label="username" required />
+      </Grid>
+      <Grid item xs={4} zeroMinWidth>
+        <h4>Password</h4>
+      </Grid>
+      <Grid item xs={8} zeroMinWidth>
+        <TextField
+          className={classes.inputFields}
+          id="password"
+          label="password"
+          type="password"
+          required
+        />
+      </Grid>
     </Grid>
-    <Grid item xs={8} zeroMinWidth>
-      <TextField id="username" label="username" required />
-    </Grid>
-    <Grid item xs={4} zeroMinWidth>
-      <h4>Password</h4>
-    </Grid>
-    <Grid item xs={8} zeroMinWidth>
-      <TextField id="password" label="password" type="password" required />
-    </Grid>
-  </Grid>
-)
+  )
+}
 
 export default DownloadKubeConfigForm


### PR DESCRIPTION
- The username and password input field is now bigger and fills up the rest of the form

- When a user hits enter, the download kubeconfig button will get triggered. (This was already implemented)

![Screen Shot 2020-12-01 at 6 07 11 PM](https://user-images.githubusercontent.com/23369276/100819389-eca7db00-3400-11eb-83e2-6b2897aaf689.png)
