### PR TITLE
UX-761/Support viewing logs for pods with multiple containers

### DIFF
--- a/src/app/plugins/kubernetes/components/pods/PodsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/PodsListPage.js
@@ -15,11 +15,16 @@ import { routes } from 'core/utils/routes'
 import { trackEvent } from 'utils/tracking'
 import SimpleLink from 'core/components/SimpleLink'
 import { makeStyles } from '@material-ui/styles'
+import { pathStrOr } from 'utils/fp'
+import Text from 'core/elements/text'
 
 const useStyles = makeStyles((theme) => ({
-  links: {
-    display: 'grid',
+  containerLogs: {
     width: 'max-content',
+    '& b': {
+      fontWeight: 600,
+      whiteSpace: 'nowrap',
+    },
   },
 }))
 
@@ -72,21 +77,34 @@ const openLogsWindow = ({ name, id, clusterName, clusterId, logs }) => () => {
   window.open(logs)
 }
 
-const renderLinks = (links, pod) => {
-  return <PodLinks pod={pod} />
+const renderName = (name, { dashboardUrl }) => {
+  return (
+    <span>
+      {name}
+      <br />
+      <ExternalLink url={dashboardUrl}>dashboard</ExternalLink>
+    </span>
+  )
 }
 
-const PodLinks = ({ pod }) => {
+const renderContainers = (value, pod) => <ContainerLogs pod={pod} />
+
+const ContainerLogs = ({ pod }) => {
   const classes = useStyles()
+  const containers = pathStrOr({}, 'spec.containers', pod)
   return (
-    <div className={classes.links}>
-      <ExternalLink url={pod.dashboardUrl}>dashboard</ExternalLink>
-      {pod.logs && (
-        <SimpleLink src={pod.logs} target="_blank" rel="noopener" onClick={openLogsWindow(pod)}>
-          View Container Logs
-        </SimpleLink>
-      )}
-    </div>
+    <>
+      {containers.map((container) => (
+        <Text key={container.name} variant="body2" className={classes.containerLogs}>
+          <span>
+            <b>{container.name}: </b>
+            <SimpleLink target="_blank" rel="noopener" onClick={openLogsWindow(pod)}>
+              View Container Logs
+            </SimpleLink>
+          </span>
+        </Text>
+      ))}
+    </>
   )
 }
 
@@ -110,11 +128,11 @@ export const options = {
   addUrl: routes.pods.add.path(),
   addText: 'Create New Pod',
   columns: [
-    { id: 'name', label: 'Name' },
+    { id: 'name', label: 'Name', render: renderName },
     { id: 'clusterName', label: 'Cluster' },
     { id: 'namespace', label: 'Namespace' },
     { id: 'labels', label: 'Labels', render: renderLabels('label') },
-    { id: 'links', label: 'Links', render: renderLinks },
+    { id: 'containers', label: 'Containers', render: renderContainers },
     { id: 'status.phase', label: 'Status', render: renderStatus },
     { id: 'status.hostIP', label: 'Node IP' },
     {

--- a/src/app/plugins/kubernetes/components/pods/PodsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/PodsListPage.js
@@ -76,7 +76,7 @@ const openLogsWindow = (log, pod) => () => {
   const { name, id, clusterName, clusterId } = pod
   const containerName = log.containerName
   trackEvent('View Pod Logs', { name, id, clusterName, clusterId, containerName })
-  window.open(log.url)
+  window.open(log.url, '_blank')
 }
 
 const renderName = (name, { dashboardUrl }) => {
@@ -100,9 +100,7 @@ const ContainerLogs = ({ pod }) => {
         <Text key={log.containerName} variant="body2" className={classes.containerLogs}>
           <span>
             <b>{log.containerName}: </b>
-            <SimpleLink target="_blank" rel="noopener" onClick={openLogsWindow(log, pod)}>
-              View Container Logs
-            </SimpleLink>
+            <SimpleLink onClick={openLogsWindow(log, pod)}>View Container Logs</SimpleLink>
           </span>
         </Text>
       ))}

--- a/src/app/plugins/kubernetes/components/pods/PodsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/PodsListPage.js
@@ -72,9 +72,10 @@ const ListPage = ({ ListContainer }) => {
     )
   }
 }
-const openLogsWindow = ({ name, id, clusterName, clusterId, logs }) => () => {
-  trackEvent('View Pod Logs', { name, id, clusterName, clusterId })
-  window.open(logs)
+const openLogsWindow = (containerName, pod) => () => {
+  const { name, id, clusterName, clusterId, logs } = pod
+  trackEvent('View Pod Logs', { name, id, clusterName, clusterId, containerName })
+  window.open(`${logs}?container=${containerName}`)
 }
 
 const renderName = (name, { dashboardUrl }) => {
@@ -91,14 +92,18 @@ const renderContainers = (value, pod) => <ContainerLogs pod={pod} />
 
 const ContainerLogs = ({ pod }) => {
   const classes = useStyles()
-  const containers = pathStrOr({}, 'spec.containers', pod)
+  const containers = pathStrOr([], 'spec.containers', pod)
   return (
     <>
       {containers.map((container) => (
         <Text key={container.name} variant="body2" className={classes.containerLogs}>
           <span>
             <b>{container.name}: </b>
-            <SimpleLink target="_blank" rel="noopener" onClick={openLogsWindow(pod)}>
+            <SimpleLink
+              target="_blank"
+              rel="noopener"
+              onClick={openLogsWindow(container.name, pod)}
+            >
               View Container Logs
             </SimpleLink>
           </span>

--- a/src/app/plugins/kubernetes/components/pods/PodsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/PodsListPage.js
@@ -72,10 +72,11 @@ const ListPage = ({ ListContainer }) => {
     )
   }
 }
-const openLogsWindow = (containerName, pod) => () => {
-  const { name, id, clusterName, clusterId, logs } = pod
+const openLogsWindow = (log, pod) => () => {
+  const { name, id, clusterName, clusterId } = pod
+  const containerName = log.containerName
   trackEvent('View Pod Logs', { name, id, clusterName, clusterId, containerName })
-  window.open(`${logs}?container=${containerName}`)
+  window.open(log.url)
 }
 
 const renderName = (name, { dashboardUrl }) => {
@@ -92,18 +93,14 @@ const renderContainers = (value, pod) => <ContainerLogs pod={pod} />
 
 const ContainerLogs = ({ pod }) => {
   const classes = useStyles()
-  const containers = pathStrOr([], 'spec.containers', pod)
+  const logs = pod.logs || []
   return (
     <>
-      {containers.map((container) => (
-        <Text key={container.name} variant="body2" className={classes.containerLogs}>
+      {logs.map((log) => (
+        <Text key={log.containerName} variant="body2" className={classes.containerLogs}>
           <span>
-            <b>{container.name}: </b>
-            <SimpleLink
-              target="_blank"
-              rel="noopener"
-              onClick={openLogsWindow(container.name, pod)}
-            >
+            <b>{log.containerName}: </b>
+            <SimpleLink target="_blank" rel="noopener" onClick={openLogsWindow(log, pod)}>
               View Container Logs
             </SimpleLink>
           </span>


### PR DESCRIPTION
Added a new 'containers' column to the pods list table that lists out the container names and the links to view the logs for the containers

![Screen Shot 2021-01-05 at 5 13 24 PM](https://user-images.githubusercontent.com/23369276/103821704-9ba08d80-5023-11eb-8875-0c98251e745b.png)
