### PR TITLE
UX-697/Redirect users to the clusters list page if the viewed cluster has be…

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDetailsPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDetailsPage.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import Tabs from 'core/components/tabs/Tabs'
 import Tab from 'core/components/tabs/Tab'
 import clsx from 'clsx'
@@ -188,14 +188,25 @@ const ClusterTaskError = ({ taskError }) => {
 }
 
 const ClusterDetailsPage = () => {
-  const { match } = useReactRouter()
+  const { match, history } = useReactRouter()
   const classes = useStyles()
   const [clusters, loading, reload] = useDataLoader(clusterActions.list, undefined, {
     loadingFeedback: false,
   })
   const session = useSelector(prop(sessionStoreKey))
   const { features } = session
-  const cluster = clusters.find((x) => x.uuid === match.params.id) || {}
+  const cluster = clusters.find((x) => x.uuid === match.params.id)
+
+  useEffect(() => {
+    if (!cluster) {
+      history.push(routes.cluster.list.path())
+    }
+  }, [cluster, history])
+
+  if (!cluster) {
+    return null
+  }
+
   const clusterHeader = (
     <>
       <ClusterStatusAndUsage cluster={cluster} loading={loading} />

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/cluster-deployed-apps.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/cluster-deployed-apps.tsx
@@ -235,7 +235,7 @@ const ClusterDeployedApps = ({ cluster, reload, loading }: ClusterDeployedAppsPr
     loadingAppsAvailableToCluster,
     reloadAppsAvailableToCluster,
   ]: IUseDataLoader<IAppsAvailableToClusterAction> = useDataLoader(appsAvailableToClusterLoader, {
-    clusterId: cluster.uuid,
+    clusterId: cluster?.uuid,
   }) as any
 
   const [
@@ -243,7 +243,7 @@ const ClusterDeployedApps = ({ cluster, reload, loading }: ClusterDeployedAppsPr
     loadingDeployedApps,
     reloadDeployedApps,
   ]: IUseDataLoader<IDeployedAppsSelector> = useDataLoader(deployedAppActions.list, {
-    clusterId: cluster.uuid,
+    clusterId: cluster?.uuid,
     namespace: allKey,
   }) as any
 
@@ -252,7 +252,7 @@ const ClusterDeployedApps = ({ cluster, reload, loading }: ClusterDeployedAppsPr
     loadingRepositories,
     reloadRepositories,
   ]: IUseDataLoader<RepositoriesForCluster> = useDataLoader(repositoriesForClusterLoader, {
-    clusterId: cluster.uuid,
+    clusterId: cluster?.uuid,
   }) as any
 
   const filteredDeployedApps = useMemo(
@@ -288,7 +288,7 @@ const ClusterDeployedApps = ({ cluster, reload, loading }: ClusterDeployedAppsPr
       {
         id: 'version',
         label: 'Kubernetes Version',
-        value: cluster.kubeRoleVersion || cluster.kubeVersion,
+        value: cluster?.kubeRoleVersion || cluster?.kubeVersion,
       },
       {
         id: 'apps',
@@ -298,7 +298,7 @@ const ClusterDeployedApps = ({ cluster, reload, loading }: ClusterDeployedAppsPr
       {
         id: 'workerNodes',
         label: 'Number of Worker Nodes',
-        value: cluster.numWorkers?.toString() || cluster.workers?.toString(),
+        value: cluster?.numWorkers?.toString() || cluster?.workers?.toString(),
       },
     ]
   }, [cluster, filteredDeployedApps])
@@ -341,7 +341,7 @@ const ClusterDeployedApps = ({ cluster, reload, loading }: ClusterDeployedAppsPr
       {showDialog && (
         <DisconnectRepositoryDialog
           name={activeRepository}
-          clusterId={cluster.uuid}
+          clusterId={cluster?.uuid}
           onSubmit={handleRepositoryDisconnect}
           onClose={handleDialogClose}
         />
@@ -366,7 +366,7 @@ const ClusterDeployedApps = ({ cluster, reload, loading }: ClusterDeployedAppsPr
         </div>
         <ClusterDeployedAppsTable
           apps={filteredDeployedApps}
-          clusterId={cluster.uuid}
+          clusterId={cluster?.uuid}
           history={history}
         />
       </Progress>

--- a/src/app/plugins/kubernetes/components/infrastructure/importedClusters/imported-cluster-details.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/importedClusters/imported-cluster-details.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import useReactRouter from 'use-react-router'
 import useDataLoader from 'core/hooks/useDataLoader'
 import { importedClusterActions } from './actions'
@@ -23,12 +23,22 @@ import { ImportedClusterSelector } from './model'
 import ClusterDeployedApps from '../clusters/cluster-deployed-apps'
 
 function ImportedClusterDetails() {
-  const { match } = useReactRouter()
+  const { match, history } = useReactRouter()
   const classes = useStyles()
   const [clusters, loading, reload]: IUseDataLoader<ImportedClusterSelector> = useDataLoader(
     importedClusterActions.list,
   ) as any
   const cluster = clusters.find((x) => x.uuid === match.params.id)
+  useEffect(() => {
+    if (!cluster) {
+      history.push(routes.cluster.imported.list.path())
+    }
+  }, [cluster, history])
+
+  if (!cluster) {
+    return null
+  }
+
   const clusterHeader = <HeaderCard title={cluster?.name} cluster={cluster} />
   return (
     <PageContainer>


### PR DESCRIPTION
…en deleted

**NOTES:**

- If the user is on any of the cluster detail pages (Nodes, Node Health, Cluster Details, and Deployed Apps) and the cluster has been deleted by another user or another active session, they will be redirected to the clusters list page
- This applies to both regular clusters and imported clusters


https://user-images.githubusercontent.com/23369276/115474607-a78b1680-a1f2-11eb-845c-e64cbca19d9d.mov


