### PR TITLE
UX-986/updated nodes list page to span entire screen

### DIFF
--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDetailsPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDetailsPage.js
@@ -133,6 +133,10 @@ const useStyles = makeStyles((theme) => ({
   },
   tabContainer: {
     paddingTop: theme.spacing(2),
+    maxWidth: 1234,
+  },
+  nodesContainer: {
+    maxWidth: 'none',
   },
   headerCard: {
     marginTop: theme.spacing(2),
@@ -235,7 +239,7 @@ const ClusterDetailsPage = () => {
       </SimpleLink>
       <Tabs>
         <Tab value="nodes" label="Nodes">
-          <div className={classes.tabContainer}>
+          <div className={`${classes.tabContainer} ${classes.nodesContainer}`}>
             {clusterHeader}
             <ClusterNodes />
           </div>

--- a/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDetailsPage.js
+++ b/src/app/plugins/kubernetes/components/infrastructure/clusters/ClusterDetailsPage.js
@@ -133,7 +133,6 @@ const useStyles = makeStyles((theme) => ({
   },
   tabContainer: {
     paddingTop: theme.spacing(2),
-    maxWidth: 1234,
   },
   headerCard: {
     marginTop: theme.spacing(2),


### PR DESCRIPTION
<img width="1611" alt="Screenshot 2021-07-01 at 12 57 22 AM" src="https://user-images.githubusercontent.com/17029951/124021635-6476cc00-da09-11eb-8d63-2f21e1e1609f.png">
