### PR TITLE
UX-675/Only allow connected nodes to be attached to a BareOs cluster and nodes can only added one at a time

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ScaleMastersPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ScaleMastersPage.tsx
@@ -17,6 +17,7 @@ import ClusterHostChooser, {
   isUnassignedNode,
   inCluster,
   isMaster,
+  isConnected,
 } from './bareos/ClusterHostChooser'
 import { IClusterSelector } from './model'
 import { allPass } from 'ramda'
@@ -205,7 +206,9 @@ const ScaleMasters: FunctionComponent<ScaleMasterProps> = ({
             id="nodes"
             selection="single"
             filterFn={
-              scaleType === 'add' ? isUnassignedNode : allPass([isMaster, inCluster(cluster.uuid)])
+              scaleType === 'add'
+                ? allPass([isUnassignedNode, isConnected])
+                : allPass([isMaster, inCluster(cluster.uuid)])
             }
             validations={[
               clusterAndNodeStatusValidator,

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ScaleWorkersPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ScaleWorkersPage.tsx
@@ -135,7 +135,7 @@ const ScaleWorkers: FunctionComponent<ScaleWorkersProps> = ({
   const addBareOsWorkerNodes = (
     <ValidatedForm onSubmit={params.scaleType === 'add' ? onAttach : onDetach}>
       <ClusterHostChooser
-        selection="multiple"
+        selection="single"
         id="workersToAdd"
         filterFn={allPass([isUnassignedNode, isConnected])}
         validations={[minScaleValidator, maxScaleValidator]}
@@ -148,7 +148,7 @@ const ScaleWorkers: FunctionComponent<ScaleWorkersProps> = ({
   const removeBareOsWorkerNodes = (
     <ValidatedForm onSubmit={params.scaleType === 'add' ? onAttach : onDetach}>
       <ClusterHostChooser
-        selection="multiple"
+        selection="single"
         id="workersToRemove"
         filterFn={allPass([isNotMaster, inCluster(cluster.uuid)])}
         validations={[minScaleValidator, maxScaleValidator]}

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ScaleWorkersPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ScaleWorkersPage.tsx
@@ -20,6 +20,7 @@ import ClusterHostChooser, {
   isUnassignedNode,
   inCluster,
   isNotMaster,
+  isConnected,
 } from './bareos/ClusterHostChooser'
 import { IClusterSelector } from './model'
 import { allPass } from 'ramda'
@@ -136,7 +137,7 @@ const ScaleWorkers: FunctionComponent<ScaleWorkersProps> = ({
       <ClusterHostChooser
         selection="multiple"
         id="workersToAdd"
-        filterFn={isUnassignedNode}
+        filterFn={allPass([isUnassignedNode, isConnected])}
         validations={[minScaleValidator, maxScaleValidator]}
         required
       />


### PR DESCRIPTION
### **Changes made:**

- **Nodes must now be connected in order to be attached to a BareOs cluster.**
- **Worker nodes can now only be scaled one at a time, just like master nodes**




ui-dev-master is disconnected so it should not show up in the node chooser

![Screen Shot 2020-12-04 at 2 15 35 PM](https://user-images.githubusercontent.com/23369276/101221039-b904c500-363b-11eb-8575-94d699113678.png)

![Screen Shot 2020-12-04 at 2 14 50 PM](https://user-images.githubusercontent.com/23369276/101221045-bdc97900-363b-11eb-8291-f3f01adb4627.png)

![Screen Shot 2020-12-04 at 2 15 06 PM](https://user-images.githubusercontent.com/23369276/101221050-c15d0000-363b-11eb-9ada-455e143662c2.png)
