### PR TITLE
UX-931/Fixed AWS cluster template bug

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/custom.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/custom.tsx
@@ -133,7 +133,7 @@ const templateOptions = [
 // small (single dev) - 1 node master + worker - select instance type (default t2.small)
 // medium (internal team) - 1 master + 3 workers - select instance (default t2.medium)
 // large (production) - 3 master + 5 workers - no workload on masters (default t2.large)
-const handleTemplateChoice = ({ setFieldValue }) => (option) => {
+const handleTemplateChoice = ({ setFieldValue, setWizardContext }) => (option) => {
   const options = {
     small: {
       numMasters: 1,
@@ -171,6 +171,7 @@ const handleTemplateChoice = ({ setFieldValue }) => (option) => {
       setFieldValue(key)(value)
     })
   })
+  setWizardContext(options[option])
 }
 
 const useStyles = makeStyles<Theme>((theme) => ({
@@ -251,6 +252,7 @@ const AdvancedAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                   options={templateOptions}
                   onChange={handleTemplateChoice({
                     setFieldValue,
+                    setWizardContext,
                   })}
                 />
 


### PR DESCRIPTION
When the user chooses a cluster template in the AWS cluster creation form, the template values are now properly updated


https://user-images.githubusercontent.com/23369276/117504734-ca7a3200-af37-11eb-8037-e149f77dc456.mov

