### PR TITLE
UX-733/Allow user to add master node to an empty BareOs cluster

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ScaleMastersPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ScaleMastersPage.tsx
@@ -92,6 +92,12 @@ export const scaleConstraints: IConstraint[] = [
 
   // grow
   {
+    startNum: 0,
+    desiredNum: 1,
+    relation: 'allow',
+    message: oneMasterMsg,
+  },
+  {
     startNum: 1,
     desiredNum: 2,
     relation: 'allow',


### PR DESCRIPTION
User can now add a master node to an empty multi-master BareOs cluster. We have constraints already in place where a user cannot scale a cluster without a VIP, meaning that it must be a multi-master cluster. Not sure if we should remove this constraint for empty clusters.

I tried testing this out as best as I could, but I had to disable a lot of stuff. Our current UI does not even allow us to create an empty cluster. Also, my empty cluster was not healthy and its status was disconnected so I had to remove the healthy cluster constraint in order to scale it. I'm not sure if that was just my cluster or  if all empty clusters would be unhealthy as well.