### PR TITLE
Bugsnag: Remove user password from error.config.data

### DIFF
--- a/src/api-client/ApiClient.ts
+++ b/src/api-client/ApiClient.ts
@@ -131,6 +131,15 @@ class ApiClient {
         const url = error?.response?.config
         const data = error?.response?.data
 
+        // If data contains user password, remove it
+        if (url?.data?.includes('{"methods":["password"]')) {
+          const dataObj = JSON.parse(url.data)
+          if (dataObj?.auth?.identity?.password?.user?.password) {
+            dataObj.auth.identity.password.user.password = 'SENSITIVE_DATA_REMOVED'
+            url.data = JSON.stringify(dataObj)
+          }
+        }
+
         Bugsnag.addMetadata('Api Url', url)
         Bugsnag.addMetadata('Api Response', data)
         Bugsnag.notify(error)


### PR DESCRIPTION
**Issue:**
If login fails, we're exposing users' passwords in Bugsnag under the API URL tab

**Fix:**
Replace the users' passwords with `SENSITIVE_DATA_REMOVED`

`error.response.config.data ` is a JSON string so I converted into an object to replace the password with `SENSITIVE_DATA_REMOVED` and then converted it back to to a string