### PR TITLE
UX-779/Allow admin users to enable/disable other users in the users table and automatically enable a disabled user when changing their password

### DIFF
--- a/src/app/plugins/account/components/userManagement/users/UsersListPage.js
+++ b/src/app/plugins/account/components/userManagement/users/UsersListPage.js
@@ -5,8 +5,9 @@ import createCRUDComponents from 'core/helpers/createCRUDComponents'
 import useDataLoader from 'core/hooks/useDataLoader'
 import { createUsePrefParamsHook } from 'core/hooks/useParams'
 import useToggler from 'core/hooks/useToggler'
+import { sessionStoreKey } from 'core/session/sessionReducers'
 import { routes } from 'core/utils/routes'
-import { both, join, pick, pipe, pluck } from 'ramda'
+import { join, pick, pipe, pluck, prop } from 'ramda'
 import React, { useMemo } from 'react'
 import { arrayIfNil } from 'utils/fp'
 import { mngmUserActions } from './actions'
@@ -15,7 +16,11 @@ import EnableDisableUserDialog from './enable-disable-user-dialog'
 const defaultParams = { systemUsers: true }
 const usePrefParams = createUsePrefParamsHook('ManagementUsers', listTablePrefs)
 
-const isEnabledUser = ([user]) => user.enabled
+const isEnabledUser = (user) => user.enabled
+const isActiveUser = (user, store) => {
+  const session = prop(sessionStoreKey, store)
+  return session.username === user.username
+}
 
 const ListPage = ({ ListContainer }) => {
   return () => {
@@ -62,13 +67,13 @@ export const options = {
   multiSelection: false,
   batchActions: [
     {
-      cond: (rows) => !isEnabledUser(rows),
+      cond: ([user], store) => !isActiveUser(user, store) && !isEnabledUser(user),
       label: 'Enable',
       icon: 'user-check',
       dialog: EnableDisableUserDialog,
     },
     {
-      cond: isEnabledUser,
+      cond: ([user], store) => !isActiveUser(user, store) && isEnabledUser(user),
       label: 'Disable',
       icon: 'user-times',
       dialog: EnableDisableUserDialog,

--- a/src/app/plugins/account/components/userManagement/users/UsersListPage.js
+++ b/src/app/plugins/account/components/userManagement/users/UsersListPage.js
@@ -6,13 +6,16 @@ import useDataLoader from 'core/hooks/useDataLoader'
 import { createUsePrefParamsHook } from 'core/hooks/useParams'
 import useToggler from 'core/hooks/useToggler'
 import { routes } from 'core/utils/routes'
-import { join, pick, pipe, pluck } from 'ramda'
+import { both, join, pick, pipe, pluck } from 'ramda'
 import React, { useMemo } from 'react'
 import { arrayIfNil } from 'utils/fp'
 import { mngmUserActions } from './actions'
+import EnableDisableUserDialog from './enable-disable-user-dialog'
 
 const defaultParams = { systemUsers: true }
 const usePrefParams = createUsePrefParamsHook('ManagementUsers', listTablePrefs)
+
+const isEnabledUser = ([user]) => user.enabled
 
 const ListPage = ({ ListContainer }) => {
   return () => {
@@ -57,6 +60,20 @@ export const options = {
   searchTarget: 'username',
   nameProp: 'username',
   multiSelection: false,
+  batchActions: [
+    {
+      cond: (rows) => !isEnabledUser(rows),
+      label: 'Enable',
+      icon: 'user-check',
+      dialog: EnableDisableUserDialog,
+    },
+    {
+      cond: isEnabledUser,
+      label: 'Disable',
+      icon: 'user-times',
+      dialog: EnableDisableUserDialog,
+    },
+  ],
   ListPage,
 }
 

--- a/src/app/plugins/account/components/userManagement/users/actions.js
+++ b/src/app/plugins/account/components/userManagement/users/actions.js
@@ -79,7 +79,10 @@ export const mngmUserActions = createCRUDActions(ActionDataKeys.ManagementUsers,
     mngmTenantActions.invalidateCache()
     return createdUser
   },
-  updateFn: async ({ id: userId, username, displayname, password, roleAssignments }, prevItems) => {
+  updateFn: async (
+    { id: userId, username, displayname, password, enabled = true, roleAssignments },
+    prevItems,
+  ) => {
     const prevRoleAssignmentsArr = await mngmUserRoleAssignmentsLoader({
       userId,
     })
@@ -98,6 +101,7 @@ export const mngmUserActions = createCRUDActions(ActionDataKeys.ManagementUsers,
       email: username,
       displayname,
       password: password || undefined,
+      enabled: enabled,
     })
     const updateTenantRolesPromises = mergedTenantIds.map((tenantId) => {
       const prevRoleId = prevRoleAssignments[tenantId]

--- a/src/app/plugins/account/components/userManagement/users/enable-disable-user-dialog.tsx
+++ b/src/app/plugins/account/components/userManagement/users/enable-disable-user-dialog.tsx
@@ -1,0 +1,54 @@
+import React, { useCallback, useMemo } from 'react'
+import ConfirmationDialog from 'core/components/ConfirmationDialog'
+import Text from 'core/elements/text'
+import useDataUpdater from 'core/hooks/useDataUpdater'
+import { mngmUserActions, mngmUserRoleAssignmentsLoader } from './actions'
+import useDataLoader from 'core/hooks/useDataLoader'
+import { pathStr } from 'utils/fp'
+
+const EnableDisableUserDialog = ({ rows: [user], onClose }) => {
+  const action = user.enabled ? 'Disable' : 'Enable'
+  const [update, updating] = useDataUpdater(mngmUserActions.update, onClose)
+  const [roleAssignments] = useDataLoader(mngmUserRoleAssignmentsLoader, {
+    userId: user.id,
+  })
+  const userRoleAssignments = useMemo(
+    () =>
+      roleAssignments.reduce(
+        (acc, roleAssignment) => ({
+          ...acc,
+          [pathStr('scope.project.id', roleAssignment)]: pathStr('role.id', roleAssignment),
+        }),
+        {},
+      ),
+    [user, roleAssignments],
+  )
+
+  const handleSubmit = useCallback(
+    () =>
+      update({
+        id: user.id,
+        username: user.username,
+        displayname: user.displayname,
+        enabled: !user.enabled,
+        roleAssignments: userRoleAssignments,
+      }),
+    [user],
+  )
+  return (
+    <ConfirmationDialog
+      title={`${action} User`}
+      text={
+        <Text component="span">
+          {action} user {user.username}?
+        </Text>
+      }
+      open
+      onCancel={onClose}
+      onConfirm={handleSubmit}
+      loading={updating}
+    />
+  )
+}
+
+export default EnableDisableUserDialog

--- a/src/app/plugins/account/components/userManagement/users/enable-disable-user-dialog.tsx
+++ b/src/app/plugins/account/components/userManagement/users/enable-disable-user-dialog.tsx
@@ -32,8 +32,6 @@ const EnableDisableUserDialog = ({ rows: [user], onClose }) => {
 
     update({
       id: user.id,
-      username: user.username,
-      displayname: user.displayname,
       enabled: !user.enabled,
       roleAssignments: userRoleAssignments,
     })

--- a/src/app/plugins/account/components/userManagement/users/enable-disable-user-dialog.tsx
+++ b/src/app/plugins/account/components/userManagement/users/enable-disable-user-dialog.tsx
@@ -1,53 +1,59 @@
-import React, { useCallback, useMemo } from 'react'
-import ConfirmationDialog from 'core/components/ConfirmationDialog'
-import Text from 'core/elements/text'
+import React, { useCallback } from 'react'
 import useDataUpdater from 'core/hooks/useDataUpdater'
 import { mngmUserActions, mngmUserRoleAssignmentsLoader } from './actions'
 import useDataLoader from 'core/hooks/useDataLoader'
 import { pathStr } from 'utils/fp'
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@material-ui/core'
+import Progress from 'core/components/progress/Progress'
+import SubmitButton from 'core/components/buttons/SubmitButton'
+import CancelButton from 'core/components/buttons/CancelButton'
 
 const EnableDisableUserDialog = ({ rows: [user], onClose }) => {
   const action = user.enabled ? 'Disable' : 'Enable'
   const [update, updating] = useDataUpdater(mngmUserActions.update, onClose)
-  const [roleAssignments] = useDataLoader(mngmUserRoleAssignmentsLoader, {
+  const [roleAssignments, loading] = useDataLoader(mngmUserRoleAssignmentsLoader, {
     userId: user.id,
   })
-  const userRoleAssignments = useMemo(
-    () =>
-      roleAssignments.reduce(
-        (acc, roleAssignment) => ({
-          ...acc,
-          [pathStr('scope.project.id', roleAssignment)]: pathStr('role.id', roleAssignment),
-        }),
-        {},
-      ),
-    [user, roleAssignments],
-  )
 
-  const handleSubmit = useCallback(
-    () =>
-      update({
-        id: user.id,
-        username: user.username,
-        displayname: user.displayname,
-        enabled: !user.enabled,
-        roleAssignments: userRoleAssignments,
+  const handleSubmit = useCallback(() => {
+    const userRoleAssignments = roleAssignments.reduce(
+      (acc, roleAssignment) => ({
+        ...acc,
+        [pathStr('scope.project.id', roleAssignment)]: pathStr('role.id', roleAssignment),
       }),
-    [user],
-  )
+      {},
+    )
+
+    update({
+      id: user.id,
+      username: user.username,
+      displayname: user.displayname,
+      enabled: !user.enabled,
+      roleAssignments: userRoleAssignments,
+    })
+  }, [user, roleAssignments])
+
   return (
-    <ConfirmationDialog
-      title={`${action} User`}
-      text={
-        <Text component="span">
-          {action} user {user.username}?
-        </Text>
-      }
-      open
-      onCancel={onClose}
-      onConfirm={handleSubmit}
-      loading={updating}
-    />
+    <Dialog open onClose={onClose}>
+      <Progress loading={loading || updating} minHeight={100} maxHeight={100}>
+        <DialogTitle>{action} User</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {action} user {user.username}?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <CancelButton onClick={onClose} />
+          <SubmitButton onClick={handleSubmit} />
+        </DialogActions>
+      </Progress>
+    </Dialog>
   )
 }
 


### PR DESCRIPTION
**NOTE:**
- 'Enable' and 'Disable' actions are disabled for the active user, meaning that you cannot enable or disable yourself.



### **Added 'Enable' and 'Disable' to the actions toolbar in the users list table**
![Screen Shot 2021-01-15 at 11 36 04 AM](https://user-images.githubusercontent.com/23369276/104774360-67b41f00-572b-11eb-8d12-ea22fd3f409d.png)

![Screen Shot 2021-01-15 at 2 50 45 PM](https://user-images.githubusercontent.com/23369276/104787266-f6cd3100-5743-11eb-81b7-320f48c2725a.png)

![Screen Shot 2021-01-15 at 2 52 04 PM](https://user-images.githubusercontent.com/23369276/104787286-ffbe0280-5743-11eb-87b6-71b3c68e2cec.png)

![Screen Shot 2021-01-15 at 2 52 23 PM](https://user-images.githubusercontent.com/23369276/104787291-0187c600-5744-11eb-8347-331fe45755e5.png)
