### PR TITLE
Check sunpike API before making imported cluster requests

### DIFF
--- a/src/api-client/Qbert.ts
+++ b/src/api-client/Qbert.ts
@@ -254,6 +254,18 @@ class Qbert extends ApiService {
     return rawClusters.map(normalizeCluster<ClusterElement>(baseUrl))
   }
 
+  getSunpikeApis = async () => {
+    const url = `/sunpike/apis/sunpike.platform9.com/v1alpha2`
+    return this.client.basicGet<any>({
+      url,
+      version: 'v4',
+      options: {
+        clsName: this.getClassName(),
+        mthdName: 'getClusters',
+      },
+    })
+  }
+
   getImportedClusters = async () => {
     const url = `/sunpike/apis/sunpike.platform9.com/v1alpha2/clusters`
     const response = await this.client.basicGet<GCluster<ImportedCluster>>({

--- a/src/app/plugins/kubernetes/components/infrastructure/importedClusters/actions.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/importedClusters/actions.ts
@@ -1,7 +1,10 @@
 import ApiClient from 'api-client/ApiClient'
 import createCRUDActions from 'core/helpers/createCRUDActions'
 import { ActionDataKeys } from 'k8s/DataKeys'
+import { intersection } from 'ramda'
 import { importedClustersSelector, makeImportedClustersSelector } from './selectors'
+
+const acceptedApiVersions = ['v1alpha2']
 
 const { qbert } = ApiClient.getInstance()
 
@@ -11,6 +14,12 @@ export const getImportedClusters = async () => {
 
 export const importedClusterActions = createCRUDActions(ActionDataKeys.ImportedClusters, {
   listFn: async () => {
+    const rawSunpikeApis = await qbert.getSunpikeApis()
+    const sunpikeApis = rawSunpikeApis.versions?.map((version) => version.version)
+    if (!intersection(sunpikeApis, acceptedApiVersions).length) {
+      // If API is not supported yet, return an empty array
+      return []
+    }
     const importedClusters = await qbert.getImportedClusters()
     return importedClusters
   },


### PR DESCRIPTION
Would be good to add the typing for the new API endpoint. What tool do you use to auto-generate the models?