### PR TITLE
Fixed Segment and Drift bug during login

### DIFF
--- a/src/app/core/components/DocumentMeta.tsx
+++ b/src/app/core/components/DocumentMeta.tsx
@@ -79,7 +79,9 @@ export interface IDocumentMetaProps {
 
 export class DocumentMeta extends React.Component<IDocumentMetaProps, {}> {
   static addElementToDomBody(element) {
-    document.body.appendChild(element)
+    if (element) {
+      document.body.appendChild(element)
+    }
   }
 
   render() {

--- a/src/app/core/containers/AppContainer.tsx
+++ b/src/app/core/containers/AppContainer.tsx
@@ -108,18 +108,12 @@ const getUserDetails = async (activeTenant, isSsoToken) => {
 
   // Segment tracking
   if (!analyticsOff) {
-    const segmentScript = createSegmentScript()
-    if (segmentScript) {
-      DocumentMeta.addElementToDomBody(segmentScript)
-    }
+    DocumentMeta.addElementToDomBody(createSegmentScript())
   }
 
   // Drift tracking code for live demo
   if (sandbox) {
-    const driftScript = createDriftScript()
-    if (driftScript) {
-      DocumentMeta.addElementToDomBody(driftScript)
-    }
+    DocumentMeta.addElementToDomBody(createDriftScript())
   }
 
   return {

--- a/src/app/core/containers/AppContainer.tsx
+++ b/src/app/core/containers/AppContainer.tsx
@@ -108,13 +108,20 @@ const getUserDetails = async (activeTenant, isSsoToken) => {
 
   // Segment tracking
   if (!analyticsOff) {
-    DocumentMeta.addElementToDomBody(createSegmentScript())
+    const segmentScript = createSegmentScript()
+    if (segmentScript) {
+      DocumentMeta.addElementToDomBody(segmentScript)
+    }
   }
 
   // Drift tracking code for live demo
   if (sandbox) {
-    DocumentMeta.addElementToDomBody(createDriftScript())
+    const driftScript = createDriftScript()
+    if (driftScript) {
+      DocumentMeta.addElementToDomBody(driftScript)
+    }
   }
+
   return {
     userDetails: user,
     scopedToken,


### PR DESCRIPTION
A bug occurs when you login, logout, then login again. When `createSegmentScript()` and `createDriftScript() ` runs for the 2nd time, it returns `undefined` since the segment script already exists. When you try to add `undefined` to the DOM body, an exception occurs.