### PR TITLE
UX-742/Fixed logic for showing insufficient nodes dialog

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/BareosClusterRequirements.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/BareosClusterRequirements.tsx
@@ -100,7 +100,6 @@ interface Props {
 
 const BareOSClusterRequirements: FC<Props> = ({ onComplete, provider }) => {
   const classes = useStyles({})
-  const [showDialog, setShowDialog] = useState(false)
   const [createType, setCreateType] = useState('')
   const [availableNodes, setAvailableNodes] = useState(0)
   const [requiredNodes, setRequiredNodes] = useState(0)
@@ -116,12 +115,11 @@ const BareOSClusterRequirements: FC<Props> = ({ onComplete, provider }) => {
   const handleClick = useCallback(
     (type: ClusterCreateTypes) => () => {
       setRequiredNodes(BareOsRequiredNodes[type])
-      const hasAvailableNodes = availableNodes >= requiredNodes
+      setCreateType(type)
 
-      if (!hasAvailableNodes) {
-        setCreateType(type)
-        setShowDialog(true)
-      } else {
+      const hasAvailableNodes = availableNodes >= BareOsRequiredNodes[type]
+
+      if (hasAvailableNodes) {
         onComplete(routes.cluster.addBareOs[provider][type].path())
       }
     },
@@ -130,13 +128,12 @@ const BareOSClusterRequirements: FC<Props> = ({ onComplete, provider }) => {
 
   return (
     <>
-      {showDialog && (
+      {availableNodes < requiredNodes && (
         <InsufficientNodesNodesDialog
           createType={createType}
           availableNodes={availableNodes}
           requiredNodes={requiredNodes}
-          showDialog={showDialog}
-          setShowDialog={setShowDialog}
+          setRequiredNodes={setRequiredNodes}
         />
       )}
       <FormFieldCard

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/InsufficientNodesDialog.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/InsufficientNodesDialog.tsx
@@ -63,15 +63,14 @@ const InsufficientNodesNodesDialog = ({
   createType,
   availableNodes,
   requiredNodes,
-  showDialog,
-  setShowDialog,
+  setRequiredNodes,
 }) => {
   const classes = useStyles()
   const selectSessionState = prop<string, SessionState>(sessionStoreKey)
   const session = useSelector(selectSessionState)
 
   return (
-    <Dialog fullWidth maxWidth="md" open={showDialog}>
+    <Dialog fullWidth maxWidth="md" open={availableNodes < requiredNodes}>
       <FormFieldCard
         className={classes.formCard}
         title={
@@ -153,7 +152,7 @@ const InsufficientNodesNodesDialog = ({
         />
       </FormFieldCard>
       <DialogActions className={classes.dialogButtons}>
-        <SubmitButton onClick={() => setShowDialog(false)}>Close</SubmitButton>
+        <SubmitButton onClick={() => setRequiredNodes(0)}>Close</SubmitButton>
       </DialogActions>
     </Dialog>
   )


### PR DESCRIPTION
A dialog now shows up when there are insufficient nodes for BareOs cluster creation.

![Screen Shot 2020-12-02 at 1 21 49 PM](https://user-images.githubusercontent.com/23369276/100932848-58418500-34a1-11eb-8444-28e5b3a0c442.png)
