### PR TITLE
UX-762/Removed cluster upgrade availability out of cluster health status

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatusUtils.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatusUtils.ts
@@ -120,7 +120,6 @@ export function getHealthStatus(
   connectionStatus: ConnectionStatus | TransientStatus,
   masterStatus: HealthStatus | TransientStatus,
   workerStatus: HealthStatus | TransientStatus,
-  canUpgrade,
 ) {
   if (connectionStatus === 'disconnected') {
     return 'unknown'
@@ -128,10 +127,6 @@ export function getHealthStatus(
 
   if (isTransientStatus(connectionStatus)) {
     return connectionStatus as TransientStatus
-  }
-
-  if (canUpgrade) {
-    return 'needs_upgrade'
   }
 
   const healthStatusAndMessage = findClusterHealthValues(masterStatus, workerStatus)
@@ -334,10 +329,6 @@ export const clusterHealthStatusFields: {
   converging: {
     status: 'loading',
     label: 'Converging',
-  },
-  needs_upgrade: {
-    status: 'upgrade',
-    label: 'Upgrade Available',
   },
 }
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.tsx
@@ -19,7 +19,7 @@ import ClusterUpgradeDialog from 'k8s/components/infrastructure/clusters/Cluster
 import PrometheusAddonDialog from 'k8s/components/prometheus/PrometheusAddonDialog'
 import { ActionDataKeys } from 'k8s/DataKeys'
 import { both, omit, prop } from 'ramda'
-import React from 'react'
+import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { capitalizeString, castBoolToStr } from 'utils/misc'
 import { cloudProviderTypes } from '../cloudProviders/selectors'
@@ -127,15 +127,20 @@ const renderNodeLink = (_, { uuid, nodes }) => {
 
 const renderStats = (_, { usage }) => <ResourceUsageTables usage={usage} />
 
-const renderK8sVersion = (_, { uuid, version, canUpgrade }) => {
+const renderK8sVersion = (_, cluster) => <K8sVersion cluster={cluster} />
+
+const K8sVersion = ({ cluster }) => {
+  const { version, canUpgrade } = cluster
+  const [showDialog, setShowDialog] = useState(false)
   return (
     <div>
       <Text variant="body2">{version}</Text>
       {canUpgrade && (
-        <SimpleLink src={routes.cluster.nodeHealth.path({ id: uuid })}>
+        <SimpleLink src="" onClick={() => setShowDialog(true)}>
           Upgrade Available
         </SimpleLink>
       )}
+      {showDialog && <ClusterUpgradeDialog rows={[cluster]} onClose={() => setShowDialog(false)} />}
     </div>
   )
 }

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.tsx
@@ -127,6 +127,19 @@ const renderNodeLink = (_, { uuid, nodes }) => {
 
 const renderStats = (_, { usage }) => <ResourceUsageTables usage={usage} />
 
+const renderK8sVersion = (_, { uuid, version, canUpgrade }) => {
+  return (
+    <div>
+      <Text variant="body2">{version}</Text>
+      {canUpgrade && (
+        <SimpleLink src={routes.cluster.nodeHealth.path({ id: uuid })}>
+          Upgrade Available
+        </SimpleLink>
+      )}
+    </div>
+  )
+}
+
 const renderClusterDetailLink = (name, cluster) => (
   <SimpleLink src={routes.cluster.nodes.path({ id: cluster.uuid })}>{name}</SimpleLink>
 )
@@ -204,7 +217,7 @@ export const options = {
       render: (type) => cloudProviderTypes[type] || capitalizeString(type),
     },
     { id: 'resource_utilization', label: 'Resource Utilization', render: renderStats },
-    { id: 'version', label: 'K8 Version' },
+    { id: 'version', label: 'K8 Version', render: renderK8sVersion },
     {
       id: 'created_at',
       label: 'Created at',

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/model.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/model.ts
@@ -22,12 +22,7 @@ export enum BareOsRequiredNodes {
   'multi-master' = 2,
 }
 
-export type HealthStatus =
-  | 'healthy'
-  | 'partially_healthy'
-  | 'unhealthy'
-  | 'unknown'
-  | 'needs_upgrade'
+export type HealthStatus = 'healthy' | 'partially_healthy' | 'unhealthy' | 'unknown'
 
 interface IClusterAsyncAction {
   progressPercent: any

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/selectors.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/selectors.ts
@@ -68,7 +68,6 @@ export const clustersSelector = createSelector(
         connectionStatus,
         masterNodesHealthStatus,
         workerNodesHealthStatus,
-        cluster.canUpgrade,
       )
       const hasMasterNode = healthyMasterNodes.length > 0
       const clusterOk = nodesInCluster.length > 0 && cluster.status === 'ok'


### PR DESCRIPTION
**NOTES:** 

- Cluster upgrade availability is no longer part of the cluster health status
- Cluster upgrade availability is now shown as a link in the K8s Version column in the clusters list table
- Link action has changed. Instead of going to the nodes details page, it will now open up the cluster upgrade dialog.

![Screen Shot 2021-04-16 at 3 15 43 PM](https://user-images.githubusercontent.com/23369276/115093640-d8f0a300-9ecf-11eb-823c-c73760c0c8a0.png)

Since it's no longer part of cluster health, 'Upgrade Available' will no longer show up in the cluster status card. 

![Screen Shot 2021-04-16 at 4 24 45 PM](https://user-images.githubusercontent.com/23369276/115093823-646a3400-9ed0-11eb-94c6-73a6ea5940db.png)

