### PR TITLE
UX-884/Load dependent cache when fetching deployed apps and modified namespa…

### DIFF
--- a/src/app/plugins/kubernetes/components/apps/actions.js
+++ b/src/app/plugins/kubernetes/components/apps/actions.js
@@ -103,6 +103,9 @@ export const appActions = createCRUDActions(ActionDataKeys.Apps, {
 
 export const deployedAppActions = createCRUDActions(ActionDataKeys.DeployedApps, {
   listFn: async ({ clusterId, namespace }) => {
+    // Fetch dependent cache
+    await appActions.list()
+
     if (namespace === allKey) {
       const namespaces = await namespaceActions.list({ clusterId })
       const releases = someAsync(

--- a/src/app/plugins/kubernetes/components/apps/selectors.ts
+++ b/src/app/plugins/kubernetes/components/apps/selectors.ts
@@ -5,6 +5,8 @@ import getDataSelector from 'core/utils/getDataSelector'
 import createSorter from 'core/helpers/createSorter'
 import { allKey } from 'app/constants'
 import { filterIf } from 'utils/fp'
+import { clustersSelector } from '../infrastructure/clusters/selectors'
+import { importedClustersSelector } from '../infrastructure/importedClusters/selectors'
 
 export const makeDeployedAppsSelector = (
   defaultParams = { orderBy: 'name', orderDirection: 'asc' },
@@ -13,10 +15,17 @@ export const makeDeployedAppsSelector = (
     [
       getDataSelector<DataKeys.DeployedApps>(DataKeys.DeployedApps, ['clusterId']),
       getDataSelector<DataKeys.Apps>(DataKeys.Apps),
+      clustersSelector,
+      importedClustersSelector,
       (_, params) => mergeLeft(params, defaultParams),
     ],
-    (deployedApps, apps, params) => {
+    (deployedApps, apps, clusters, importedClusters, params) => {
       const { clusterId, namespace, orderBy, orderDirection } = params
+      const allClusters = [...clusters, ...importedClusters]
+      if (!clusterId || !allClusters.find(propEq('uuid', clusterId))) {
+        // If no cluster if found, this item is invalid because the cluster has been deleted
+        return []
+      }
       return pipe<any, any, any, any, any>(
         filterIf(clusterId && clusterId !== allKey, propEq('clusterId', clusterId)),
         filterIf(namespace && namespace !== allKey, propEq('namespace', namespace)),

--- a/src/app/plugins/kubernetes/components/common/NamespacePicklist.js
+++ b/src/app/plugins/kubernetes/components/common/NamespacePicklist.js
@@ -9,15 +9,16 @@ import namespaceActions from 'k8s/components/namespaces/actions'
 
 // We need to use `forwardRef` as a workaround of an issue with material-ui Tooltip https://github.com/gregnb/mui-datatables/issues/595
 const NamespacePicklist = forwardRef(
-  ({ clusterId, loading, onChange, selectFirst, ...rest }, ref) => {
+  ({ clusterId, loading, onChange, selectFirst, value, ...rest }, ref) => {
     const [namespaces, namespacesLoading] = useDataLoader(namespaceActions.list, { clusterId })
     const options = useMemo(
       () => projectAs({ label: 'name', value: 'name' }, uniqBy(prop('name'), namespaces)),
       [namespaces],
     )
+
     // Select the first item as soon as data is loaded
     useEffect(() => {
-      if (!isEmpty(options) && selectFirst) {
+      if (!value && !isEmpty(options) && selectFirst) {
         onChange(propOr(allKey, 'value', head(options)))
       }
     }, [options])
@@ -29,6 +30,7 @@ const NamespacePicklist = forwardRef(
         onChange={onChange}
         loading={loading || namespacesLoading}
         options={options}
+        value={value}
       />
     )
   },


### PR DESCRIPTION
…cePicklist

Bug #1:
If you log in and immediately go to cluster details -> deployed apps tab, the default app icons are shown instead of the actual app icons. Also, the number of deployed apps in each repository is always 0.

Reason:
`GET /releases` doesn't provide info such as icon and repository name. `GET /releases/<release_name>` has icon info, but not repository info. We had to get that info from apps but if you didn't go into the apps tab and load the apps first, then the cache doesn't have the icon and repository info

Fix:
The only way to get the both the icon and repository info for a deployed app is to get it from apps. So to fix this issue, fetch apps every time we fetch deployed apps. Then in the deployed apps selector, the icon and repository info from the apps cache is added in.

Bug #2:
The namespace picklist kept defaulting to the first namespace in the list even though you clicked and chose a different namespace.

Fix:
The first namespace should be selected only on the first load if `selectFirst === true and values != undefined`

Not sure why the `useEffect` is being called though. 

Also in the deployed apps selector, I accounted for undefined/deleted clusters