### PR TITLE
UX-995/Default domainId to empty string in AWS one-click cluster form

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/one-click.tsx
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/aws/create-templates/one-click.tsx
@@ -46,6 +46,7 @@ export const initialContext = {
   networkStack: 'ipv4',
   privileged: true,
   calicoDetectionMethod: CalicoDetectionTypes.FirstFound,
+  domainId: '',
 }
 
 const columns = [


### PR DESCRIPTION
**Issue:**
Creating an AWS cluster without a `domainId` in the one-click form results in an error from the API. This shouldn't happen because `domainId` field is not required

**Fix:**
`domainId` is required by the API but can be an empty string so default it to an empty string