### PR TITLE
UX-909/Add BareOS "useHostname" Flag during cluster create

### DIFF
--- a/src/app/core/components/validatedForm/radio-fields.tsx
+++ b/src/app/core/components/validatedForm/radio-fields.tsx
@@ -1,7 +1,7 @@
 import React, { FC, PureComponent } from 'react'
 import { FormControl, FormControlLabel, FormHelperText, Radio, WithStyles } from '@material-ui/core'
 import { withStyles } from '@material-ui/styles'
-import { withInfoTooltip } from 'app/core/components/InfoTooltip'
+import InfoTooltip, { withInfoTooltip } from 'app/core/components/InfoTooltip'
 import { compose } from 'app/utils/fp'
 import withFormContext from 'core/components/validatedForm/withFormContext'
 import { ValidatedFormProps } from './model'
@@ -20,6 +20,8 @@ const styles = (theme) => ({
 interface OptionType {
   value: string | number
   label: string | number
+  info?: string
+  infoPlacement?: string
 }
 interface FormProps {
   id: string
@@ -60,17 +62,19 @@ const RadioFields = compose(
         <div className={classes.root}>
           {options.map((option) => (
             <FormControl key={option.value} className={classes.formControl} error={hasError}>
-              <FormControlLabel
-                classes={formControlLabelClasses}
-                label={option.label}
-                control={
-                  <Radio
-                    color="primary"
-                    checked={option.value === value}
-                    onChange={() => this.handleChange(option.value)}
-                  />
-                }
-              />
+              <InfoTooltip info={option.info} placement={option.infoPlacement}>
+                <FormControlLabel
+                  classes={formControlLabelClasses}
+                  label={option.label}
+                  control={
+                    <Radio
+                      color="primary"
+                      checked={option.value === value}
+                      onChange={() => this.handleChange(option.value)}
+                    />
+                  }
+                />
+              </InfoTooltip>
               {errorMessage && <FormHelperText>{errorMessage}</FormHelperText>}
             </FormControl>
           ))}

--- a/src/app/core/components/validatedForm/radio-fields.tsx
+++ b/src/app/core/components/validatedForm/radio-fields.tsx
@@ -17,11 +17,12 @@ const styles = (theme) => ({
     marginTop: theme.spacing(1),
   },
 })
-interface OptionType {
+export interface OptionType {
   value: string | number
   label: string | number
   info?: string
   infoPlacement?: string
+  disabled?: boolean
 }
 interface FormProps {
   id: string
@@ -60,17 +61,18 @@ const RadioFields = compose(
 
       return (
         <div className={classes.root}>
-          {options.map((option) => (
-            <FormControl key={option.value} className={classes.formControl} error={hasError}>
-              <InfoTooltip info={option.info} placement={option.infoPlacement}>
+          {options.map(({ label, value: optionValue, info, infoPlacement, disabled = false }) => (
+            <FormControl key={optionValue} className={classes.formControl} error={hasError}>
+              <InfoTooltip info={info} placement={infoPlacement}>
                 <FormControlLabel
                   classes={formControlLabelClasses}
-                  label={option.label}
+                  label={label}
                   control={
                     <Radio
                       color="primary"
-                      checked={option.value === value}
-                      onChange={() => this.handleChange(option.value)}
+                      checked={optionValue === value}
+                      onChange={() => this.handleChange(optionValue)}
+                      disabled={disabled}
                     />
                   }
                 />

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/custom.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/custom.tsx
@@ -133,7 +133,7 @@ const templateOptions = [
 // small (single dev) - 1 node master + worker - select instance type (default t2.small)
 // medium (internal team) - 1 master + 3 workers - select instance (default t2.medium)
 // large (production) - 3 master + 5 workers - no workload on masters (default t2.large)
-const handleTemplateChoice = ({ setFieldValue }) => (option) => {
+const handleTemplateChoice = ({ setFieldValue, setWizardContext }) => (option) => {
   const options = {
     small: {
       numMasters: 1,
@@ -171,6 +171,7 @@ const handleTemplateChoice = ({ setFieldValue }) => (option) => {
       setFieldValue(key)(value)
     })
   })
+  setWizardContext(options[option])
 }
 
 const useStyles = makeStyles<Theme>((theme) => ({
@@ -251,6 +252,7 @@ const AdvancedAwsCluster: FC<Props> = ({ wizardContext, setWizardContext, onNext
                   options={templateOptions}
                   onChange={handleTemplateChoice({
                     setFieldValue,
+                    setWizardContext,
                   })}
                 />
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-multi-master.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-multi-master.tsx
@@ -65,6 +65,8 @@ export const initialContext = {
   calicoIPv4: 'autodetect',
   calicoIPv6: 'none',
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
+  useHostname: 'false',
+  nodeRegistrationType: 'ipAddress',
 }
 
 interface Props {
@@ -104,43 +106,53 @@ const PhysicalMultiMasterCluster: FC<Props> = ({ onNext, ...props }) => {
           withAddonManager
           elevated={false}
         >
-          {/* Cluster Name */}
-          <FormFieldCard
-            title={`Name your ${ClusterCreateTypeNames[ClusterCreateTypes.MultiMaster]} Cluster`}
-            link={
-              <ExternalLink textVariant="caption2" url={pmkCliOverviewLink}>
-                BareOS Cluster Help
-              </ExternalLink>
-            }
-          >
-            <ClusterNameField setWizardContext={setWizardContext} />
-          </FormFieldCard>
+          {({ setFieldValue, values }) => (
+            <>
+              {/* Cluster Name */}
+              <FormFieldCard
+                title={`Name your ${
+                  ClusterCreateTypeNames[ClusterCreateTypes.MultiMaster]
+                } Cluster`}
+                link={
+                  <ExternalLink textVariant="caption2" url={pmkCliOverviewLink}>
+                    BareOS Cluster Help
+                  </ExternalLink>
+                }
+              >
+                <ClusterNameField setWizardContext={setWizardContext} />
+              </FormFieldCard>
 
-          {/* Cluster Settings */}
-          <FormFieldCard title="Cluster Settings">
-            <KubernetesVersion />
+              {/* Cluster Settings */}
+              <FormFieldCard title="Cluster Settings">
+                <KubernetesVersion />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Cluster Network Stack</Text>
-            <NetworkStack {...props} />
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Cluster Network Stack</Text>
+                <NetworkStack {...props} />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Node Registration</Text>
-            <NodeRegistrationChooser {...props} />
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Node Registration</Text>
+                <NodeRegistrationChooser
+                  values={values}
+                  wizardContext={wizardContext}
+                  setWizardContext={setWizardContext}
+                />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Application & Container Settings</Text>
-            <PrivilegedContainers {...props} />
-            <AllowWorkloadsOnMaster setWizardContext={setWizardContext} />
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Application & Container Settings</Text>
+                <PrivilegedContainers {...props} />
+                <AllowWorkloadsOnMaster setWizardContext={setWizardContext} />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Cluster Add-Ons</Text>
-            <AddonTogglers
-              wizardContext={wizardContext}
-              setWizardContext={setWizardContext}
-              addons={clusterAddons}
-            />
-          </FormFieldCard>
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Cluster Add-Ons</Text>
+                <AddonTogglers
+                  wizardContext={wizardContext}
+                  setWizardContext={setWizardContext}
+                  addons={clusterAddons}
+                />
+              </FormFieldCard>
+            </>
+          )}
         </ValidatedForm>
       </WizardStep>
       <WizardStep

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-multi-master.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-multi-master.tsx
@@ -65,7 +65,7 @@ export const initialContext = {
   calicoIPv4: 'autodetect',
   calicoIPv6: 'none',
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
-  useHostname: 'false',
+  useHostname: false,
   nodeRegistrationType: 'ipAddress',
 }
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-multi-master.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-multi-master.tsx
@@ -43,6 +43,7 @@ import { ClusterCreateTypeNames, ClusterCreateTypes } from '../../model'
 import { bareOSClusterTracking } from '../../tracking'
 import { CloudProviders } from 'k8s/components/infrastructure/cloudProviders/model'
 import CustomApiFlags from '../../form-components/custom-api-flag'
+import NodeRegistrationChooser from '../../form-components/node-registration-chooser'
 export const initialContext = {
   containersCidr: '10.20.0.0/16',
   servicesCidr: '10.21.0.0/16',
@@ -122,6 +123,10 @@ const PhysicalMultiMasterCluster: FC<Props> = ({ onNext, ...props }) => {
             <Divider className={classes.divider} />
             <Text variant="caption1">Cluster Network Stack</Text>
             <NetworkStack {...props} />
+
+            <Divider className={classes.divider} />
+            <Text variant="caption1">Node Registration</Text>
+            <NodeRegistrationChooser {...props} />
 
             <Divider className={classes.divider} />
             <Text variant="caption1">Application & Container Settings</Text>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-one-click.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-one-click.tsx
@@ -44,6 +44,7 @@ export const initialContext = {
   calicoIPv4: 'autodetect',
   calicoIPv6: 'none',
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
+  useHostname: 'false',
 }
 
 const columns = [

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-one-click.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-one-click.tsx
@@ -44,7 +44,7 @@ export const initialContext = {
   calicoIPv4: 'autodetect',
   calicoIPv6: 'none',
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
-  useHostname: 'false',
+  useHostname: false,
 }
 
 const columns = [

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-single-master.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-single-master.tsx
@@ -65,7 +65,7 @@ export const initialContext = {
   calicoIPv4: 'autodetect',
   calicoIPv6: 'none',
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
-  useHostname: 'false',
+  useHostname: false,
   nodeRegistrationType: 'ipAddress',
 }
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-single-master.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-single-master.tsx
@@ -65,6 +65,8 @@ export const initialContext = {
   calicoIPv4: 'autodetect',
   calicoIPv6: 'none',
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
+  useHostname: 'false',
+  nodeRegistrationType: 'ipAddress',
 }
 
 interface Props {
@@ -104,43 +106,53 @@ const PhysicalSingleMasterCluster: FC<Props> = ({ onNext, ...props }) => {
           withAddonManager
           elevated={false}
         >
-          {/* Cluster Name */}
-          <FormFieldCard
-            title={`Name your ${ClusterCreateTypeNames[ClusterCreateTypes.SingleMaster]} Cluster`}
-            link={
-              <ExternalLink textVariant="caption2" url={bareOSSingleMasterSetupDocsLink}>
-                BareOS Cluster Help
-              </ExternalLink>
-            }
-          >
-            <ClusterNameField setWizardContext={setWizardContext} />
-          </FormFieldCard>
+          {({ setFieldValue, values }) => (
+            <>
+              {/* Cluster Name */}
+              <FormFieldCard
+                title={`Name your ${
+                  ClusterCreateTypeNames[ClusterCreateTypes.SingleMaster]
+                } Cluster`}
+                link={
+                  <ExternalLink textVariant="caption2" url={bareOSSingleMasterSetupDocsLink}>
+                    BareOS Cluster Help
+                  </ExternalLink>
+                }
+              >
+                <ClusterNameField setWizardContext={setWizardContext} />
+              </FormFieldCard>
 
-          {/* Cluster Settings */}
-          <FormFieldCard title="Cluster Settings">
-            <KubernetesVersion />
+              {/* Cluster Settings */}
+              <FormFieldCard title="Cluster Settings">
+                <KubernetesVersion />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Cluster Network Stack</Text>
-            <NetworkStack {...props} />
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Cluster Network Stack</Text>
+                <NetworkStack {...props} />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Node Registration</Text>
-            <NodeRegistrationChooser {...props} />
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Node Registration</Text>
+                <NodeRegistrationChooser
+                  values={values}
+                  wizardContext={wizardContext}
+                  setWizardContext={setWizardContext}
+                />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Application & Container Settings</Text>
-            <PrivilegedContainers {...props} />
-            <AllowWorkloadsOnMaster setWizardContext={setWizardContext} />
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Application & Container Settings</Text>
+                <PrivilegedContainers {...props} />
+                <AllowWorkloadsOnMaster setWizardContext={setWizardContext} />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Cluster Add-Ons</Text>
-            <AddonTogglers
-              addons={clusterAddons}
-              wizardContext={wizardContext}
-              setWizardContext={setWizardContext}
-            />
-          </FormFieldCard>
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Cluster Add-Ons</Text>
+                <AddonTogglers
+                  addons={clusterAddons}
+                  wizardContext={wizardContext}
+                  setWizardContext={setWizardContext}
+                />
+              </FormFieldCard>
+            </>
+          )}
         </ValidatedForm>
       </WizardStep>
       <WizardStep

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-single-master.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-single-master.tsx
@@ -42,6 +42,7 @@ import { ClusterCreateTypeNames, ClusterCreateTypes } from '../../model'
 import { CloudProviders } from 'k8s/components/infrastructure/cloudProviders/model'
 import { bareOSClusterTracking } from '../../tracking'
 import CustomApiFlags from '../../form-components/custom-api-flag'
+import NodeRegistrationChooser from '../../form-components/node-registration-chooser'
 
 export const initialContext = {
   containersCidr: '10.20.0.0/16',
@@ -122,6 +123,10 @@ const PhysicalSingleMasterCluster: FC<Props> = ({ onNext, ...props }) => {
             <Divider className={classes.divider} />
             <Text variant="caption1">Cluster Network Stack</Text>
             <NetworkStack {...props} />
+
+            <Divider className={classes.divider} />
+            <Text variant="caption1">Node Registration</Text>
+            <NodeRegistrationChooser {...props} />
 
             <Divider className={classes.divider} />
             <Text variant="caption1">Application & Container Settings</Text>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-multi-master.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-multi-master.tsx
@@ -43,6 +43,7 @@ import { ClusterCreateTypeNames, ClusterCreateTypes } from '../../model'
 import { CloudProviders } from 'k8s/components/infrastructure/cloudProviders/model'
 import { bareOSClusterTracking } from '../../tracking'
 import CustomApiFlags from '../../form-components/custom-api-flag'
+import NodeRegistrationChooser from '../../form-components/node-registration-chooser'
 export const initialContext = {
   containersCidr: '10.20.0.0/16',
   servicesCidr: '10.21.0.0/16',
@@ -64,6 +65,8 @@ export const initialContext = {
   calicoIPv4: 'autodetect',
   calicoIPv6: 'none',
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
+  useHostname: 'false',
+  nodeRegistrationType: 'ipAddress',
 }
 
 interface Props {
@@ -122,6 +125,10 @@ const VirtualMultiMasterCluster: FC<Props> = ({ onNext, ...props }) => {
             <Divider className={classes.divider} />
             <Text variant="caption1">Cluster Network Stack</Text>
             <NetworkStack {...props} />
+
+            <Divider className={classes.divider} />
+            <Text variant="caption1">Node Registration</Text>
+            <NodeRegistrationChooser {...props} />
 
             <Divider className={classes.divider} />
             <Text variant="caption1">Application & Container Settings</Text>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-multi-master.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-multi-master.tsx
@@ -65,7 +65,7 @@ export const initialContext = {
   calicoIPv4: 'autodetect',
   calicoIPv6: 'none',
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
-  useHostname: 'false',
+  useHostname: false,
   nodeRegistrationType: 'ipAddress',
 }
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-multi-master.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-multi-master.tsx
@@ -106,43 +106,53 @@ const VirtualMultiMasterCluster: FC<Props> = ({ onNext, ...props }) => {
           withAddonManager
           elevated={false}
         >
-          {/* Cluster Name */}
-          <FormFieldCard
-            title={`Name your ${ClusterCreateTypeNames[ClusterCreateTypes.MultiMaster]} Cluster`}
-            link={
-              <ExternalLink textVariant="caption2" url={pmkCliOverviewLink}>
-                BareOS Cluster Help
-              </ExternalLink>
-            }
-          >
-            <ClusterNameField setWizardContext={setWizardContext} />
-          </FormFieldCard>
+          {({ setFieldValue, values }) => (
+            <>
+              {/* Cluster Name */}
+              <FormFieldCard
+                title={`Name your ${
+                  ClusterCreateTypeNames[ClusterCreateTypes.MultiMaster]
+                } Cluster`}
+                link={
+                  <ExternalLink textVariant="caption2" url={pmkCliOverviewLink}>
+                    BareOS Cluster Help
+                  </ExternalLink>
+                }
+              >
+                <ClusterNameField setWizardContext={setWizardContext} />
+              </FormFieldCard>
 
-          {/* Cluster Settings */}
-          <FormFieldCard title="Cluster Settings">
-            <KubernetesVersion />
+              {/* Cluster Settings */}
+              <FormFieldCard title="Cluster Settings">
+                <KubernetesVersion />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Cluster Network Stack</Text>
-            <NetworkStack {...props} />
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Cluster Network Stack</Text>
+                <NetworkStack {...props} />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Node Registration</Text>
-            <NodeRegistrationChooser {...props} />
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Node Registration</Text>
+                <NodeRegistrationChooser
+                  values={values}
+                  wizardContext={wizardContext}
+                  setWizardContext={setWizardContext}
+                />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Application & Container Settings</Text>
-            <PrivilegedContainers {...props} />
-            <AllowWorkloadsOnMaster setWizardContext={setWizardContext} />
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Application & Container Settings</Text>
+                <PrivilegedContainers {...props} />
+                <AllowWorkloadsOnMaster setWizardContext={setWizardContext} />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Cluster Add-Ons</Text>
-            <AddonTogglers
-              addons={clusterAddons}
-              wizardContext={wizardContext}
-              setWizardContext={setWizardContext}
-            />
-          </FormFieldCard>
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Cluster Add-Ons</Text>
+                <AddonTogglers
+                  addons={clusterAddons}
+                  wizardContext={wizardContext}
+                  setWizardContext={setWizardContext}
+                />
+              </FormFieldCard>
+            </>
+          )}
         </ValidatedForm>
       </WizardStep>
       <WizardStep

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-one-click.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-one-click.tsx
@@ -44,6 +44,7 @@ export const initialContext = {
   calicoIPv4: 'autodetect',
   calicoIPv6: 'none',
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
+  useHostname: 'false',
 }
 
 const columns = [

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-one-click.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-one-click.tsx
@@ -44,7 +44,7 @@ export const initialContext = {
   calicoIPv4: 'autodetect',
   calicoIPv6: 'none',
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
-  useHostname: 'false',
+  useHostname: false,
 }
 
 const columns = [

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-single-master.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-single-master.tsx
@@ -111,44 +111,54 @@ const VirtualSingleMasterCluster: FC<Props> = ({ onNext, ...props }) => {
           withAddonManager
           elevated={false}
         >
-          {/* <PollingData loading={loading} onReload={reload} hidden /> */}
-          {/* Cluster Name */}
-          <FormFieldCard
-            title={`Name your ${ClusterCreateTypeNames[ClusterCreateTypes.SingleMaster]} Cluster`}
-            link={
-              <ExternalLink textVariant="caption2" url={bareOSSingleMasterSetupDocsLink}>
-                BareOS Cluster Help
-              </ExternalLink>
-            }
-          >
-            <ClusterNameField setWizardContext={setWizardContext} />
-          </FormFieldCard>
+          {({ setFieldValue, values }) => (
+            <>
+              {/* <PollingData loading={loading} onReload={reload} hidden /> */}
+              {/* Cluster Name */}
+              <FormFieldCard
+                title={`Name your ${
+                  ClusterCreateTypeNames[ClusterCreateTypes.SingleMaster]
+                } Cluster`}
+                link={
+                  <ExternalLink textVariant="caption2" url={bareOSSingleMasterSetupDocsLink}>
+                    BareOS Cluster Help
+                  </ExternalLink>
+                }
+              >
+                <ClusterNameField setWizardContext={setWizardContext} />
+              </FormFieldCard>
 
-          {/* Cluster Settings */}
-          <FormFieldCard title="Cluster Settings">
-            <KubernetesVersion />
+              {/* Cluster Settings */}
+              <FormFieldCard title="Cluster Settings">
+                <KubernetesVersion />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Cluster Network Stack</Text>
-            <NetworkStack {...props} />
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Cluster Network Stack</Text>
+                <NetworkStack {...props} />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Node Registration</Text>
-            <NodeRegistrationChooser {...props} />
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Node Registration</Text>
+                <NodeRegistrationChooser
+                  values={values}
+                  wizardContext={wizardContext}
+                  setWizardContext={setWizardContext}
+                />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Application & Container Settings</Text>
-            <PrivilegedContainers {...props} />
-            <AllowWorkloadsOnMaster setWizardContext={setWizardContext} />
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Application & Container Settings</Text>
+                <PrivilegedContainers {...props} />
+                <AllowWorkloadsOnMaster setWizardContext={setWizardContext} />
 
-            <Divider className={classes.divider} />
-            <Text variant="caption1">Cluster Add-Ons</Text>
-            <AddonTogglers
-              addons={clusterAddons}
-              wizardContext={wizardContext}
-              setWizardContext={setWizardContext}
-            />
-          </FormFieldCard>
+                <Divider className={classes.divider} />
+                <Text variant="caption1">Cluster Add-Ons</Text>
+                <AddonTogglers
+                  addons={clusterAddons}
+                  wizardContext={wizardContext}
+                  setWizardContext={setWizardContext}
+                />
+              </FormFieldCard>
+            </>
+          )}
         </ValidatedForm>
       </WizardStep>
       <WizardStep

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-single-master.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-single-master.tsx
@@ -70,7 +70,7 @@ export const initialContext = {
   calicoIPv4: 'autodetect',
   calicoIPv6: 'none',
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
-  useHostname: 'false',
+  useHostname: false,
   nodeRegistrationType: 'ipAddress',
 }
 

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-single-master.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-single-master.tsx
@@ -47,6 +47,7 @@ import { ClusterCreateTypeNames, ClusterCreateTypes } from '../../model'
 import { CloudProviders } from 'k8s/components/infrastructure/cloudProviders/model'
 import { bareOSClusterTracking } from '../../tracking'
 import CustomApiFlags from '../../form-components/custom-api-flag'
+import NodeRegistrationChooser from '../../form-components/node-registration-chooser'
 
 export const initialContext = {
   containersCidr: '10.20.0.0/16',
@@ -69,6 +70,8 @@ export const initialContext = {
   calicoIPv4: 'autodetect',
   calicoIPv6: 'none',
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
+  useHostname: 'false',
+  nodeRegistrationType: 'ipAddress',
 }
 
 interface Props {
@@ -128,6 +131,10 @@ const VirtualSingleMasterCluster: FC<Props> = ({ onNext, ...props }) => {
             <Divider className={classes.divider} />
             <Text variant="caption1">Cluster Network Stack</Text>
             <NetworkStack {...props} />
+
+            <Divider className={classes.divider} />
+            <Text variant="caption1">Node Registration</Text>
+            <NodeRegistrationChooser {...props} />
 
             <Divider className={classes.divider} />
             <Text variant="caption1">Application & Container Settings</Text>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/node-registration-chooser.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/node-registration-chooser.tsx
@@ -36,7 +36,7 @@ const NodeRegistrationChooser = ({ values, wizardContext, setWizardContext }) =>
   return (
     <RadioFields
       id="nodeRegistrationType"
-      value={wizardContext['nodeRegistrationType']}
+      value={wizardContext.nodeRegistrationType}
       options={nodeRegistrationOptions}
       onChange={handleChange}
     />

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/node-registration-chooser.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/node-registration-chooser.tsx
@@ -7,10 +7,13 @@ const nodeRegistrationOptions = [
   {
     label: 'Use Node IP address for Cluster Creation',
     value: 'ipAddress',
+  },
+  {
+    label: 'Use Node Hostname for Cluster Creation ',
+    value: 'hostname',
     info:
       'Warning: DNS Resolution must be working to use Hostname. Failure to resolve a hostname will result in cluster error.',
   },
-  { label: 'Use Node Hostname for Cluster Creation ', value: 'hostname' },
 ]
 
 const NodeRegistrationChooser = ({ wizardContext, setWizardContext }) => {

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/node-registration-chooser.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/node-registration-chooser.tsx
@@ -1,0 +1,32 @@
+import RadioFields from 'core/components/validatedForm/radio-fields'
+import React from 'react'
+
+const formKey = 'nodeRegistrationType'
+
+const nodeRegistrationOptions = [
+  {
+    label: 'Use Node IP address for Cluster Creation',
+    value: 'ipAddress',
+    info:
+      'Warning: DNS Resolution must be working to use Hostname. Failure to resolve a hostname will result in cluster error.',
+  },
+  { label: 'Use Node Hostname for Cluster Creation ', value: 'hostname' },
+]
+
+const NodeRegistrationChooser = ({ wizardContext, setWizardContext }) => {
+  const handleChange = (value) => {
+    const useHostname = value === 'hostname'
+    setWizardContext({ useHostname, [formKey]: value })
+  }
+
+  return (
+    <RadioFields
+      id={formKey}
+      value={wizardContext[formKey]}
+      options={nodeRegistrationOptions}
+      onChange={handleChange}
+    />
+  )
+}
+
+export default NodeRegistrationChooser

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/node-registration-chooser.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/form-components/node-registration-chooser.tsx
@@ -1,31 +1,42 @@
-import RadioFields from 'core/components/validatedForm/radio-fields'
-import React from 'react'
+import RadioFields, { OptionType } from 'core/components/validatedForm/radio-fields'
+import React, { useEffect, useMemo } from 'react'
+import { NetworkStackTypes } from '../constants'
 
-const formKey = 'nodeRegistrationType'
+const NodeRegistrationChooser = ({ values, wizardContext, setWizardContext }) => {
+  const nodeRegistrationOptions: Array<OptionType> = useMemo(() => {
+    return [
+      {
+        label: 'Use Node IP address for Cluster Creation',
+        value: 'ipAddress',
+      },
+      {
+        label: 'Use Node Hostname for Cluster Creation ',
+        value: 'hostname',
+        disabled: wizardContext.networkStack === NetworkStackTypes.IPv6,
+        info:
+          'Warning: DNS Resolution must be working to use Hostname. Failure to resolve a hostname will result in cluster error.',
+      },
+    ]
+  }, [wizardContext.networkStack])
 
-const nodeRegistrationOptions = [
-  {
-    label: 'Use Node IP address for Cluster Creation',
-    value: 'ipAddress',
-  },
-  {
-    label: 'Use Node Hostname for Cluster Creation ',
-    value: 'hostname',
-    info:
-      'Warning: DNS Resolution must be working to use Hostname. Failure to resolve a hostname will result in cluster error.',
-  },
-]
+  useEffect(() => {
+    // If a user selects IPv6, we need to automatically select the ipAddress option
+    if (values.networkStack === NetworkStackTypes.IPv6) {
+      setWizardContext({ useHostname: false, nodeRegistrationType: 'ipAddress' })
+    }
+  }, [values.networkStack])
 
-const NodeRegistrationChooser = ({ wizardContext, setWizardContext }) => {
   const handleChange = (value) => {
+    // useHostname is a flag that is used by the cluster creation API
+    // nodeRegistrationType is just used by the UI to keep track of which type the user chooses
     const useHostname = value === 'hostname'
-    setWizardContext({ useHostname, [formKey]: value })
+    setWizardContext({ useHostname, nodeRegistrationType: value })
   }
 
   return (
     <RadioFields
-      id={formKey}
-      value={wizardContext[formKey]}
+      id="nodeRegistrationType"
+      value={wizardContext['nodeRegistrationType']}
       options={nodeRegistrationOptions}
       onChange={handleChange}
     />

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/helpers.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/helpers.ts
@@ -235,6 +235,7 @@ export const createBareOSCluster = async (data) => {
     'appCatalogEnabled',
     'deployKubevirt',
     'deployLuigiOperator',
+    'useHostname',
   ]
 
   const body = pick(keysToPluck, data)


### PR DESCRIPTION
**Background:**
A new `useHostname` field has been added to cluster creation API. This parameter is ignored when deploying clusters on public clouds - AWS, Azure. and when deploying bare OS IPv6 clusters.

**Changes:**

- Added a new section called "Node Registration" on step one of BareOS VM and Physical single and multi-master cluster wizards with a radio toggle field that allows users to setup their cluster using hostname or IP address
- `useHostname` flag is defaulted to false for BareOs one-click clusters

![Screen Shot 2021-05-12 at 11 12 51 AM](https://user-images.githubusercontent.com/23369276/118024028-113ea200-b313-11eb-8d03-febb6dd41403.png)

- If IPv6 is chosen, the 'Use Node Hostname' field is disabled and the useHostname flag is automatically set to false

https://user-images.githubusercontent.com/23369276/118024952-20721f80-b314-11eb-90fd-a90b6b57ec51.mov

- Info message is shown when you hoover over the 'Use Node Hostname' field

![Screen Shot 2021-05-12 at 11 24 08 AM](https://user-images.githubusercontent.com/23369276/118025380-9fffee80-b314-11eb-92a5-23583130d3a4.png)


