### PR TITLE
UX-889/Added 'Submit a Support Request' tile in the Help Page

### DIFF
--- a/src/app/plugins/kubernetes/components/common/HelpPage.tsx
+++ b/src/app/plugins/kubernetes/components/common/HelpPage.tsx
@@ -10,18 +10,21 @@ import {
   tutorialsHelpLink,
   slackLink,
   forumHelpLink,
+  requestFormLink,
 } from 'k8s/links'
 import ExternalLink from 'core/components/ExternalLink'
 import { hexToRGBA } from 'core/utils/colorHelpers'
 import { useSelector } from 'react-redux'
 import { CustomerTiers } from 'app/constants'
 import { pathOr, prop } from 'ramda'
-import { sessionStoreKey } from 'core/session/sessionReducers'
-import { showAndOpenZendeskWidget, showZendeskWidget } from 'utils/zendesk-widget'
+import { SessionState, sessionStoreKey } from 'core/session/sessionReducers'
+import { showAndOpenZendeskWidget } from 'utils/zendesk-widget'
 import useScopedPreferences from 'core/session/useScopedPreferences'
 import { showZendeskChatOption } from 'core/utils/helpers'
+import Theme from 'core/themes/model'
+import { RootState } from 'app/store'
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   pageHeader: {
     marginBottom: theme.spacing(2),
     paddingTop: theme.spacing(2),
@@ -79,7 +82,16 @@ const useStyles = makeStyles((theme) => ({
 
 const brandIcons = ['slack-hash']
 
-const SupportCard = ({ title, icon, body = '', src, action, onClick }) => {
+interface SupportCardProps {
+  title: string
+  icon: string
+  body?: string
+  src: string
+  action: string
+  onClick?: any
+}
+
+const SupportCard = ({ title, icon, body = '', src, action, onClick }: SupportCardProps) => {
   const classes = useStyles()
   return (
     <div className={classes.card}>
@@ -109,10 +121,12 @@ const SupportCard = ({ title, icon, body = '', src, action, onClick }) => {
 
 const HelpPage = () => {
   const classes = useStyles()
-  const session = useSelector(prop(sessionStoreKey))
+  const session = useSelector<RootState, SessionState>(prop(sessionStoreKey))
   const { features } = session
-  const customerTier = pathOr(CustomerTiers.Freedom, ['customer_tier'], features)
+  const customerTier = pathOr<CustomerTiers>(CustomerTiers.Freedom, ['customer_tier'], features)
   const [{ lastStack }] = useScopedPreferences()
+  const showSupportRequestOption =
+    customerTier === CustomerTiers.Growth || customerTier === CustomerTiers.Enterprise
 
   return (
     <>
@@ -161,6 +175,14 @@ const HelpPage = () => {
           src={slackLink}
           action="Open Slack"
         />
+        {showSupportRequestOption && (
+          <SupportCard
+            title="Submit a Support Request"
+            icon="file-alt"
+            src={requestFormLink}
+            action="Open Request Form"
+          />
+        )}
         {showZendeskChatOption(lastStack, customerTier) && (
           <SupportCard
             title="Chat With Us"

--- a/src/app/plugins/kubernetes/links.ts
+++ b/src/app/plugins/kubernetes/links.ts
@@ -23,6 +23,7 @@ export const slackLink = 'https://slack.platform9.io'
 export const forumHelpLink = `${communityBaseUrl}/`
 export const pf9PmkArchitectureDigLink = `${k8sBaseUrl}/multimaster-architecture-platform9-managed-kubernetes/`
 export const pmkDocumentationLink = `${k8sBaseUrl}/introduction/overview`
+export const requestFormLink = `${pf9SupportBaseUrl}/hc/en-us/requests/new?ticket_form_id=360000924873`
 
 // Aws
 export const awsPrerequisitesLink = `${k8sBaseUrl}/aws/`


### PR DESCRIPTION
**NOTES:**

- A 'Submit a Support Request' tile has been added in the help page
- It links to the PF9 request form (https://support.platform9.com/hc/en-us/requests/new?ticket_form_id=360000924873)
- This will only show for  Growth and Enterprise customers


![Screen Shot 2021-04-21 at 1 40 37 PM](https://user-images.githubusercontent.com/23369276/115618576-be3f7500-a2a7-11eb-9258-993c9a1399b1.png)

