### PR TITLE
UX-739/Added OS options for host agent download

### DIFF
--- a/src/app/core/components/DownloadHostAgentWalkthrough.tsx
+++ b/src/app/core/components/DownloadHostAgentWalkthrough.tsx
@@ -101,7 +101,7 @@ const DownloadHostAgentWalkthrough = ({ osOptions }): JSX.Element => {
       setDownloadOptions(options)
     }
     loadDownloadLinks()
-  }, [downloadOptions])
+  }, [osOptions, downloadOptions])
 
   const handleDownloadClick = (event) => {
     setAnchorEl(event.currentTarget)
@@ -137,7 +137,7 @@ const DownloadHostAgentWalkthrough = ({ osOptions }): JSX.Element => {
             >
               {downloadOptions.map((option) => (
                 <SimpleLink src={option.link} key={option.label}>
-                  <MenuItem>{option.label}</MenuItem>
+                  <MenuItem onClick={handleMenuClose}>{option.label}</MenuItem>
                 </SimpleLink>
               ))}
             </Menu>

--- a/src/app/core/components/DownloadHostAgentWalkthrough.tsx
+++ b/src/app/core/components/DownloadHostAgentWalkthrough.tsx
@@ -1,15 +1,30 @@
 import React, { FC, useEffect, useState } from 'react'
-import { Paper } from '@material-ui/core'
+import { Paper, Menu, MenuItem } from '@material-ui/core'
 import Text from 'core/elements/text'
 import { makeStyles } from '@material-ui/styles'
 import CodeBlock from 'core/components/CodeBlock'
 import Theme from 'core/themes/model'
 import { hexToRGBA } from 'core/utils/colorHelpers'
 import FontAwesomeIcon from 'core/components/FontAwesomeIcon'
-import SimpleLink from 'core/components/SimpleLink'
 import clsx from 'clsx'
 import { getDownloadLinks } from 'openstack/components/hosts/actions'
 import SubmitButton from './buttons/SubmitButton'
+import SimpleLink from './SimpleLink'
+
+export enum OsOptions {
+  Linux = 'Linux',
+  Ubuntu = 'Ubuntu',
+}
+
+enum OsDownloadLabel {
+  Linux = 'for Enterprise Linux (CentOs/Redhat) 7.6 (64-bit)',
+  Ubuntu = 'for Ubuntu 16.04 LTS and Ubuntu 18.04 LTS (64-bit)',
+}
+
+enum osDownloadLinkName {
+  Linux = 'rpm_install',
+  Ubuntu = 'deb_install',
+}
 
 const useStyles = makeStyles((theme: Theme) => ({
   paper: {
@@ -61,19 +76,40 @@ const useStyles = makeStyles((theme: Theme) => ({
   spaceAbove: {
     marginTop: theme.spacing(2),
   },
+  dropdown: {
+    position: 'relative',
+  },
 }))
 
-const DownloadHostAgentWalkthrough = (): JSX.Element => {
+const DownloadHostAgentWalkthrough = ({ osOptions }): JSX.Element => {
   const classes = useStyles({})
-  const [downloadLink, setDownloadLink] = useState('')
+  const [anchorEl, setAnchorEl] = useState(null)
+  const [downloadOptions, setDownloadOptions] = useState([])
+
   useEffect(() => {
-    const loadDownloadLink = async () => {
+    const loadDownloadLinks = async () => {
       const links = await getDownloadLinks()
+      if (!links) return
+
       // In the future when supporting openstack, will want to show all download links
-      setDownloadLink(links.rpm_install)
+      const options = osOptions.map((os) => {
+        return {
+          label: OsDownloadLabel[os],
+          link: links[osDownloadLinkName[os]],
+        }
+      })
+      setDownloadOptions(options)
     }
-    loadDownloadLink()
-  }, [setDownloadLink])
+    loadDownloadLinks()
+  }, [downloadOptions])
+
+  const handleDownloadClick = (event) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleMenuClose = () => {
+    setAnchorEl(null)
+  }
 
   return (
     <Paper className={classes.paper} elevation={0}>
@@ -85,18 +121,26 @@ const DownloadHostAgentWalkthrough = (): JSX.Element => {
             <Text className={classes.fullRow}>
               Download the host agent installer for your host operating system version:
             </Text>
-            <SimpleLink
-              className={clsx(classes.fullRow, classes.spaceAbove)}
-              src={downloadLink}
-              variant="primary"
+            <SubmitButton onClick={handleDownloadClick}>
+              Download Installer
+              <FontAwesomeIcon className={classes.downloadIcon} size="sm" solid>
+                download
+              </FontAwesomeIcon>
+            </SubmitButton>
+            <Menu
+              id="download-options"
+              anchorEl={anchorEl}
+              open={Boolean(anchorEl)}
+              onClose={handleMenuClose}
+              getContentAnchorEl={null}
+              anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
             >
-              <SubmitButton>
-                Download Installer
-                <FontAwesomeIcon className={classes.downloadIcon} size="sm" solid>
-                  download
-                </FontAwesomeIcon>
-              </SubmitButton>
-            </SimpleLink>
+              {downloadOptions.map((option) => (
+                <SimpleLink src={option.link} key={option.label}>
+                  <MenuItem>{option.label}</MenuItem>
+                </SimpleLink>
+              ))}
+            </Menu>
           </div>
         }
       />

--- a/src/app/plugins/kubernetes/components/infrastructure/nodes/download-host-agent-page.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/nodes/download-host-agent-page.tsx
@@ -4,9 +4,13 @@ import { makeStyles } from '@material-ui/core'
 import Text from 'core/elements/text'
 import CodeBlock from 'core/components/CodeBlock'
 import Info from 'core/components/validatedForm/Info'
-import DownloadHostAgentWalkthrough from 'core/components/DownloadHostAgentWalkthrough'
+import DownloadHostAgentWalkthrough, {
+  OsOptions,
+} from 'core/components/DownloadHostAgentWalkthrough'
 import ExternalLink from 'core/components/ExternalLink'
 import { nodePrerequisitesDocumentationLink } from 'k8s/links'
+
+const hostAgentDownloadOsOptions = [OsOptions.Linux, OsOptions.Ubuntu]
 
 const useStyles = makeStyles((theme: Theme) => ({
   downloadHostAgent: {
@@ -117,7 +121,7 @@ const DownloadHostAgentPage = () => {
           authorized on the Nodes dashboard.
         </Text>
       </p>
-      <DownloadHostAgentWalkthrough />
+      <DownloadHostAgentWalkthrough osOptions={hostAgentDownloadOsOptions} />
       <p className={classes.spacer}></p>
       <SupportedDistributionsAndPrerequisitesInfo />
       <p className={classes.spacer}></p>

--- a/src/app/plugins/openstack/components/ironicSetup/IronicSetupPage.tsx
+++ b/src/app/plugins/openstack/components/ironicSetup/IronicSetupPage.tsx
@@ -21,8 +21,12 @@ import { IPf9IronicInspector, IPf9NeutronOvsAgent, IPf9GlanceRole } from './mode
 import { IUseDataLoader } from 'k8s/components/infrastructure/nodes/model'
 import { Host } from 'api-client/resmgr.model'
 import DocumentMeta from 'core/components/DocumentMeta'
-import DownloadHostAgentWalkthrough from 'core/components/DownloadHostAgentWalkthrough'
+import DownloadHostAgentWalkthrough, {
+  OsOptions,
+} from 'core/components/DownloadHostAgentWalkthrough'
 const FormWrapper: any = FormWrapperDefault // types on forward ref .js file dont work well.
+
+const hostAgentDownloadOsOptions = [OsOptions.Linux]
 
 const getProvisioningNetwork = (networks) =>
   networks.find((network) => network['provider:physical_network'] === 'provisioning')
@@ -221,7 +225,7 @@ const SetupWizard = ({ initialContext, startingStep, setSubmittingStep }) => {
                   Install the Platform9 Host Agent on the node that will become the controller for
                   Bare Metal.
                 </div>
-                <DownloadHostAgentWalkthrough />
+                <DownloadHostAgentWalkthrough osOptions={hostAgentDownloadOsOptions} />
               </WizardStep>
               <WizardStep stepId="step3" label="Authorize Host Agent" keepContentMounted={false}>
                 <AuthorizeHostStep


### PR DESCRIPTION
Added Linux and Ubuntu download options to the Onboard Node Advanced page

![Screen Shot 2020-12-02 at 3 31 10 PM](https://user-images.githubusercontent.com/23369276/100947187-f80b0d00-34b9-11eb-8a54-2c0c7b536334.png)
