### PR TITLE
UX-945/Fix bug where when scaling down a cluster, the old nodes still show up

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/actions.js
@@ -21,7 +21,7 @@ import { loadNodes } from 'k8s/components/infrastructure/nodes/actions'
 import { ActionDataKeys } from 'k8s/DataKeys'
 import { mergeLeft, pathOr, pick, propEq } from 'ramda'
 import { mapAsync } from 'utils/async'
-import { adjustWith, isNilOrEmpty, updateWith } from 'utils/fp'
+import { adjustWith, emptyObj, isNilOrEmpty, updateWith } from 'utils/fp'
 import { trackEvent } from 'utils/tracking'
 import { importedClusterActions } from '../importedClusters/actions'
 import { importedClustersSelector } from '../importedClusters/selectors'
@@ -54,7 +54,7 @@ export const clusterActions = createCRUDActions(ActionDataKeys.Clusters, {
       qbert.getClusters(),
       // Fetch dependent caches
       clusterTagActions.list(),
-      loadNodes(),
+      loadNodes(emptyObj, true),
       loadResMgrHosts(),
     ])
     if (settledClusters.status !== 'fulfilled') {


### PR DESCRIPTION
**Bug Description:**
After scaling down worker nodes for an AWS cluster, the node count in the clusters list table did not accurately reflect the number of nodes in the cluster. 

My cluster, kim-test, had 1 master node and 5 workers nodes. After scaling it down to 1 worker node and waiting for the cluster to finish updating, the clusters table still showed 6 nodes for my cluster even though the nodes api response shows only 2.

![Screen Shot 2021-05-14 at 10 53 44 AM](https://user-images.githubusercontent.com/23369276/118332775-7d5e0900-b4bf-11eb-98d3-6b6bba76d9b1.png)

I noticed when refetching the nodes, we were doing `upsertAll` with the data in the cache. That's why the old nodes still remained

**Fix:**
When we fetch nodes for the clusters, we should pass `refetch = true` to `loadNodes` so that we do a `replaceAll` instead of `upsertAll` with the data