### PR TITLE
UX-315/Add 'Node Clock Drift' status in cluster and node health status and prevent cluster upgrades if clock drift detected

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatus.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterStatus.tsx
@@ -15,6 +15,7 @@ import Theme from 'core/themes/model'
 import FontAwesomeIcon from 'core/components/FontAwesomeIcon'
 import clsx from 'clsx'
 import { routes } from 'core/utils/routes'
+import { clockDriftDetectedInNodes } from '../nodes/helper'
 
 const getIconOrBubbleColor = (status: IClusterStatus, theme: Theme) =>
   ({
@@ -110,7 +111,7 @@ const ClusterStatusSpan: FC<Props> = (props) => {
 
 export default ClusterStatusSpan
 
-const renderErrorStatus = (nodesDetailsUrl, variant) => (
+export const renderErrorStatus = (nodesDetailsUrl, variant, text) => (
   <ClusterStatusSpan
     iconStatus
     title="Click the link to view more details"
@@ -118,7 +119,7 @@ const renderErrorStatus = (nodesDetailsUrl, variant) => (
     variant={variant}
   >
     <SimpleLink variant="error" src={nodesDetailsUrl}>
-      Error
+      {text}
     </SimpleLink>
   </ClusterStatusSpan>
 )
@@ -174,7 +175,13 @@ export const ClusterHealthStatus: FC<IClusterStatusProps> = ({
         </ClusterStatusSpan>
       )}
       {cluster.taskError &&
-        renderErrorStatus(routes.cluster.detail.path({ id: cluster.uuid }), variant)}
+        renderErrorStatus(routes.cluster.detail.path({ id: cluster.uuid }), variant, 'Error')}
+      {clockDriftDetectedInNodes(cluster.nodes) &&
+        renderErrorStatus(
+          routes.cluster.nodes.path({ id: cluster.uuid }),
+          variant,
+          'Node Clock Drift',
+        )}
     </div>
   )
 }

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClustersListPage.tsx
@@ -36,6 +36,7 @@ import {
   isAzureAutoscalingCluster,
 } from './helpers'
 import { IClusterSelector } from './model'
+import { clockDriftDetectedInNodes } from '../nodes/helper'
 
 const useStyles = makeStyles((theme) => ({
   links: {
@@ -311,6 +312,10 @@ export const options = {
       icon: 'level-up',
       label: 'Upgrade Cluster',
       dialog: ClusterUpgradeDialog,
+      disabledInfo: ([cluster]) =>
+        !!cluster && clockDriftDetectedInNodes(cluster.nodes)
+          ? 'Cannot upgrade cluster: clock drift detected in at least one node'
+          : 'Cannot upgrade cluster',
     },
     {
       cond: both(isAdmin, notBusy),

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/helpers.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/helpers.ts
@@ -6,6 +6,7 @@ import { pathEq, pick, prop, propEq, propSatisfies } from 'ramda'
 import { isTruthy, keyValueArrToObj, pathStrOr } from 'utils/fp'
 import { sanitizeUrl } from 'utils/misc'
 import { CloudProviders } from '../cloudProviders/model'
+import { clockDriftDetectedInNodes } from '../nodes/helper'
 import { hasConvergingNodes } from './ClusterStatusUtils'
 import { NetworkStackTypes } from './constants'
 import { CalicoDetectionTypes } from './form-components/calico-network-fields'
@@ -30,7 +31,8 @@ export const canScaleMasters = ([cluster]) =>
 export const canScaleWorkers = ([cluster]) =>
   clusterNotBusy(cluster) && !isAzureAutoscalingCluster(cluster)
 
-export const canUpgradeCluster = ([cluster]) => !!(cluster && cluster.canUpgrade)
+export const canUpgradeCluster = ([cluster]) =>
+  !!cluster && cluster.canUpgrade && !clockDriftDetectedInNodes(cluster.nodes)
 
 export const canDeleteCluster = ([cluster]) =>
   !['creating', 'deleting'].includes(cluster.taskStatus)

--- a/src/app/plugins/kubernetes/components/infrastructure/nodes/NodesListPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/nodes/NodesListPage.js
@@ -31,6 +31,8 @@ import ResourceUsageTables from '../common/ResourceUsageTables'
 import NodesStatePicklist from './nodes-state-picklist'
 import NodeAuthDialog from './NodeAuthDialog'
 import { NodeState } from './model'
+import { clockDriftDetectedInNodes, hasClockDrift } from './helper'
+import { renderErrorStatus } from '../clusters/ClusterStatus'
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -214,9 +216,13 @@ export const renderNodeHealthStatus = (_, node, onClick = undefined) => {
     fields.label
   )
   return (
-    <ClusterStatusSpan title={fields.label} status={fields.status}>
-      {onClick ? <SimpleLink onClick={() => onClick(node)}>{fields.label}</SimpleLink> : content}
-    </ClusterStatusSpan>
+    <>
+      <ClusterStatusSpan title={fields.label} status={fields.status}>
+        {onClick ? <SimpleLink onClick={() => onClick(node)}>{fields.label}</SimpleLink> : content}
+      </ClusterStatusSpan>
+      {hasClockDrift(node) &&
+        renderErrorStatus(routes.nodes.detail.path({ id: node.uuid }), 'table', 'Node Clock Drift')}
+    </>
   )
 }
 

--- a/src/app/plugins/kubernetes/components/infrastructure/nodes/helper.ts
+++ b/src/app/plugins/kubernetes/components/infrastructure/nodes/helper.ts
@@ -1,1 +1,12 @@
 export const isUnauthorizedHost = (host) => !host?.roles?.includes('pf9-kube')
+
+export const hasClockDrift = (node) => node?.message?.warn && node.message.warn[0]
+
+/**
+ * Checks whether or not any node in the nodes array have clock drift
+ * @param nodes Array of nodes
+ * @returns True if clock drift is detected in any of the nodes. False if none of the nodes have clock drift
+ */
+export const clockDriftDetectedInNodes = (nodes) => {
+  return nodes && !!nodes.find((node) => hasClockDrift(node))
+}


### PR DESCRIPTION
**Changes:**

- 'Node Clock Drift' status is added under cluster health column. Links to the cluster nodes list table

![Screen Shot 2021-05-12 at 5 02 25 PM](https://user-images.githubusercontent.com/23369276/118059324-1fa5b180-b345-11eb-86cf-80358eaa8425.png)

-  'Node Clock Drift' status is added under node health column. Links to the node details page

![Screen Shot 2021-05-12 at 5 02 38 PM](https://user-images.githubusercontent.com/23369276/118059394-4bc13280-b345-11eb-986b-9299339a94b9.png)

- Cluster upgrade is disabled if clock drift is detected

![Screen Shot 2021-05-12 at 5 04 15 PM](https://user-images.githubusercontent.com/23369276/118059525-9478eb80-b345-11eb-8750-92f5abaf5163.png)
