### PR TITLE
UX-226/Add ETCD Backup card to cluster details page

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDetailsPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDetailsPage.js
@@ -176,14 +176,17 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-const ClusterTaskError = ({ taskError }) => {
+const clusterTaskErrorTitle = 'Error Impacting Cluster Availability'
+const etcdBackupTaskErrorTitle = 'ETCD Backup Error'
+
+const ClusterTaskError = ({ title, taskError }) => {
   const classes = useStyles()
   const formattedError = cleanupStacktrace(taskError)
   return (
     <div className={classes.taskErrorAlert}>
       <header>
         <FontAwesomeIcon>{variantIcon.error}</FontAwesomeIcon>
-        <Text variant="caption1">Error Impacting Cluster Availability</Text>
+        <Text variant="caption1">{title}</Text>
         <CopyToClipboard copyText={formattedError} copyIcon="copy" codeBlock={false} />
       </header>
       <CodeBlock className={classes.taskErrorMessage}>{formattedError}</CodeBlock>
@@ -214,7 +217,15 @@ const ClusterDetailsPage = () => {
   const clusterHeader = (
     <>
       <ClusterStatusAndUsage cluster={cluster} loading={loading} />
-      {cluster.taskError && <ClusterTaskError taskError={cluster.taskError} />}
+      {cluster.taskError && (
+        <ClusterTaskError title={clusterTaskErrorTitle} taskError={cluster.taskError} />
+      )}
+      {cluster.etcdBackup?.taskErrorDetail && (
+        <ClusterTaskError
+          title={etcdBackupTaskErrorTitle}
+          taskError={cluster.etcdBackup.taskErrorDetail}
+        />
+      )}
     </>
   )
   return (

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterInfo.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterInfo.tsx
@@ -220,16 +220,40 @@ const azureCloudProps = (cluster) => getFieldsForCard(azureCloudFields, cluster)
 const csiDriverProps = (driver: any) => getFieldsForCard(csiDriverFields, driver)
 const etcdBackupProps = (cluster) => getFieldsForCard(etcdBackupFields, cluster)
 
-const renderCloudInfo = (cluster) => {
+const renderCloudInfo = (cluster, classes) => {
   switch (cluster.cloudProviderType) {
     case 'aws':
-      return <InfoPanel title="Cloud Properties" items={awsCloudProps(cluster)} />
+      return (
+        <InfoPanel
+          className={classes.card}
+          title="Cloud Properties"
+          items={awsCloudProps(cluster)}
+        />
+      )
     case 'local':
-      return <InfoPanel title="Networking" items={bareOsNetworkingProps(cluster)} />
+      return (
+        <InfoPanel
+          className={classes.card}
+          title="Networking"
+          items={bareOsNetworkingProps(cluster)}
+        />
+      )
     case 'azure':
-      return <InfoPanel title="Cloud Properties" items={azureCloudProps(cluster)} />
+      return (
+        <InfoPanel
+          className={classes.card}
+          title="Cloud Properties"
+          items={azureCloudProps(cluster)}
+        />
+      )
     default:
-      return <InfoPanel title="Cloud Properties" items={{ 'Data not found': '' }} />
+      return (
+        <InfoPanel
+          className={classes.card}
+          title="Cloud Properties"
+          items={{ 'Data not found': '' }}
+        />
+      )
   }
 }
 
@@ -279,7 +303,7 @@ const ClusterInfo = () => {
         )}
       </div>
       <div className={classes.column}>
-        {renderCloudInfo(cluster)}
+        {renderCloudInfo(cluster, classes)}
         <InfoPanel className={classes.card} title="ETCD Backup" items={etcdBackupFields} />
       </div>
     </div>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterInfo.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterInfo.tsx
@@ -205,11 +205,27 @@ const csiDriverFields = [
   },
 ]
 
+const etcdBackupFields = [
+  {
+    id: 'etcdBackup.isEtcdBackupEnabled',
+    title: 'ETCD Backup',
+    required: true,
+    render: castBoolToStr(),
+  },
+  { id: 'etcdBackup.storageProperties.localPath', title: 'ETCD Data Directory' },
+  {
+    id: 'etcdBackup.taskStatus',
+    title: 'Task Status',
+    condition: (cluster) => !!cluster.etcdBackupEnabled,
+  },
+]
+
 const overviewStats = (cluster) => getFieldsForCard(clusterOverviewFields, cluster)
 const bareOsNetworkingProps = (cluster) => getFieldsForCard(bareOsNetworkingFields, cluster)
 const awsCloudProps = (cluster) => getFieldsForCard(awsCloudFields, cluster)
 const azureCloudProps = (cluster) => getFieldsForCard(azureCloudFields, cluster)
 const csiDriverProps = (driver: any) => getFieldsForCard(csiDriverFields, driver)
+const etcdBackupProps = (cluster) => getFieldsForCard(etcdBackupFields, cluster)
 
 const renderCloudInfo = (cluster) => {
   switch (cluster.cloudProviderType) {
@@ -232,6 +248,13 @@ const useStyles = makeStyles<Theme>((theme) => ({
     alignItems: 'start',
     justifyItems: 'start',
   },
+  column: {
+    display: 'grid',
+    gridGap: theme.spacing(2),
+  },
+  card: {
+    width: 'inherit',
+  },
   text: {
     color: theme.palette.common.white,
   },
@@ -248,15 +271,24 @@ const ClusterInfo = () => {
 
   const overview = overviewStats(cluster)
   const csiDrivers = cluster?.csiDrivers?.drivers || []
+  const etcdBackupFields = etcdBackupProps(cluster)
 
   return (
     <div className={classes.clusterInfo}>
-      <InfoPanel title="Overview" items={overview} />
-
-      {renderCloudInfo(cluster)}
-      {csiDrivers.length > 0 && (
-        <InfoPanel title="CSI Driver Details" items={csiDrivers.map(csiDriverProps)} />
-      )}
+      <div className={classes.column}>
+        <InfoPanel className={classes.card} title="Overview" items={overview} />
+        {csiDrivers.length > 0 && (
+          <InfoPanel
+            className={classes.card}
+            title="CSI Driver Details"
+            items={csiDrivers.map(csiDriverProps)}
+          />
+        )}
+      </div>
+      <div className={classes.column}>
+        {renderCloudInfo(cluster)}
+        <InfoPanel className={classes.card} title="ETCD Backup" items={etcdBackupFields} />
+      </div>
     </div>
   )
 }

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterInfo.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterInfo.tsx
@@ -79,24 +79,6 @@ const clusterOverviewFields: Array<IClusterDetailFields<IClusterSelector>> = [
   { id: 'privileged', title: 'Privileged', required: true, render: castBoolToStr() },
   { id: 'uuid', title: 'Unique ID', required: true },
   { id: 'dockerRoot', title: 'Docker Root Directory', required: true },
-  { id: 'etcdBackupEnabled', title: 'ETCD Backup', required: true, render: castBoolToStr() },
-  {
-    id: 'etcdBackup.storageProperties.localPath',
-    title: 'ETCD Backup Storage Path',
-    condition: (cluster) => !!cluster.etcdBackupEnabled,
-  },
-  {
-    id: 'etcdBackup.intervalInMins',
-    title: 'ETCD Backup Interval',
-    condition: (cluster) => !!cluster.etcdBackupEnabled,
-  },
-  { id: 'etcdDataDir', title: 'ETCD Data Directory', required: true },
-  {
-    id: 'etcdVersion',
-    title: 'ETCD version',
-    required: true,
-    condition: (cluster) => !!cluster.etcdBackupEnabled,
-  },
   { id: 'k8sApiPort', title: 'K8S API Server port', required: true },
   { id: 'mtuSize', title: 'MTU size', required: true },
   { id: 'flannelIfaceLabel', title: 'Flannel interface' },
@@ -206,16 +188,27 @@ const csiDriverFields = [
 ]
 
 const etcdBackupFields = [
-  {
-    id: 'etcdBackup.isEtcdBackupEnabled',
-    title: 'ETCD Backup',
-    required: true,
-    render: castBoolToStr(),
-  },
-  { id: 'etcdBackup.storageProperties.localPath', title: 'ETCD Data Directory' },
+  { id: 'etcdBackupEnabled', title: 'ETCD Backup', required: true, render: castBoolToStr() },
   {
     id: 'etcdBackup.taskStatus',
     title: 'Task Status',
+    condition: (cluster) => !!cluster.etcdBackupEnabled,
+  },
+  {
+    id: 'etcdBackup.storageProperties.localPath',
+    title: 'ETCD Backup Storage Path',
+    condition: (cluster) => !!cluster.etcdBackupEnabled,
+  },
+  {
+    id: 'etcdBackup.intervalInMins',
+    title: 'ETCD Backup Interval',
+    condition: (cluster) => !!cluster.etcdBackupEnabled,
+  },
+  { id: 'etcdDataDir', title: 'ETCD Data Directory', required: true },
+  {
+    id: 'etcdVersion',
+    title: 'ETCD version',
+    required: true,
     condition: (cluster) => !!cluster.etcdBackupEnabled,
   },
 ]

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatus.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatus.tsx
@@ -173,7 +173,7 @@ export const ClusterHealthStatus: FC<IClusterStatusProps> = ({
           )}
         </ClusterStatusSpan>
       )}
-      {cluster.taskError &&
+      {(cluster.taskError || cluster.etcdBackup?.taskErrorDetail) &&
         renderErrorStatus(routes.cluster.detail.path({ id: cluster.uuid }), variant)}
     </div>
   )

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/custom.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/custom.tsx
@@ -133,7 +133,7 @@ const templateOptions = [
 // small (single dev) - 1 node master + worker - select instance type (default t2.small)
 // medium (internal team) - 1 master + 3 workers - select instance (default t2.medium)
 // large (production) - 3 master + 5 workers - no workload on masters (default t2.large)
-const handleTemplateChoice = ({ setFieldValue }) => (option) => {
+const handleTemplateChoice = ({ setFieldValue, setWizardContext }) => (option) => {
   const options = {
     small: {
       numMasters: 1,
@@ -171,6 +171,7 @@ const handleTemplateChoice = ({ setFieldValue }) => (option) => {
       setFieldValue(key)(value)
     })
   })
+  setWizardContext(options[option])
 }
 
 const useStyles = makeStyles<Theme>((theme) => ({
@@ -251,6 +252,7 @@ const AdvancedAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                   options={templateOptions}
                   onChange={handleTemplateChoice({
                     setFieldValue,
+                    setWizardContext,
                   })}
                 />
 

--- a/src/app/plugins/kubernetes/components/infrastructure/nodes/NodeDetailsPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/nodes/NodeDetailsPage.tsx
@@ -49,6 +49,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     justifyContent: 'flex-end',
     color: theme.palette.grey[700],
     textAlign: 'right',
+    whiteSpace: 'nowrap',
   },
   rowValue: {
     marginLeft: theme.spacing(0.5),


### PR DESCRIPTION
**Changes:**

- Added ETCD Backup card to cluster details page that displays the following info:

  - ETCD Backup: Enabled or Not Enabled (Required)
  - Task Status
  - ETCD Backup Storage Path
  - ETCD Backup Interval
  - ETCD Data Directory (required)
  - ETCD Version

- Removed ETCD Backup related fields from the Overview card
- Fixed the InfoCard styling


### ETCD Backup Enabled
![Screen Shot 2021-05-11 at 4 09 05 PM](https://user-images.githubusercontent.com/23369276/117895640-a8541d00-b273-11eb-9b5c-acdc7e996a6f.png)


### ETCD Backup Not Enabled
![Screen Shot 2021-05-11 at 4 12 43 PM](https://user-images.githubusercontent.com/23369276/117895675-bbff8380-b273-11eb-83b2-dd03a11776e6.png)

### If there is an error with the etcd backup, the task error will be displayed like the cluster task error
![Screen Shot 2021-05-11 at 4 23 45 PM](https://user-images.githubusercontent.com/23369276/117896755-1d285680-b276-11eb-817b-6f19433051e2.png)





