### PR TITLE
UX-927/Fixed bug where block size is listed twice in cluster creation defaul…

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/one-click.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/one-click.tsx
@@ -63,7 +63,7 @@ const columns = [
   { id: 'calicoIpIpMode', label: 'IP in IP Encapsulation Mode' },
   { id: 'calicoNatOutgoing', label: 'NAT Outgoing', render: (value) => castBoolToStr()(value) },
   { id: 'calicoBlockSize', label: 'Block Size' },
-  { id: 'mtuSize', label: 'Block Size' },
+  { id: 'mtuSize', label: 'MTU Size' },
   {
     id: 'etcdBackup',
     label: 'ETCD Backup',

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-one-click.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/physical-one-click.tsx
@@ -58,7 +58,7 @@ const columns = [
   { id: 'calicoIpIpMode', label: 'IP in IP Encapsulation Mode' },
   { id: 'calicoNatOutgoing', label: 'NAT Outgoing', render: (value) => castBoolToStr()(value) },
   { id: 'calicoBlockSize', label: 'Block Size' },
-  { id: 'mtuSize', label: 'Block Size' },
+  { id: 'mtuSize', label: 'MTU Size' },
   {
     id: 'privileged',
     label: 'Privileged',

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-one-click.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/bareos/create-templates/virtual-one-click.tsx
@@ -58,7 +58,7 @@ const columns = [
   { id: 'calicoIpIpMode', label: 'IP in IP Encapsulation Mode' },
   { id: 'calicoNatOutgoing', label: 'NAT Outgoing', render: (value) => castBoolToStr()(value) },
   { id: 'calicoBlockSize', label: 'Block Size' },
-  { id: 'mtuSize', label: 'Block Size' },
+  { id: 'mtuSize', label: 'MTU Size' },
   {
     id: 'privileged',
     label: 'Privileged',


### PR DESCRIPTION
…ts section

**Changes Made:**
- Changed 'Block Size' to 'MTU Size' in AWS one-click, BareOS virtual and physical one-click forms

![Screen Shot 2021-05-13 at 10 27 58 AM](https://user-images.githubusercontent.com/23369276/118162926-30523800-b3d6-11eb-9cbb-48a2b33bebc1.png)
