### PR TITLE
UX-440/Allow deployments to be deleted

### DIFF
--- a/src/api-client/Qbert.ts
+++ b/src/api-client/Qbert.ts
@@ -555,7 +555,7 @@ class Qbert extends ApiService {
   }
 
   deleteDeployment = async (clusterId, namespace, name) => {
-    const url = `/k8sapi/apis/apps/v1/namespaces/${namespace}/deployments/${name}`
+    const url = `/clusters/${clusterId}/k8sapi/apis/apps/v1/namespaces/${namespace}/deployments/${name}`
     return this.client.basicDelete({
       url,
       options: {

--- a/src/app/plugins/kubernetes/components/pods/DeploymentsListPage.js
+++ b/src/app/plugins/kubernetes/components/pods/DeploymentsListPage.js
@@ -11,6 +11,8 @@ import renderLabels from 'k8s/components/pods/renderLabels'
 import ExternalLink from 'core/components/ExternalLink'
 import { DateAndTime } from 'core/components/listTable/cells/DateCell'
 import { routes } from 'core/utils/routes'
+import DeleteDeploymentDialog from './delete-deployment-dialog'
+import { ActionDataKeys } from 'k8s/DataKeys'
 
 const defaultParams = {
   masterNodeClusters: true,
@@ -69,9 +71,9 @@ const renderName = (name, { dashboardUrl }) => {
 
 export const options = {
   loaderFn: deploymentActions.list,
-  deleteFn: deploymentActions.delete,
-  deleteCond: () => false,
-  deleteDisabledInfo: 'Feature not yet implemented',
+  multiSelection: false,
+  deleteCond: () => true,
+  DeleteDialog: DeleteDeploymentDialog,
   addUrl: routes.deployments.add.path(),
   addText: 'Add Deployment',
   columns: [
@@ -85,6 +87,7 @@ export const options = {
   ],
   name: 'Deployments',
   title: 'Deployments',
+  cacheKey: ActionDataKeys.Deployments,
   ListPage,
 }
 const components = createCRUDComponents(options)

--- a/src/app/plugins/kubernetes/components/pods/actions.js
+++ b/src/app/plugins/kubernetes/components/pods/actions.js
@@ -62,6 +62,11 @@ export const deploymentActions = createCRUDActions(ActionDataKeys.Deployments, {
     })
     return created
   },
+  deleteFn: async ({ clusterId, namespace, name, id }) => {
+    const result = await qbert.deleteDeployment(clusterId, namespace, name)
+    trackEvent('Delete Deployment', { clusterId, namespace, name, id })
+    return result
+  },
   service: 'qbert',
   indexBy: 'clusterId',
   selectorCreator: makeDeploymentsSelector,

--- a/src/app/plugins/kubernetes/components/pods/delete-deployment-dialog.tsx
+++ b/src/app/plugins/kubernetes/components/pods/delete-deployment-dialog.tsx
@@ -1,0 +1,58 @@
+import useDataUpdater from 'core/hooks/useDataUpdater'
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@material-ui/core'
+import React from 'react'
+import { deploymentActions } from './actions'
+import Progress from 'core/components/progress/Progress'
+import CancelButton from 'core/components/buttons/CancelButton'
+import SubmitButton from 'core/components/buttons/SubmitButton'
+
+const protectedNamespaces = [
+  'platform9-system',
+  'kube-system',
+  'pf9-olm',
+  'pf9-operators',
+  'pf9-monitoring',
+]
+
+const DeleteDeploymentDialog = ({ rows: [deployment], onClose }) => {
+  const { clusterId, namespace, name, id } = deployment
+  const [deleteDeployment, deletingDeployment] = useDataUpdater(deploymentActions.delete, onClose)
+  const allowDelete = !protectedNamespaces.includes(namespace)
+
+  const handleSubmit = () => {
+    deleteDeployment({ clusterId, namespace, name, id })
+  }
+
+  return (
+    <Dialog open onClose={onClose}>
+      <Progress loading={deletingDeployment} minHeight={100} maxHeight={100}>
+        <DialogTitle>Delete Deployment</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {allowDelete
+              ? `Delete deployment: ${name}?`
+              : 'Protected Namespace - Please contact Platform9 for assistance'}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          {allowDelete ? (
+            <>
+              <CancelButton onClick={onClose} />
+              <SubmitButton onClick={handleSubmit} />
+            </>
+          ) : (
+            <CancelButton onClick={onClose}>Close</CancelButton>
+          )}
+        </DialogActions>
+      </Progress>
+    </Dialog>
+  )
+}
+
+export default DeleteDeploymentDialog


### PR DESCRIPTION
**NOTES:**
- Namespaces in these protected namespaces cannot be deleted by the user: 
          - platform9-system
          - kube-system
          - pf9-olm
          - pf9-operators
          - pf9-monitoring

![Screen Shot 2021-04-15 at 1 59 11 PM](https://user-images.githubusercontent.com/23369276/114939371-2f3ce380-9df5-11eb-9261-22f96d576bb2.png)

![Screen Shot 2021-04-15 at 1 57 20 PM](https://user-images.githubusercontent.com/23369276/114939382-3237d400-9df5-11eb-9ce7-eb0bfd7d7eef.png)
